### PR TITLE
Add canister_balance128

### DIFF
--- a/examples/ic_api/src/ic_api.did
+++ b/examples/ic_api/src/ic_api.did
@@ -1,6 +1,7 @@
 service: {
     "caller": () -> (principal) query;
-    "canisterBalance": () -> (nat64) query;
+    "canister_balance": () -> (nat64) query;
+    "canister_balance128": () -> (nat) query;
     "id": () -> (principal) query;
     "print": (text) -> (bool) query;
     "time": () -> (nat64) query;

--- a/examples/ic_api/src/ic_api.ts
+++ b/examples/ic_api/src/ic_api.ts
@@ -1,8 +1,9 @@
 import {
-    Query,
-    nat64,
     ic,
-    Principal
+    nat,
+    nat64,
+    Principal,
+    Query
 } from 'azle';
 
 // returns the principal of the identity that called this function
@@ -11,8 +12,13 @@ export function caller(): Query<Principal> {
 }
 
 // returns the amount of cycles available in the canister
-export function canisterBalance(): Query<nat64> {
-    return ic.canisterBalance();
+export function canister_balance(): Query<nat64> {
+    return ic.canister_balance();
+}
+
+// returns the amount of cycles available in the canister
+export function canister_balance128(): Query<nat> {
+    return ic.canister_balance128();
 }
 
 // returns this canister's id

--- a/examples/ic_api/test/dfx_generated/ic_api/ic_api.did
+++ b/examples/ic_api/test/dfx_generated/ic_api/ic_api.did
@@ -1,6 +1,7 @@
 service: {
     "caller": () -> (principal) query;
-    "canisterBalance": () -> (nat64) query;
+    "canister_balance": () -> (nat64) query;
+    "canister_balance128": () -> (nat) query;
     "id": () -> (principal) query;
     "print": (text) -> (bool) query;
     "time": () -> (nat64) query;

--- a/examples/ic_api/test/dfx_generated/ic_api/ic_api.did.d.ts
+++ b/examples/ic_api/test/dfx_generated/ic_api/ic_api.did.d.ts
@@ -1,7 +1,8 @@
 import type { Principal } from '@dfinity/principal';
 export interface _SERVICE {
   'caller' : () => Promise<Principal>,
-  'canisterBalance' : () => Promise<bigint>,
+  'canister_balance' : () => Promise<bigint>,
+  'canister_balance128' : () => Promise<bigint>,
   'id' : () => Promise<Principal>,
   'print' : (arg_0: string) => Promise<boolean>,
   'time' : () => Promise<bigint>,

--- a/examples/ic_api/test/dfx_generated/ic_api/ic_api.did.js
+++ b/examples/ic_api/test/dfx_generated/ic_api/ic_api.did.js
@@ -1,7 +1,8 @@
 export const idlFactory = ({ IDL }) => {
   return IDL.Service({
     'caller' : IDL.Func([], [IDL.Principal], ['query']),
-    'canisterBalance' : IDL.Func([], [IDL.Nat64], ['query']),
+    'canister_balance' : IDL.Func([], [IDL.Nat64], ['query']),
+    'canister_balance128' : IDL.Func([], [IDL.Nat], ['query']),
     'id' : IDL.Func([], [IDL.Principal], ['query']),
     'print' : IDL.Func([IDL.Text], [IDL.Bool], ['query']),
     'time' : IDL.Func([], [IDL.Nat64], ['query']),

--- a/examples/ic_api/test/test.ts
+++ b/examples/ic_api/test/test.ts
@@ -46,9 +46,19 @@ const tests: Test[] = [
         }
     },
     {
-        name: 'canisterBalance',
+        name: 'canister_balance',
         test: async () => {
-            const result = await ic_api_canister.canisterBalance();
+            const result = await ic_api_canister.canister_balance();
+
+            return {
+                ok: result === 4_000_000_000_000n
+            };
+        }
+    },
+    {
+        name: 'canister_balance128',
+        test: async () => {
+            const result = await ic_api_canister.canister_balance128();
 
             return {
                 ok: result === 4_000_000_000_000n

--- a/index.ts
+++ b/index.ts
@@ -74,7 +74,8 @@ type ic = {
     canisters: {
         [canisterName: string]: <T>(canisterId: Principal) => T;
     };
-    canisterBalance: () => nat64;
+    canister_balance: () => nat64;
+    canister_balance128: () => nat;
     id: () => Principal;
     print: (...args: any) => void;
     // rawRand: () => nat8[]; // TODO I think we want this to really be a JS Uint8Array

--- a/src/compiler/typescript_to_rust/generators/ic_object/functions/canister_balance128.ts
+++ b/src/compiler/typescript_to_rust/generators/ic_object/functions/canister_balance128.ts
@@ -1,13 +1,13 @@
 import { Rust } from '../../../../../types';
 
-export function generateIcObjectFunctionCanisterBalance(): Rust {
+export function generateIcObjectFunctionCanisterBalance128(): Rust {
     return `
-        fn _azle_ic_canister_balance(
+        fn _azle_ic_canister_balance128(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             _context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            Ok(ic_cdk::api::canister_balance().azle_into_js_value(_context))
+            Ok(ic_cdk::api::canister_balance128().azle_into_js_value(_context))
         }
     `;
 }

--- a/src/compiler/typescript_to_rust/generators/ic_object/index.ts
+++ b/src/compiler/typescript_to_rust/generators/ic_object/index.ts
@@ -13,8 +13,13 @@ export function generateIcObject(stableStorageVariableInfos: StableStorageVariab
                 0
             )
             .function(
-                azle_ic_canister_balance,
-                "canisterBalance",
+                _azle_ic_canister_balance,
+                "canister_balance",
+                0
+            )
+            .function(
+                _azle_ic_canister_balance128,
+                "canister_balance128",
                 0
             )
             .function(

--- a/src/compiler/typescript_to_rust/generators/lib_file.ts
+++ b/src/compiler/typescript_to_rust/generators/lib_file.ts
@@ -3,6 +3,7 @@ import { generateCanisterMethodInit } from './canister_methods/init';
 import { generateHead } from './head';
 import { generateIcObjectFunctionCaller } from './ic_object/functions/caller';
 import { generateIcObjectFunctionCanisterBalance } from './ic_object/functions/canister_balance';
+import { generateIcObjectFunctionCanisterBalance128 } from './ic_object/functions/canister_balance128';
 import { generateIcObjectFunctionId } from './ic_object/functions/id';
 import { generateIcObjectFunctionPrint } from './ic_object/functions/print';
 import { generateIcObjectFunctionTime } from './ic_object/functions/time';
@@ -65,6 +66,7 @@ export async function generateLibFile(
 
     const icObjectFunctionCaller: Rust = generateIcObjectFunctionCaller();
     const icObjectFunctionCanisterBalance: Rust = generateIcObjectFunctionCanisterBalance();
+    const icObjectFunctionCanisterBalance128: Rust = generateIcObjectFunctionCanisterBalance128();
     const icObjectFunctionId: Rust = generateIcObjectFunctionId();
     const icObjectFunctionPrint: Rust = generateIcObjectFunctionPrint();
     const icObjectFunctionTime: Rust = generateIcObjectFunctionTime();
@@ -91,6 +93,7 @@ export async function generateLibFile(
 
         ${icObjectFunctionCaller}
         ${icObjectFunctionCanisterBalance}
+        ${icObjectFunctionCanisterBalance128}
         ${icObjectFunctionId}
         ${icObjectFunctionPrint}
         ${icObjectFunctionTime}


### PR DESCRIPTION
Adds the canister_balance128 method.

BREAKING CHANGE: The `canisterBalance` method has changed to `canister_balance`. We will have a team discussion later on the pros/cons of camelCase vs snake_case. For now, the majority of the ledger and management canisters use snake_case and that's what the underlying rust implementation is, so we've normalized to that for now.

Resolves #373