### PR TITLE
IC API Canister inspect message

### DIFF
--- a/examples/inspect_message/dfx.json
+++ b/examples/inspect_message/dfx.json
@@ -1,0 +1,15 @@
+{
+    "canisters": {
+        "inspect_message": {
+            "type": "custom",
+            "build": "npx azle inspect_message",
+            "root": "src",
+            "ts": "src/inspect_message.ts",
+            "candid": "src/inspect_message.did",
+            "wasm": "target/wasm32-unknown-unknown/release/inspect_message.wasm",
+            "declarations": {
+                "output": "test/dfx_generated/inspect_message"
+            }
+        }
+    }
+}

--- a/examples/inspect_message/package-lock.json
+++ b/examples/inspect_message/package-lock.json
@@ -1,0 +1,1704 @@
+{
+    "name": "inspect_message",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "dependencies": {
+                "azle": "0.4.0"
+            },
+            "devDependencies": {
+                "@dfinity/agent": "0.11.1",
+                "ts-node": "10.7.0",
+                "typescript": "4.6.3"
+            }
+        },
+        "../..": {
+            "version": "0.1.0-rc.13",
+            "integrity": "sha512-TfU9eU9MptG7cI1v5/xM6e7sHWImEk190JUJaOtNNxQeL0BmXcdfh2JEqHoEPWz9BNxgccZb+URv9bURZqrK+Q==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "@swc/core": "1.2.151",
+                "azle-syn": "0.0.0",
+                "esbuild": "0.14.25",
+                "fs-extra": "10.0.1",
+                "ts-node": "10.3.1",
+                "typescript": "4.4.4"
+            },
+            "bin": {
+                "azle": "bin.js"
+            },
+            "devDependencies": {
+                "@types/fs-extra": "9.0.13",
+                "eslint": "8.11.0",
+                "eslint-config-prettier": "8.5.0",
+                "husky": "7.0.4",
+                "lint-staged": "12.3.7",
+                "prettier": "2.6.1"
+            }
+        },
+        "node_modules/@cspotcode/source-map-consumer": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+            "dependencies": {
+                "@cspotcode/source-map-consumer": "0.8.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@dfinity/agent": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.11.1.tgz",
+            "integrity": "sha512-Z1zw8l3d+AG3uu7d8G/Rd9Q5MWT9gB+Cori/Rqb6IjSEribRhL36ulCSkDYZJU/dhqSUp1VlvX5u51+wgv+MLg==",
+            "dev": true,
+            "dependencies": {
+                "base64-arraybuffer": "^0.2.0",
+                "bignumber.js": "^9.0.0",
+                "borc": "^2.1.1",
+                "js-sha256": "0.9.0",
+                "simple-cbor": "^0.4.1"
+            },
+            "peerDependencies": {
+                "@dfinity/candid": "^0.11.1",
+                "@dfinity/principal": "^0.11.1"
+            }
+        },
+        "node_modules/@dfinity/candid": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.11.1.tgz",
+            "integrity": "sha512-EYZZg+x7OgZxa56D9SWMeTlaMb09HJ7wIfL42+l/e0lgrx+sTXYxKe8bM9FrUW9AWo9/gKkOGV/IxJL/Acncng==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@dfinity/principal": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.11.1.tgz",
+            "integrity": "sha512-TlYkwq0fLwmY24X/vrw8mXNRYTkelkM0R5wGjhgK7au24zn7lcXYW3HG+se8YYWFICYY4prI1cS8/6N9z14qjg==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@swc/core": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.151.tgz",
+            "integrity": "sha512-oHgqKwK/Djv765zUHPiGqfMCaKIxXTgQyyCUBKLBQfAJwe/7FVobQ2fghBp4FsZA/NE1LZBmMPpRZNQwlGjeHw==",
+            "bin": {
+                "swcx": "run_swcx.js"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/swc"
+            },
+            "optionalDependencies": {
+                "@swc/core-android-arm-eabi": "1.2.151",
+                "@swc/core-android-arm64": "1.2.151",
+                "@swc/core-darwin-arm64": "1.2.151",
+                "@swc/core-darwin-x64": "1.2.151",
+                "@swc/core-freebsd-x64": "1.2.151",
+                "@swc/core-linux-arm-gnueabihf": "1.2.151",
+                "@swc/core-linux-arm64-gnu": "1.2.151",
+                "@swc/core-linux-arm64-musl": "1.2.151",
+                "@swc/core-linux-x64-gnu": "1.2.151",
+                "@swc/core-linux-x64-musl": "1.2.151",
+                "@swc/core-win32-arm64-msvc": "1.2.151",
+                "@swc/core-win32-ia32-msvc": "1.2.151",
+                "@swc/core-win32-x64-msvc": "1.2.151"
+            }
+        },
+        "node_modules/@swc/core-android-arm-eabi": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.151.tgz",
+            "integrity": "sha512-Suk3IcHdha33K4hq9tfBCwkXJsENh7kjXCseLqL8Yvy8QobqkXjf1fcoJxX9BdCmPwsKmIw0ZgCBYR+Hl83M2w==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-android-arm64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.151.tgz",
+            "integrity": "sha512-HZVy69dVWT5RgrMJMRK5aiicPmhzkyCHAexApYAHYLgAIhsxL7uoAIPmuRKRkrKNJjrwsWL7H27bBH5bddRDvg==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-darwin-arm64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.151.tgz",
+            "integrity": "sha512-Ql7rXMu+IC76TemRtkt+opl5iSpX2ApAXVSfvf6afNVTrfTKLpDwiR3ySRRlG0FnNIv6TfOCJpHf655xp01S/g==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-darwin-x64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.151.tgz",
+            "integrity": "sha512-N1OBIB7xatR5eybLo91ZhvMJMxT0zxRQURV/a9I8o5CyP4iLd1k8gmrYvBbtj08ohS8F9z7k/dFjxk/9ve5Drw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-freebsd-x64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.151.tgz",
+            "integrity": "sha512-WVIRiDzuz+/W7BMjVtg1Cmk1+zmDT18Qq+Ygr9J6aFQ1JQUkLEE1pvtkGD3JIEa6Jhz/VwM6AFHtY5o1CrZ21w==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm-gnueabihf": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.151.tgz",
+            "integrity": "sha512-pfBrIUwu3cR/M7DzDCUJAw9jFKXvJ/Ge8auFk07lRb+JcDnPm0XxLyrLqGvNQWdcHgXeXfmnS4fMQxdb9GUN1w==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-gnu": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.151.tgz",
+            "integrity": "sha512-M+BTkTdPY7gteM+0dYz9wrU/j9taL4ccqPEHkDEKP21lS24y99UtuKsvdBLzDm/6ShBVLFAkgIBPu5cEb7y6ig==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-musl": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.151.tgz",
+            "integrity": "sha512-7A+yTtSvPJVwO8X1cxUbD/PVCx8G9MKn83G9pH/r+9sQMBXqxyw6/NR0DG6nMMiyOmJkmYWgh5mO47BN7WC4dQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-gnu": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.151.tgz",
+            "integrity": "sha512-ORlbN3wf1w0IQGjGToYYC/hV/Vwfcs88Ohfxc4X+IQaw/VxKG6/XT65c0btK640F2TVhvhH1MbYFJJlsycsW7g==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-musl": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.151.tgz",
+            "integrity": "sha512-r6odKE3+9+ReVdnNTZnICt5tscyFFtP4GFcmPQzBSlVoD9LZX6O4WeOlFXn77rVK/+205n2ag/KkKgZH+vdPuQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-arm64-msvc": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.151.tgz",
+            "integrity": "sha512-jnjJTNHpLhBaPwRgiKv1TdrMljL88ePqMCdVMantyd7yl4lP0D2e5/xR9ysR9S4EGcUnOyo9w8WUYhx/TioMZw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-ia32-msvc": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.151.tgz",
+            "integrity": "sha512-hSCxAiyDDXKvdUExj4jSIhzWFePqoqak1qdNUjlhEhEinDG8T8PTRCLalyW6fqZDcLf6Tqde7H79AqbfhRlYGQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-x64-msvc": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.151.tgz",
+            "integrity": "sha512-HOkqcJWCChps83Maj0M5kifPDuZ2sGPqpLM67poawspTFkBh0QJ9TMmxW1doQw+74cqsTpRi1ewr/KhsN18i5g==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+            "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
+        },
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+            "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+            "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+            "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
+        },
+        "node_modules/@types/node": {
+            "version": "17.0.23",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+            "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+            "peer": true
+        },
+        "node_modules/acorn": {
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+        },
+        "node_modules/azle": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/azle/-/azle-0.4.0.tgz",
+            "integrity": "sha512-Q0U5fP0ItzoajCFdl0N01zEC/EvSj+NJwpGjGd70RbXTq98gtgoIzHentBBTIRg09RaLkrlFtb/CGHLTRX4NDg==",
+            "dependencies": {
+                "@swc/core": "1.2.151",
+                "azle-syn": "0.0.0",
+                "esbuild": "0.14.25",
+                "fs-extra": "10.0.1",
+                "hash.js": "1.1.7",
+                "ts-node": "10.3.1",
+                "typescript": "4.4.4"
+            },
+            "bin": {
+                "azle": "bin.js"
+            }
+        },
+        "node_modules/azle-syn": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/azle-syn/-/azle-syn-0.0.0.tgz",
+            "integrity": "sha512-fWExJb5/hOEJOuBQ8hMMHRs9WryYeLLa9/ydqPWxbwjMEpE8RKdU1dTK6mdZtzNMhbeHdyne2pU1iVKiKmImGw=="
+        },
+        "node_modules/azle/node_modules/ts-node": {
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.3.1.tgz",
+            "integrity": "sha512-Yw3W2mYzhHfCHOICGNJqa0i+rbL0rAyg7ZIHxU+K4pgY8gd2Lh1j+XbHCusJMykbj6RZMJVOY0MlHVd+GOivcw==",
+            "dependencies": {
+                "@cspotcode/source-map-support": "0.7.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/azle/node_modules/typescript": {
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+            "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/base64-arraybuffer": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+            "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/bignumber.js": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+            "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/borc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
+            "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+            "dev": true,
+            "dependencies": {
+                "bignumber.js": "^9.0.0",
+                "buffer": "^5.5.0",
+                "commander": "^2.15.0",
+                "ieee754": "^1.1.13",
+                "iso-url": "~0.4.7",
+                "json-text-sequence": "~0.1.0",
+                "readable-stream": "^3.6.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
+        },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+        },
+        "node_modules/delimit-stream": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+            "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs=",
+            "dev": true
+        },
+        "node_modules/diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.25.tgz",
+            "integrity": "sha512-4JHEIOMNFvK09ziiL+iVmldIhLbn49V4NAVo888tcGFKedEZY/Y8YapfStJ6zSE23tzYPKxqKwQBnQoIO0BI/Q==",
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "esbuild-android-64": "0.14.25",
+                "esbuild-android-arm64": "0.14.25",
+                "esbuild-darwin-64": "0.14.25",
+                "esbuild-darwin-arm64": "0.14.25",
+                "esbuild-freebsd-64": "0.14.25",
+                "esbuild-freebsd-arm64": "0.14.25",
+                "esbuild-linux-32": "0.14.25",
+                "esbuild-linux-64": "0.14.25",
+                "esbuild-linux-arm": "0.14.25",
+                "esbuild-linux-arm64": "0.14.25",
+                "esbuild-linux-mips64le": "0.14.25",
+                "esbuild-linux-ppc64le": "0.14.25",
+                "esbuild-linux-riscv64": "0.14.25",
+                "esbuild-linux-s390x": "0.14.25",
+                "esbuild-netbsd-64": "0.14.25",
+                "esbuild-openbsd-64": "0.14.25",
+                "esbuild-sunos-64": "0.14.25",
+                "esbuild-windows-32": "0.14.25",
+                "esbuild-windows-64": "0.14.25",
+                "esbuild-windows-arm64": "0.14.25"
+            }
+        },
+        "node_modules/esbuild-android-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.25.tgz",
+            "integrity": "sha512-L5vCUk7TzFbBnoESNoXjU3x9+/+7TDIE/1mTfy/erAfvZAqC+S3sp/Qa9wkypFMcFvN9FzvESkTlpeQDolREtQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-android-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.25.tgz",
+            "integrity": "sha512-4jv5xPjM/qNm27T5j3ZEck0PvjgQtoMHnz4FzwF5zNP56PvY2CT0WStcAIl6jNlsuDdN63rk2HRBIsO6xFbcFw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-darwin-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.25.tgz",
+            "integrity": "sha512-TGp8tuudIxOyWd1+8aYPxQmC1ZQyvij/AfNBa35RubixD0zJ1vkKHVAzo0Zao1zcG6pNqiSyzfPto8vmg0s7oA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-darwin-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.25.tgz",
+            "integrity": "sha512-oTcDgdm0MDVEmw2DWu8BV68pYuImpFgvWREPErBZmNA4MYKGuBRaCiJqq6jZmBR1x+3y1DWCjez+5uLtuAm6mw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-freebsd-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.25.tgz",
+            "integrity": "sha512-ueAqbnMZ8arnuLH8tHwTCQYeptnHOUV7vA6px6j4zjjQwDx7TdP7kACPf3TLZLdJQ3CAD1XCvQ2sPhX+8tacvQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-freebsd-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.25.tgz",
+            "integrity": "sha512-+ZVWud2HKh+Ob6k/qiJWjBtUg4KmJGGmbvEXXW1SNKS7hW7HU+Zq2ZCcE1akFxOPkVB+EhOty/sSek30tkCYug==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-32": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.25.tgz",
+            "integrity": "sha512-3OP/lwV3kCzEz45tobH9nj+uE4ubhGsfx+tn0L26WAGtUbmmcRpqy7XRG/qK7h1mClZ+eguIANcQntYMdYklfw==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.25.tgz",
+            "integrity": "sha512-+aKHdHZmX9qwVlQmu5xYXh7GsBFf4TWrePgeJTalhXHOG7NNuUwoHmketGiZEoNsWyyqwH9rE5BC+iwcLY30Ug==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-arm": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.25.tgz",
+            "integrity": "sha512-aTLcE2VBoLydL943REcAcgnDi3bHtmULSXWLbjtBdtykRatJVSxKMjK9YlBXUZC4/YcNQfH7AxwVeQr9fNxPhw==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.25.tgz",
+            "integrity": "sha512-UxfenPx/wSZx55gScCImPtXekvZQLI2GW3qe5dtlmU7luiqhp5GWPzGeQEbD3yN3xg/pHc671m5bma5Ns7lBHw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-mips64le": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.25.tgz",
+            "integrity": "sha512-wLWYyqVfYx9Ur6eU5RT92yJVsaBGi5RdkoWqRHOqcJ38Kn60QMlcghsKeWfe9jcYut8LangYZ98xO1LxIoSXrQ==",
+            "cpu": [
+                "mips64el"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-ppc64le": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.25.tgz",
+            "integrity": "sha512-0dR6Csl6Zas3g4p9ULckEl8Mo8IInJh33VCJ3eaV1hj9+MHGdmDOakYMN8MZP9/5nl+NU/0ygpd14cWgy8uqRw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-riscv64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.25.tgz",
+            "integrity": "sha512-J4d20HDmTrgvhR0bdkDhvvJGaikH3LzXQnNaseo8rcw9Yqby9A90gKUmWpfwqLVNRILvNnAmKLfBjCKU9ajg8w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-s390x": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.25.tgz",
+            "integrity": "sha512-YI2d5V6nTE73ZnhEKQD7MtsPs1EtUZJ3obS21oxQxGbbRw1G+PtJKjNyur+3t6nzHP9oTg6GHQ3S3hOLLmbDIQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-netbsd-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.25.tgz",
+            "integrity": "sha512-TKIVgNWLUOkr+Exrye70XTEE1lJjdQXdM4tAXRzfHE9iBA7LXWcNtVIuSnphTqpanPzTDFarF0yqq4kpbC6miA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-openbsd-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.25.tgz",
+            "integrity": "sha512-QgFJ37A15D7NIXBTYEqz29+uw3nNBOIyog+3kFidANn6kjw0GHZ0lEYQn+cwjyzu94WobR+fes7cTl/ZYlHb1A==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-sunos-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.25.tgz",
+            "integrity": "sha512-rmWfjUItYIVlqr5EnTH1+GCxXiBOC42WBZ3w++qh7n2cS9Xo0lO5pGSG2N+huOU2fX5L+6YUuJ78/vOYvefeFw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-32": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.25.tgz",
+            "integrity": "sha512-HGAxVUofl3iUIz9W10Y9XKtD0bNsK9fBXv1D55N/ljNvkrAYcGB8YCm0v7DjlwtyS6ws3dkdQyXadbxkbzaKOA==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.25.tgz",
+            "integrity": "sha512-TirEohRkfWU9hXLgoDxzhMQD1g8I2mOqvdQF2RS9E/wbkORTAqJHyh7wqGRCQAwNzdNXdg3JAyhQ9/177AadWA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.25.tgz",
+            "integrity": "sha512-4ype9ERiI45rSh+R8qUoBtaj6kJvUOI7oVLhKqPEpcF4Pa5PpT3hm/mXAyotJHREkHpM87PAJcA442mLnbtlNA==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/fs-extra": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+            "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+        },
+        "node_modules/hash.js": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "node_modules/iso-url": {
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
+            "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/js-sha256": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+            "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+            "dev": true
+        },
+        "node_modules/json-text-sequence": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+            "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+            "dev": true,
+            "dependencies": {
+                "delimit-stream": "0.1.0"
+            }
+        },
+        "node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+        },
+        "node_modules/minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+        },
+        "node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dev": true,
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/simple-cbor": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
+            "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
+            "dev": true
+        },
+        "node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "node_modules/ts-node": {
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+            "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+            "dev": true,
+            "dependencies": {
+                "@cspotcode/source-map-support": "0.7.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.0",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-esm": "dist/bin-esm.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "node_modules/v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true
+        },
+        "node_modules/yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "engines": {
+                "node": ">=6"
+            }
+        }
+    },
+    "dependencies": {
+        "@cspotcode/source-map-consumer": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg=="
+        },
+        "@cspotcode/source-map-support": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+            "requires": {
+                "@cspotcode/source-map-consumer": "0.8.0"
+            }
+        },
+        "@dfinity/agent": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.11.1.tgz",
+            "integrity": "sha512-Z1zw8l3d+AG3uu7d8G/Rd9Q5MWT9gB+Cori/Rqb6IjSEribRhL36ulCSkDYZJU/dhqSUp1VlvX5u51+wgv+MLg==",
+            "dev": true,
+            "requires": {
+                "base64-arraybuffer": "^0.2.0",
+                "bignumber.js": "^9.0.0",
+                "borc": "^2.1.1",
+                "js-sha256": "0.9.0",
+                "simple-cbor": "^0.4.1"
+            }
+        },
+        "@dfinity/candid": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.11.1.tgz",
+            "integrity": "sha512-EYZZg+x7OgZxa56D9SWMeTlaMb09HJ7wIfL42+l/e0lgrx+sTXYxKe8bM9FrUW9AWo9/gKkOGV/IxJL/Acncng==",
+            "dev": true,
+            "peer": true
+        },
+        "@dfinity/principal": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.11.1.tgz",
+            "integrity": "sha512-TlYkwq0fLwmY24X/vrw8mXNRYTkelkM0R5wGjhgK7au24zn7lcXYW3HG+se8YYWFICYY4prI1cS8/6N9z14qjg==",
+            "dev": true,
+            "peer": true
+        },
+        "@swc/core": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.151.tgz",
+            "integrity": "sha512-oHgqKwK/Djv765zUHPiGqfMCaKIxXTgQyyCUBKLBQfAJwe/7FVobQ2fghBp4FsZA/NE1LZBmMPpRZNQwlGjeHw==",
+            "requires": {
+                "@swc/core-android-arm-eabi": "1.2.151",
+                "@swc/core-android-arm64": "1.2.151",
+                "@swc/core-darwin-arm64": "1.2.151",
+                "@swc/core-darwin-x64": "1.2.151",
+                "@swc/core-freebsd-x64": "1.2.151",
+                "@swc/core-linux-arm-gnueabihf": "1.2.151",
+                "@swc/core-linux-arm64-gnu": "1.2.151",
+                "@swc/core-linux-arm64-musl": "1.2.151",
+                "@swc/core-linux-x64-gnu": "1.2.151",
+                "@swc/core-linux-x64-musl": "1.2.151",
+                "@swc/core-win32-arm64-msvc": "1.2.151",
+                "@swc/core-win32-ia32-msvc": "1.2.151",
+                "@swc/core-win32-x64-msvc": "1.2.151"
+            }
+        },
+        "@swc/core-android-arm-eabi": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.151.tgz",
+            "integrity": "sha512-Suk3IcHdha33K4hq9tfBCwkXJsENh7kjXCseLqL8Yvy8QobqkXjf1fcoJxX9BdCmPwsKmIw0ZgCBYR+Hl83M2w==",
+            "optional": true
+        },
+        "@swc/core-android-arm64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.151.tgz",
+            "integrity": "sha512-HZVy69dVWT5RgrMJMRK5aiicPmhzkyCHAexApYAHYLgAIhsxL7uoAIPmuRKRkrKNJjrwsWL7H27bBH5bddRDvg==",
+            "optional": true
+        },
+        "@swc/core-darwin-arm64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.151.tgz",
+            "integrity": "sha512-Ql7rXMu+IC76TemRtkt+opl5iSpX2ApAXVSfvf6afNVTrfTKLpDwiR3ySRRlG0FnNIv6TfOCJpHf655xp01S/g==",
+            "optional": true
+        },
+        "@swc/core-darwin-x64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.151.tgz",
+            "integrity": "sha512-N1OBIB7xatR5eybLo91ZhvMJMxT0zxRQURV/a9I8o5CyP4iLd1k8gmrYvBbtj08ohS8F9z7k/dFjxk/9ve5Drw==",
+            "optional": true
+        },
+        "@swc/core-freebsd-x64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.151.tgz",
+            "integrity": "sha512-WVIRiDzuz+/W7BMjVtg1Cmk1+zmDT18Qq+Ygr9J6aFQ1JQUkLEE1pvtkGD3JIEa6Jhz/VwM6AFHtY5o1CrZ21w==",
+            "optional": true
+        },
+        "@swc/core-linux-arm-gnueabihf": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.151.tgz",
+            "integrity": "sha512-pfBrIUwu3cR/M7DzDCUJAw9jFKXvJ/Ge8auFk07lRb+JcDnPm0XxLyrLqGvNQWdcHgXeXfmnS4fMQxdb9GUN1w==",
+            "optional": true
+        },
+        "@swc/core-linux-arm64-gnu": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.151.tgz",
+            "integrity": "sha512-M+BTkTdPY7gteM+0dYz9wrU/j9taL4ccqPEHkDEKP21lS24y99UtuKsvdBLzDm/6ShBVLFAkgIBPu5cEb7y6ig==",
+            "optional": true
+        },
+        "@swc/core-linux-arm64-musl": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.151.tgz",
+            "integrity": "sha512-7A+yTtSvPJVwO8X1cxUbD/PVCx8G9MKn83G9pH/r+9sQMBXqxyw6/NR0DG6nMMiyOmJkmYWgh5mO47BN7WC4dQ==",
+            "optional": true
+        },
+        "@swc/core-linux-x64-gnu": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.151.tgz",
+            "integrity": "sha512-ORlbN3wf1w0IQGjGToYYC/hV/Vwfcs88Ohfxc4X+IQaw/VxKG6/XT65c0btK640F2TVhvhH1MbYFJJlsycsW7g==",
+            "optional": true
+        },
+        "@swc/core-linux-x64-musl": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.151.tgz",
+            "integrity": "sha512-r6odKE3+9+ReVdnNTZnICt5tscyFFtP4GFcmPQzBSlVoD9LZX6O4WeOlFXn77rVK/+205n2ag/KkKgZH+vdPuQ==",
+            "optional": true
+        },
+        "@swc/core-win32-arm64-msvc": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.151.tgz",
+            "integrity": "sha512-jnjJTNHpLhBaPwRgiKv1TdrMljL88ePqMCdVMantyd7yl4lP0D2e5/xR9ysR9S4EGcUnOyo9w8WUYhx/TioMZw==",
+            "optional": true
+        },
+        "@swc/core-win32-ia32-msvc": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.151.tgz",
+            "integrity": "sha512-hSCxAiyDDXKvdUExj4jSIhzWFePqoqak1qdNUjlhEhEinDG8T8PTRCLalyW6fqZDcLf6Tqde7H79AqbfhRlYGQ==",
+            "optional": true
+        },
+        "@swc/core-win32-x64-msvc": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.151.tgz",
+            "integrity": "sha512-HOkqcJWCChps83Maj0M5kifPDuZ2sGPqpLM67poawspTFkBh0QJ9TMmxW1doQw+74cqsTpRi1ewr/KhsN18i5g==",
+            "optional": true
+        },
+        "@tsconfig/node10": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+            "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
+        },
+        "@tsconfig/node12": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+            "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
+        },
+        "@tsconfig/node14": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+            "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
+        },
+        "@tsconfig/node16": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+            "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
+        },
+        "@types/node": {
+            "version": "17.0.23",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+            "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+            "peer": true
+        },
+        "acorn": {
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+        },
+        "acorn-walk": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+        },
+        "arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+        },
+        "azle": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/azle/-/azle-0.4.0.tgz",
+            "integrity": "sha512-Q0U5fP0ItzoajCFdl0N01zEC/EvSj+NJwpGjGd70RbXTq98gtgoIzHentBBTIRg09RaLkrlFtb/CGHLTRX4NDg==",
+            "requires": {
+                "@swc/core": "1.2.151",
+                "azle-syn": "0.0.0",
+                "esbuild": "0.14.25",
+                "fs-extra": "10.0.1",
+                "hash.js": "1.1.7",
+                "ts-node": "10.3.1",
+                "typescript": "4.4.4"
+            },
+            "dependencies": {
+                "ts-node": {
+                    "version": "10.3.1",
+                    "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.3.1.tgz",
+                    "integrity": "sha512-Yw3W2mYzhHfCHOICGNJqa0i+rbL0rAyg7ZIHxU+K4pgY8gd2Lh1j+XbHCusJMykbj6RZMJVOY0MlHVd+GOivcw==",
+                    "requires": {
+                        "@cspotcode/source-map-support": "0.7.0",
+                        "@tsconfig/node10": "^1.0.7",
+                        "@tsconfig/node12": "^1.0.7",
+                        "@tsconfig/node14": "^1.0.0",
+                        "@tsconfig/node16": "^1.0.2",
+                        "acorn": "^8.4.1",
+                        "acorn-walk": "^8.1.1",
+                        "arg": "^4.1.0",
+                        "create-require": "^1.1.0",
+                        "diff": "^4.0.1",
+                        "make-error": "^1.1.1",
+                        "yn": "3.1.1"
+                    }
+                },
+                "typescript": {
+                    "version": "4.4.4",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+                    "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
+                }
+            }
+        },
+        "azle-syn": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/azle-syn/-/azle-syn-0.0.0.tgz",
+            "integrity": "sha512-fWExJb5/hOEJOuBQ8hMMHRs9WryYeLLa9/ydqPWxbwjMEpE8RKdU1dTK6mdZtzNMhbeHdyne2pU1iVKiKmImGw=="
+        },
+        "base64-arraybuffer": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+            "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+            "dev": true
+        },
+        "base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true
+        },
+        "bignumber.js": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+            "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+            "dev": true
+        },
+        "borc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
+            "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+            "dev": true,
+            "requires": {
+                "bignumber.js": "^9.0.0",
+                "buffer": "^5.5.0",
+                "commander": "^2.15.0",
+                "ieee754": "^1.1.13",
+                "iso-url": "~0.4.7",
+                "json-text-sequence": "~0.1.0",
+                "readable-stream": "^3.6.0"
+            }
+        },
+        "buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
+        },
+        "create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+        },
+        "delimit-stream": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+            "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs=",
+            "dev": true
+        },
+        "diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+        },
+        "esbuild": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.25.tgz",
+            "integrity": "sha512-4JHEIOMNFvK09ziiL+iVmldIhLbn49V4NAVo888tcGFKedEZY/Y8YapfStJ6zSE23tzYPKxqKwQBnQoIO0BI/Q==",
+            "requires": {
+                "esbuild-android-64": "0.14.25",
+                "esbuild-android-arm64": "0.14.25",
+                "esbuild-darwin-64": "0.14.25",
+                "esbuild-darwin-arm64": "0.14.25",
+                "esbuild-freebsd-64": "0.14.25",
+                "esbuild-freebsd-arm64": "0.14.25",
+                "esbuild-linux-32": "0.14.25",
+                "esbuild-linux-64": "0.14.25",
+                "esbuild-linux-arm": "0.14.25",
+                "esbuild-linux-arm64": "0.14.25",
+                "esbuild-linux-mips64le": "0.14.25",
+                "esbuild-linux-ppc64le": "0.14.25",
+                "esbuild-linux-riscv64": "0.14.25",
+                "esbuild-linux-s390x": "0.14.25",
+                "esbuild-netbsd-64": "0.14.25",
+                "esbuild-openbsd-64": "0.14.25",
+                "esbuild-sunos-64": "0.14.25",
+                "esbuild-windows-32": "0.14.25",
+                "esbuild-windows-64": "0.14.25",
+                "esbuild-windows-arm64": "0.14.25"
+            }
+        },
+        "esbuild-android-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.25.tgz",
+            "integrity": "sha512-L5vCUk7TzFbBnoESNoXjU3x9+/+7TDIE/1mTfy/erAfvZAqC+S3sp/Qa9wkypFMcFvN9FzvESkTlpeQDolREtQ==",
+            "optional": true
+        },
+        "esbuild-android-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.25.tgz",
+            "integrity": "sha512-4jv5xPjM/qNm27T5j3ZEck0PvjgQtoMHnz4FzwF5zNP56PvY2CT0WStcAIl6jNlsuDdN63rk2HRBIsO6xFbcFw==",
+            "optional": true
+        },
+        "esbuild-darwin-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.25.tgz",
+            "integrity": "sha512-TGp8tuudIxOyWd1+8aYPxQmC1ZQyvij/AfNBa35RubixD0zJ1vkKHVAzo0Zao1zcG6pNqiSyzfPto8vmg0s7oA==",
+            "optional": true
+        },
+        "esbuild-darwin-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.25.tgz",
+            "integrity": "sha512-oTcDgdm0MDVEmw2DWu8BV68pYuImpFgvWREPErBZmNA4MYKGuBRaCiJqq6jZmBR1x+3y1DWCjez+5uLtuAm6mw==",
+            "optional": true
+        },
+        "esbuild-freebsd-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.25.tgz",
+            "integrity": "sha512-ueAqbnMZ8arnuLH8tHwTCQYeptnHOUV7vA6px6j4zjjQwDx7TdP7kACPf3TLZLdJQ3CAD1XCvQ2sPhX+8tacvQ==",
+            "optional": true
+        },
+        "esbuild-freebsd-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.25.tgz",
+            "integrity": "sha512-+ZVWud2HKh+Ob6k/qiJWjBtUg4KmJGGmbvEXXW1SNKS7hW7HU+Zq2ZCcE1akFxOPkVB+EhOty/sSek30tkCYug==",
+            "optional": true
+        },
+        "esbuild-linux-32": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.25.tgz",
+            "integrity": "sha512-3OP/lwV3kCzEz45tobH9nj+uE4ubhGsfx+tn0L26WAGtUbmmcRpqy7XRG/qK7h1mClZ+eguIANcQntYMdYklfw==",
+            "optional": true
+        },
+        "esbuild-linux-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.25.tgz",
+            "integrity": "sha512-+aKHdHZmX9qwVlQmu5xYXh7GsBFf4TWrePgeJTalhXHOG7NNuUwoHmketGiZEoNsWyyqwH9rE5BC+iwcLY30Ug==",
+            "optional": true
+        },
+        "esbuild-linux-arm": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.25.tgz",
+            "integrity": "sha512-aTLcE2VBoLydL943REcAcgnDi3bHtmULSXWLbjtBdtykRatJVSxKMjK9YlBXUZC4/YcNQfH7AxwVeQr9fNxPhw==",
+            "optional": true
+        },
+        "esbuild-linux-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.25.tgz",
+            "integrity": "sha512-UxfenPx/wSZx55gScCImPtXekvZQLI2GW3qe5dtlmU7luiqhp5GWPzGeQEbD3yN3xg/pHc671m5bma5Ns7lBHw==",
+            "optional": true
+        },
+        "esbuild-linux-mips64le": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.25.tgz",
+            "integrity": "sha512-wLWYyqVfYx9Ur6eU5RT92yJVsaBGi5RdkoWqRHOqcJ38Kn60QMlcghsKeWfe9jcYut8LangYZ98xO1LxIoSXrQ==",
+            "optional": true
+        },
+        "esbuild-linux-ppc64le": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.25.tgz",
+            "integrity": "sha512-0dR6Csl6Zas3g4p9ULckEl8Mo8IInJh33VCJ3eaV1hj9+MHGdmDOakYMN8MZP9/5nl+NU/0ygpd14cWgy8uqRw==",
+            "optional": true
+        },
+        "esbuild-linux-riscv64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.25.tgz",
+            "integrity": "sha512-J4d20HDmTrgvhR0bdkDhvvJGaikH3LzXQnNaseo8rcw9Yqby9A90gKUmWpfwqLVNRILvNnAmKLfBjCKU9ajg8w==",
+            "optional": true
+        },
+        "esbuild-linux-s390x": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.25.tgz",
+            "integrity": "sha512-YI2d5V6nTE73ZnhEKQD7MtsPs1EtUZJ3obS21oxQxGbbRw1G+PtJKjNyur+3t6nzHP9oTg6GHQ3S3hOLLmbDIQ==",
+            "optional": true
+        },
+        "esbuild-netbsd-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.25.tgz",
+            "integrity": "sha512-TKIVgNWLUOkr+Exrye70XTEE1lJjdQXdM4tAXRzfHE9iBA7LXWcNtVIuSnphTqpanPzTDFarF0yqq4kpbC6miA==",
+            "optional": true
+        },
+        "esbuild-openbsd-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.25.tgz",
+            "integrity": "sha512-QgFJ37A15D7NIXBTYEqz29+uw3nNBOIyog+3kFidANn6kjw0GHZ0lEYQn+cwjyzu94WobR+fes7cTl/ZYlHb1A==",
+            "optional": true
+        },
+        "esbuild-sunos-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.25.tgz",
+            "integrity": "sha512-rmWfjUItYIVlqr5EnTH1+GCxXiBOC42WBZ3w++qh7n2cS9Xo0lO5pGSG2N+huOU2fX5L+6YUuJ78/vOYvefeFw==",
+            "optional": true
+        },
+        "esbuild-windows-32": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.25.tgz",
+            "integrity": "sha512-HGAxVUofl3iUIz9W10Y9XKtD0bNsK9fBXv1D55N/ljNvkrAYcGB8YCm0v7DjlwtyS6ws3dkdQyXadbxkbzaKOA==",
+            "optional": true
+        },
+        "esbuild-windows-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.25.tgz",
+            "integrity": "sha512-TirEohRkfWU9hXLgoDxzhMQD1g8I2mOqvdQF2RS9E/wbkORTAqJHyh7wqGRCQAwNzdNXdg3JAyhQ9/177AadWA==",
+            "optional": true
+        },
+        "esbuild-windows-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.25.tgz",
+            "integrity": "sha512-4ype9ERiI45rSh+R8qUoBtaj6kJvUOI7oVLhKqPEpcF4Pa5PpT3hm/mXAyotJHREkHpM87PAJcA442mLnbtlNA==",
+            "optional": true
+        },
+        "fs-extra": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+            "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+        },
+        "hash.js": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "requires": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "iso-url": {
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
+            "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+            "dev": true
+        },
+        "js-sha256": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+            "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+            "dev": true
+        },
+        "json-text-sequence": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+            "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+            "dev": true,
+            "requires": {
+                "delimit-stream": "0.1.0"
+            }
+        },
+        "jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+            }
+        },
+        "make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+        },
+        "minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+        },
+        "readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true
+        },
+        "simple-cbor": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
+            "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "ts-node": {
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+            "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+            "dev": true,
+            "requires": {
+                "@cspotcode/source-map-support": "0.7.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.0",
+                "yn": "3.1.1"
+            }
+        },
+        "typescript": {
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+            "dev": true
+        },
+        "universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true
+        },
+        "yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+        }
+    }
+}

--- a/examples/inspect_message/package.json
+++ b/examples/inspect_message/package.json
@@ -1,0 +1,13 @@
+{
+    "scripts": {
+        "test": "ts-node --transpile-only --ignore=false test/test.ts"
+    },
+    "dependencies": {
+        "azle": "0.4.0"
+    },
+    "devDependencies": {
+        "@dfinity/agent": "0.11.1",
+        "ts-node": "10.7.0",
+        "typescript": "4.6.3"
+    }
+}

--- a/examples/inspect_message/src/inspect_message.did
+++ b/examples/inspect_message/src/inspect_message.did
@@ -1,0 +1,3 @@
+service: {
+    "getInitialized": () -> (bool);
+}

--- a/examples/inspect_message/src/inspect_message.ts
+++ b/examples/inspect_message/src/inspect_message.ts
@@ -1,12 +1,10 @@
 import { InspectMessage, Update } from 'azle';
 
-let initialized = false;
-
 export function inspectMessage(): InspectMessage {
-    initialized = true;
-    console.log('inspect_message initialized', initialized);
+    console.log('inspect_message initialized');
 }
 
+// This method will always return a 403
 export function getInitialized(): Update<boolean> {
-    return initialized;
+    return true;
 }

--- a/examples/inspect_message/src/inspect_message.ts
+++ b/examples/inspect_message/src/inspect_message.ts
@@ -1,0 +1,12 @@
+import { InspectMessage, Update } from 'azle';
+
+let initialized = false;
+
+export function inspectMessage(): InspectMessage {
+    initialized = true;
+    console.log('inspect_message initialized', initialized);
+}
+
+export function getInitialized(): Update<boolean> {
+    return initialized;
+}

--- a/examples/inspect_message/test/dfx_generated/inspect_message/index.js
+++ b/examples/inspect_message/test/dfx_generated/inspect_message/index.js
@@ -1,0 +1,38 @@
+import { Actor, HttpAgent } from "@dfinity/agent";
+
+// Imports and re-exports candid interface
+import { idlFactory } from './inspect_message.did.js';
+export { idlFactory } from './inspect_message.did.js';
+// CANISTER_ID is replaced by webpack based on node environment
+export const canisterId = process.env.INSPECT_MESSAGE_CANISTER_ID;
+
+/**
+ * 
+ * @param {string | import("@dfinity/principal").Principal} canisterId Canister ID of Agent
+ * @param {{agentOptions?: import("@dfinity/agent").HttpAgentOptions; actorOptions?: import("@dfinity/agent").ActorConfig}} [options]
+ * @return {import("@dfinity/agent").ActorSubclass<import("./inspect_message.did.js")._SERVICE>}
+ */
+ export const createActor = (canisterId, options) => {
+  const agent = new HttpAgent({ ...options?.agentOptions });
+  
+  // Fetch root key for certificate validation during development
+  if(process.env.NODE_ENV !== "production") {
+    agent.fetchRootKey().catch(err=>{
+      console.warn("Unable to fetch root key. Check to ensure that your local replica is running");
+      console.error(err);
+    });
+  }
+
+  // Creates an actor with using the candid interface and the HttpAgent
+  return Actor.createActor(idlFactory, {
+    agent,
+    canisterId,
+    ...options?.actorOptions,
+  });
+};
+  
+/**
+ * A ready-to-use agent for the inspect_message canister
+ * @type {import("@dfinity/agent").ActorSubclass<import("./inspect_message.did.js")._SERVICE>}
+ */
+//  export const inspect_message = createActor(canisterId);

--- a/examples/inspect_message/test/dfx_generated/inspect_message/inspect_message.did
+++ b/examples/inspect_message/test/dfx_generated/inspect_message/inspect_message.did
@@ -1,0 +1,3 @@
+service: {
+    "getInitialized": () -> (bool);
+}

--- a/examples/inspect_message/test/dfx_generated/inspect_message/inspect_message.did.d.ts
+++ b/examples/inspect_message/test/dfx_generated/inspect_message/inspect_message.did.d.ts
@@ -1,0 +1,2 @@
+import type { Principal } from '@dfinity/principal';
+export interface _SERVICE { 'getInitialized' : () => Promise<boolean> }

--- a/examples/inspect_message/test/dfx_generated/inspect_message/inspect_message.did.js
+++ b/examples/inspect_message/test/dfx_generated/inspect_message/inspect_message.did.js
@@ -1,0 +1,4 @@
+export const idlFactory = ({ IDL }) => {
+  return IDL.Service({ 'getInitialized' : IDL.Func([], [IDL.Bool], []) });
+};
+export const init = ({ IDL }) => { return []; };

--- a/examples/inspect_message/test/test.ts
+++ b/examples/inspect_message/test/test.ts
@@ -1,0 +1,50 @@
+import { run_tests, Test } from 'azle/test';
+import { execSync } from 'child_process';
+import { createActor } from './dfx_generated/inspect_message';
+
+const inspect_message_canister = createActor('rrkah-fqaaa-aaaaa-aaaaq-cai', {
+    agentOptions: {
+        host: 'http://127.0.0.1:8000'
+    }
+});
+
+const tests: Test[] = [
+    {
+        name: 'clear canister memory',
+        prep: async () => {
+            execSync(`dfx canister uninstall-code inspect_message || true`, {
+                stdio: 'inherit'
+            });
+        }
+    },
+    {
+        // TODO hopefully we can get rid of this: https://forum.dfinity.org/t/generated-declarations-in-node-js-environment-break/12686/16?u=lastmjs
+        name: 'waiting for createActor fetchRootKey',
+        wait: 5000
+    },
+    {
+        name: 'deploy',
+        prep: async () => {
+            execSync(`dfx deploy`, {
+                stdio: 'inherit'
+            });
+        }
+    },
+    {
+        name: 'getInitialized',
+        test: async () => {
+            try {
+                const result = await inspect_message_canister.getInitialized();
+                return {
+                    ok: false
+                };
+            } catch (error) {
+                return {
+                    ok: ((error as any).message as string).includes('Code: 403')
+                };
+            }
+        }
+    }
+];
+
+run_tests(tests);

--- a/examples/inspect_message/tsconfig.json
+++ b/examples/inspect_message/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "target": "ES2020",
+        "moduleResolution": "node",
+        "allowJs": true,
+        "outDir": "HACK_BECAUSE_OF_ALLOW_JS"
+    }
+}

--- a/index.ts
+++ b/index.ts
@@ -90,6 +90,7 @@ export type PreUpgrade = void;
 export type PostUpgrade = void;
 export type Heartbeat = void | Generator;
 export type Init = void;
+export type InspectMessage = void;
 export type Query<T> = T;
 // export type QueryAsync<T> = Generator<T>; // TODO enable once this is resolved: https://forum.dfinity.org/t/inter-canister-query-calls-community-consideration/6754
 export type Update<T> = T;

--- a/src/compiler/typescript_to_rust/generators/canister_methods/heartbeat.ts
+++ b/src/compiler/typescript_to_rust/generators/canister_methods/heartbeat.ts
@@ -32,7 +32,7 @@ export function generateCanisterMethodHeartbeat(sourceFiles: readonly tsc.Source
         #[ic_cdk_macros::heartbeat]
         fn _azle_${heartbeatFunctionName}() {
             unsafe {
-                ic_cdk::block_on(async {
+                ic_cdk::spawn(async {
                     let boa_context_option = BOA_CONTEXT_OPTION.as_mut();
 
                     if let Some(boa_context) = boa_context_option {

--- a/src/compiler/typescript_to_rust/generators/canister_methods/inspect_message.ts
+++ b/src/compiler/typescript_to_rust/generators/canister_methods/inspect_message.ts
@@ -36,44 +36,34 @@ export function generateCanisterMethodInspectMessage(
         #[ic_cdk_macros::inspect_message]
         fn _azle_${inspectMessageFunctionName}() {
             unsafe {
-                ic_cdk::spawn(async {
-                    let boa_context_option = BOA_CONTEXT_OPTION.as_mut();
+                let boa_context_option = BOA_CONTEXT_OPTION.as_mut();
 
-                    if let Some(boa_context) = boa_context_option {
-                        let exports_js_value_result = boa_context.eval("exports");
+                if let Some(boa_context) = boa_context_option {
+                    let exports_js_value_result = boa_context.eval("exports");
 
-                        if let Ok(exports_js_value) = exports_js_value_result {
-                            let exports_js_object_option = exports_js_value.as_object();
+                    if let Ok(exports_js_value) = exports_js_value_result {
+                        let exports_js_object_option = exports_js_value.as_object();
 
-                            if let Some(exports_js_object) = exports_js_object_option {
-                                let ${inspectMessageFunctionName}_js_value_result =
-                                    exports_js_object.get("${inspectMessageFunctionName}", boa_context);
+                        if let Some(exports_js_object) = exports_js_object_option {
+                            let ${inspectMessageFunctionName}_js_value_result =
+                                exports_js_object.get("${inspectMessageFunctionName}", boa_context);
 
-                                if let Ok(${inspectMessageFunctionName}_js_value) =
-                                    ${inspectMessageFunctionName}_js_value_result
+                            if let Ok(${inspectMessageFunctionName}_js_value) =
+                                ${inspectMessageFunctionName}_js_value_result
+                            {
+                                let ${inspectMessageFunctionName}_js_object_option =
+                                    ${inspectMessageFunctionName}_js_value.as_object();
+
+                                if let Some(${inspectMessageFunctionName}_js_object) =
+                                    ${inspectMessageFunctionName}_js_object_option
                                 {
-                                    let ${inspectMessageFunctionName}_js_object_option =
-                                        ${inspectMessageFunctionName}_js_value.as_object();
-
-                                    if let Some(${inspectMessageFunctionName}_js_object) =
-                                        ${inspectMessageFunctionName}_js_object_option
-                                    {
-                                        let return_value_result = ${inspectMessageFunctionName}_js_object
-                                            .call(&boa_engine::JsValue::Null, &[], boa_context);
-
-                                        if let Ok(return_value) = return_value_result {
-                                            if return_value.is_object() == true
-                                                && return_value.as_object().unwrap().is_generator() == true
-                                            {
-                                                handle_generator_result(boa_context, &return_value).await;
-                                            }
-                                        }
-                                    }
+                                    let return_value = ${inspectMessageFunctionName}_js_object
+                                        .call(&boa_engine::JsValue::Null, &[], boa_context).unwrap();
                                 }
                             }
                         }
                     }
-                });
+                }
             }
         }
     `;

--- a/src/compiler/typescript_to_rust/generators/canister_methods/inspect_message.ts
+++ b/src/compiler/typescript_to_rust/generators/canister_methods/inspect_message.ts
@@ -1,0 +1,80 @@
+import { Rust } from '../../../../types';
+import { getCanisterMethodFunctionDeclarationsFromSourceFiles } from '../../../typescript_to_candid/ast_utilities/canister_methods';
+import { getFunctionName } from '../../../typescript_to_candid/ast_utilities/miscellaneous';
+
+import * as tsc from 'typescript';
+
+export function generateCanisterMethodInspectMessage(
+    sourceFiles: readonly tsc.SourceFile[]
+): Rust {
+    const inspectMessageFunctionDeclarations =
+        getCanisterMethodFunctionDeclarationsFromSourceFiles(sourceFiles, [
+            'InspectMessage'
+        ]);
+
+    if (inspectMessageFunctionDeclarations.length > 1) {
+        throw new Error(`Only one InspectMessage function can be defined`);
+    }
+
+    const inspectMessageFunctionDeclaration:
+        | tsc.FunctionDeclaration
+        | undefined = inspectMessageFunctionDeclarations[0];
+
+    if (inspectMessageFunctionDeclaration === undefined) {
+        return '';
+    }
+
+    const inspectMessageFunctionName = getFunctionName(
+        inspectMessageFunctionDeclaration
+    );
+
+    // TODO study deeply what is going on here...I wonder if init and inspectMessage might be writing over each other
+    // TODO I probably did not need to do all of the weird pyramid stuff, unless the shared mutable state is actually an issue
+    // TODO I am hoping that it isn't though, as I hope that each update call is executed independently
+    // TODO we will have to see though
+    return /* rust */ `
+        #[ic_cdk_macros::inspect_message]
+        fn _azle_${inspectMessageFunctionName}() {
+            unsafe {
+                ic_cdk::spawn(async {
+                    let boa_context_option = BOA_CONTEXT_OPTION.as_mut();
+
+                    if let Some(boa_context) = boa_context_option {
+                        let exports_js_value_result = boa_context.eval("exports");
+
+                        if let Ok(exports_js_value) = exports_js_value_result {
+                            let exports_js_object_option = exports_js_value.as_object();
+
+                            if let Some(exports_js_object) = exports_js_object_option {
+                                let ${inspectMessageFunctionName}_js_value_result =
+                                    exports_js_object.get("${inspectMessageFunctionName}", boa_context);
+
+                                if let Ok(${inspectMessageFunctionName}_js_value) =
+                                    ${inspectMessageFunctionName}_js_value_result
+                                {
+                                    let ${inspectMessageFunctionName}_js_object_option =
+                                        ${inspectMessageFunctionName}_js_value.as_object();
+
+                                    if let Some(${inspectMessageFunctionName}_js_object) =
+                                        ${inspectMessageFunctionName}_js_object_option
+                                    {
+                                        let return_value_result = ${inspectMessageFunctionName}_js_object
+                                            .call(&boa_engine::JsValue::Null, &[], boa_context);
+
+                                        if let Ok(return_value) = return_value_result {
+                                            if return_value.is_object() == true
+                                                && return_value.as_object().unwrap().is_generator() == true
+                                            {
+                                                handle_generator_result(boa_context, &return_value).await;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        }
+    `;
+}

--- a/src/compiler/typescript_to_rust/generators/canister_methods/inspect_message.ts
+++ b/src/compiler/typescript_to_rust/generators/canister_methods/inspect_message.ts
@@ -28,10 +28,6 @@ export function generateCanisterMethodInspectMessage(
         inspectMessageFunctionDeclaration
     );
 
-    // TODO study deeply what is going on here...I wonder if init and inspectMessage might be writing over each other
-    // TODO I probably did not need to do all of the weird pyramid stuff, unless the shared mutable state is actually an issue
-    // TODO I am hoping that it isn't though, as I hope that each update call is executed independently
-    // TODO we will have to see though
     return /* rust */ `
         #[ic_cdk_macros::inspect_message]
         fn _azle_${inspectMessageFunctionName}() {

--- a/src/compiler/typescript_to_rust/generators/lib_file.ts
+++ b/src/compiler/typescript_to_rust/generators/lib_file.ts
@@ -1,5 +1,6 @@
 import { generateCanisterMethodsDeveloperDefined } from './canister_methods/developer_defined';
 import { generateCanisterMethodInit } from './canister_methods/init';
+import { generateCanisterMethodInspectMessage } from './canister_methods/inspect_message';
 import { generateHead } from './head';
 import { generateIcObjectFunctionCaller } from './ic_object/functions/caller';
 import { generateIcObjectFunctionCanisterBalance } from './ic_object/functions/canister_balance';
@@ -50,6 +51,7 @@ export async function generateLibFile(
         js,
         sourceFiles
     );
+    const canisterMethodInspectMessage: Rust = generateCanisterMethodInspectMessage(sourceFiles);
     const canisterMethodPreUpgrade: Rust = generateCanisterMethodPreUpgrade(sourceFiles);
     const canisterMethodPostUpgrade: Rust = generateCanisterMethodPostUpgrade(sourceFiles);
     const canisterMethodHeartbeat: Rust = generateCanisterMethodHeartbeat(sourceFiles);
@@ -84,6 +86,7 @@ export async function generateLibFile(
         ${azleTryFromJsValueTrait}
 
         ${canisterMethodInit}
+        ${canisterMethodInspectMessage}
         ${canisterMethodPreUpgrade}
         ${canisterMethodPostUpgrade}
         ${canisterMethodHeartbeat}

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type CanisterMethodTypeName =
     'Update' |
     'UpdateAsync' |
     'Init' |
+    'InspectMessage' |
     'Heartbeat' |
     'PreUpgrade' |
     'PostUpgrade';


### PR DESCRIPTION
Adds the `InspectMessage` return type for decorating canister methods. Note that until `accept_message` is implemented, this will only cause all methods to return 403s.

Resolves #234 