### PR TITLE
Abstract lib file subsections

### DIFF
--- a/src/compiler/typescript_to_rust/generators/canister_methods/heartbeat.ts
+++ b/src/compiler/typescript_to_rust/generators/canister_methods/heartbeat.ts
@@ -28,7 +28,7 @@ export function generateCanisterMethodHeartbeat(sourceFiles: readonly tsc.Source
     // TODO I probably did not need to do all of the weird pyramid stuff, unless the shared mutable state is actually an issue
     // TODO I am hoping that it isn't though, as I hope that each update call is executed independently
     // TODO we will have to see though
-    return `
+    return /* rust */ `
         #[ic_cdk_macros::heartbeat]
         fn _azle_${heartbeatFunctionName}() {
             unsafe {
@@ -40,13 +40,13 @@ export function generateCanisterMethodHeartbeat(sourceFiles: readonly tsc.Source
 
                         if let Ok(exports_js_value) = exports_js_value_result {
                             let exports_js_object_option = exports_js_value.as_object();
-        
+
                             if let Some(exports_js_object) = exports_js_object_option {
                                 let ${heartbeatFunctionName}_js_value_result = exports_js_object.get("${heartbeatFunctionName}", boa_context);
-                                
+
                                 if let Ok(${heartbeatFunctionName}_js_value) = ${heartbeatFunctionName}_js_value_result {
                                     let ${heartbeatFunctionName}_js_object_option = ${heartbeatFunctionName}_js_value.as_object();
-                            
+
                                     if let Some(${heartbeatFunctionName}_js_object) = ${heartbeatFunctionName}_js_object_option {
                                         let return_value_result = ${heartbeatFunctionName}_js_object.call(
                                             &boa_engine::JsValue::Null,

--- a/src/compiler/typescript_to_rust/generators/canister_methods/index.ts
+++ b/src/compiler/typescript_to_rust/generators/canister_methods/index.ts
@@ -1,0 +1,29 @@
+import { Rust } from '../../../../types';
+import { generateCanisterMethodHeartbeat } from './heartbeat';
+import { generateCanisterMethodInit } from './init';
+import { generateCanisterMethodInspectMessage } from './inspect_message';
+import { generateCanisterMethodPostUpgrade } from './post_upgrade';
+import { generateCanisterMethodPreUpgrade } from './pre_upgrade';
+import { SourceFile } from 'typescript';
+
+export function generateSystemCanisterMethods(
+    sourceFiles: readonly SourceFile[]
+) {
+    const canisterMethodInit: Rust = generateCanisterMethodInit(sourceFiles);
+    const canisterMethodInspectMessage: Rust =
+        generateCanisterMethodInspectMessage(sourceFiles);
+    const canisterMethodPreUpgrade: Rust =
+        generateCanisterMethodPreUpgrade(sourceFiles);
+    const canisterMethodPostUpgrade: Rust =
+        generateCanisterMethodPostUpgrade(sourceFiles);
+    const canisterMethodHeartbeat: Rust =
+        generateCanisterMethodHeartbeat(sourceFiles);
+
+    return `
+        ${canisterMethodInit}
+        ${canisterMethodInspectMessage}
+        ${canisterMethodPreUpgrade}
+        ${canisterMethodPostUpgrade}
+        ${canisterMethodHeartbeat}
+    `;
+}

--- a/src/compiler/typescript_to_rust/generators/canister_methods/post_upgrade.ts
+++ b/src/compiler/typescript_to_rust/generators/canister_methods/post_upgrade.ts
@@ -1,7 +1,4 @@
-import {
-    JavaScript,
-    Rust
-} from '../../../../types';
+import { Rust } from '../../../../types';
 import * as tsc from 'typescript';
 import { getCanisterMethodFunctionDeclarationsFromSourceFiles } from '../../../typescript_to_candid/ast_utilities/canister_methods';
 import { getUserDefinedInitFunctionParams } from './init';
@@ -43,7 +40,7 @@ export function generateCanisterMethodPostUpgrade(sourceFiles: readonly tsc.Sour
 
     const developerDefinedPostUpgradeFunctionName = getDeveloperDefinedPostUpgradeFunctionName(postUpgradeFunctionDeclaration);
 
-    return `
+    return /* rust */ `
         #[ic_cdk_macros::post_upgrade]
         fn post_upgrade(${userDefinedInitFunctionParams.filter((param) => param.paramName !== 'boa_context').map((param) => `${param.paramName}: ${param.paramType}`).join(', ')}) {
             unsafe {
@@ -68,7 +65,7 @@ export function generateCanisterMethodPostUpgrade(sourceFiles: readonly tsc.Sour
                     compiled_js = MAIN_JS
                 )).unwrap();
 
-                ${postUpgradeFunctionDeclaration === undefined ? '' : `
+                ${postUpgradeFunctionDeclaration === undefined ? '' : /* rust */ `
                     let exports_js_value = boa_context.eval("exports").unwrap();
                     let exports_js_object = exports_js_value.as_object().unwrap();
         

--- a/src/compiler/typescript_to_rust/generators/canister_methods/pre_upgrade.ts
+++ b/src/compiler/typescript_to_rust/generators/canister_methods/pre_upgrade.ts
@@ -24,13 +24,13 @@ export function generateCanisterMethodPreUpgrade(sourceFiles: readonly tsc.Sourc
 
     const developerDefinedPreUpgradeFunctionName = getDeveloperDefinedPreUpgradeFunctionName(preUpgradeFunctionDeclaration);
 
-    return `
+    return /* rust */ `
         #[ic_cdk_macros::pre_upgrade]
         fn pre_upgrade() {
             unsafe {
                 let mut boa_context = BOA_CONTEXT_OPTION.as_mut().unwrap();
 
-                ${preUpgradeFunctionDeclaration === undefined ? '' : `
+                ${preUpgradeFunctionDeclaration === undefined ? '' : /* rust */ `
                     let exports_js_value = boa_context.eval("exports").unwrap();
                     let exports_js_object = exports_js_value.as_object().unwrap();
         
@@ -52,14 +52,14 @@ export function generateCanisterMethodPreUpgrade(sourceFiles: readonly tsc.Sourc
                 let _azle_stable_storage_js_object = _azle_stable_storage_js_value.as_object().unwrap();
     
                 ${stableStorageVariableInfos.map((stableStorageVariableInfo) => {
-                    return `
+                    return /* rust */ `
                         let ${stableStorageVariableInfo.name}_js_value = _azle_stable_storage_js_object.get("${stableStorageVariableInfo.name}", &mut boa_context).unwrap();
                         let ${stableStorageVariableInfo.name}: ${stableStorageVariableInfo.rustType} = ${stableStorageVariableInfo.name}_js_value.azle_try_from_js_value(&mut boa_context).unwrap();
                     `;
                 }).join('')}
     
                 // TODO should we panic ever in the pre_upgrade?? If so we should unwrap the stable_save
-                ${stableStorageVariableInfos.length === 0 ? '' : `
+                ${stableStorageVariableInfos.length === 0 ? '' : /* rust */ `
                     ic_cdk::storage::stable_save((${stableStorageVariableInfos.map((stableStorageVariableInfo) => `${stableStorageVariableInfo.name}`).join(',')}${stableStorageVariableInfos.length === 1 ? ',' : ''}));
                 `}
             }

--- a/src/compiler/typescript_to_rust/generators/ic_object/functions/caller.ts
+++ b/src/compiler/typescript_to_rust/generators/ic_object/functions/caller.ts
@@ -1,7 +1,7 @@
 import { Rust } from '../../../../../types';
 
 export function generateIcObjectFunctionCaller(): Rust {
-    return `
+    return /* rust */ `
         fn azle_ic_caller(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],

--- a/src/compiler/typescript_to_rust/generators/ic_object/functions/canister_balance.ts
+++ b/src/compiler/typescript_to_rust/generators/ic_object/functions/canister_balance.ts
@@ -1,7 +1,7 @@
 import { Rust } from '../../../../../types';
 
 export function generateIcObjectFunctionCanisterBalance(): Rust {
-    return `
+    return /* rust */ `
         fn _azle_ic_canister_balance(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],

--- a/src/compiler/typescript_to_rust/generators/ic_object/functions/canister_balance128.ts
+++ b/src/compiler/typescript_to_rust/generators/ic_object/functions/canister_balance128.ts
@@ -1,7 +1,7 @@
 import { Rust } from '../../../../../types';
 
 export function generateIcObjectFunctionCanisterBalance128(): Rust {
-    return `
+    return /* rust */ `
         fn _azle_ic_canister_balance128(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],

--- a/src/compiler/typescript_to_rust/generators/ic_object/functions/id.ts
+++ b/src/compiler/typescript_to_rust/generators/ic_object/functions/id.ts
@@ -1,7 +1,7 @@
 import { Rust } from '../../../../../types';
 
 export function generateIcObjectFunctionId(): Rust {
-    return `
+    return /* rust */ `
         fn azle_ic_id(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],

--- a/src/compiler/typescript_to_rust/generators/ic_object/functions/index.ts
+++ b/src/compiler/typescript_to_rust/generators/ic_object/functions/index.ts
@@ -1,0 +1,35 @@
+import { Rust } from '../../../../../types';
+
+import { generateIcObjectFunctionAcceptMessage } from './accept_message';
+import { generateIcObjectFunctionCaller } from './caller';
+import { generateIcObjectFunctionCanisterBalance } from './canister_balance';
+import { generateIcObjectFunctionCanisterBalance128 } from './canister_balance128';
+import { generateIcObjectFunctionId } from './id';
+import { generateIcObjectFunctionMethodName } from './method_name';
+import { generateIcObjectFunctionPrint } from './print';
+import { generateIcObjectFunctionTime } from './time';
+import { generateIcObjectFunctionTrap } from './trap';
+
+export function generateIcObjectFunctions(): Rust {
+    const icObjectFunctionAcceptMessage: Rust = generateIcObjectFunctionAcceptMessage();
+    const icObjectFunctionCaller: Rust = generateIcObjectFunctionCaller();
+    const icObjectFunctionCanisterBalance: Rust = generateIcObjectFunctionCanisterBalance();
+    const icObjectFunctionCanisterBalance128: Rust = generateIcObjectFunctionCanisterBalance128();
+    const icObjectFunctionId: Rust = generateIcObjectFunctionId();
+    const icObjectFunctionMethodName: Rust = generateIcObjectFunctionMethodName();
+    const icObjectFunctionPrint: Rust = generateIcObjectFunctionPrint();
+    const icObjectFunctionTime: Rust = generateIcObjectFunctionTime();
+    const icObjectFunctionTrap: Rust = generateIcObjectFunctionTrap();
+
+    return `
+        ${icObjectFunctionAcceptMessage}
+        ${icObjectFunctionCaller}
+        ${icObjectFunctionCanisterBalance}
+        ${icObjectFunctionCanisterBalance128}
+        ${icObjectFunctionId}
+        ${icObjectFunctionMethodName}
+        ${icObjectFunctionPrint}
+        ${icObjectFunctionTime}
+        ${icObjectFunctionTrap}
+  `;
+}

--- a/src/compiler/typescript_to_rust/generators/ic_object/functions/print.ts
+++ b/src/compiler/typescript_to_rust/generators/ic_object/functions/print.ts
@@ -1,14 +1,14 @@
 import { Rust } from '../../../../../types';
 
 export function generateIcObjectFunctionPrint(): Rust {
-    return `
+    return /* rust */ `
         fn azle_ic_print(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             _context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
             ic_cdk::println!("{:#?}", _aargs);
-        
+
             return Ok(boa_engine::JsValue::Undefined);
         }
     `;

--- a/src/compiler/typescript_to_rust/generators/ic_object/functions/time.ts
+++ b/src/compiler/typescript_to_rust/generators/ic_object/functions/time.ts
@@ -1,7 +1,7 @@
 import { Rust } from '../../../../../types';
 
 export function generateIcObjectFunctionTime(): Rust {
-    return `
+    return /* rust */ `
         fn azle_ic_time(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],

--- a/src/compiler/typescript_to_rust/generators/ic_object/functions/trap.ts
+++ b/src/compiler/typescript_to_rust/generators/ic_object/functions/trap.ts
@@ -1,7 +1,7 @@
 import { Rust } from '../../../../../types';
 
 export function generateIcObjectFunctionTrap(): Rust {
-    return `
+    return /* rust */ `
         fn azle_ic_trap(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],

--- a/src/compiler/typescript_to_rust/generators/lib_file.ts
+++ b/src/compiler/typescript_to_rust/generators/lib_file.ts
@@ -2,15 +2,7 @@ import { generateCanisterMethodsDeveloperDefined } from './canister_methods/deve
 import { generateCanisterMethodInit } from './canister_methods/init';
 import { generateCanisterMethodInspectMessage } from './canister_methods/inspect_message';
 import { generateHead } from './head';
-import { generateIcObjectFunctionAcceptMessage } from './ic_object/functions/accept_message';
-import { generateIcObjectFunctionCaller } from './ic_object/functions/caller';
-import { generateIcObjectFunctionCanisterBalance } from './ic_object/functions/canister_balance';
-import { generateIcObjectFunctionCanisterBalance128 } from './ic_object/functions/canister_balance128';
-import { generateIcObjectFunctionId } from './ic_object/functions/id';
-import { generateIcObjectFunctionMethodName } from './ic_object/functions/method_name';
-import { generateIcObjectFunctionPrint } from './ic_object/functions/print';
-import { generateIcObjectFunctionTime } from './ic_object/functions/time';
-import { generateIcObjectFunctionTrap } from './ic_object/functions/trap';
+import { generateIcObjectFunctions } from './ic_object/functions';
 import { generateAzleTryFromJsValueTrait } from './azle_try_from_js_value_trait';
 import { generateAzleIntoJsValueTrait } from './azle_into_js_value_trait';
 import { modifyRustCandidTypes } from './modified_rust_candid_types';
@@ -68,15 +60,7 @@ export async function generateLibFile(
 
     const handleGeneratorResultFunction = generateHandleGeneratorResultFunction(callFunctionInfos);
 
-    const icObjectFunctionAcceptMessage: Rust = generateIcObjectFunctionAcceptMessage();
-    const icObjectFunctionCaller: Rust = generateIcObjectFunctionCaller();
-    const icObjectFunctionCanisterBalance: Rust = generateIcObjectFunctionCanisterBalance();
-    const icObjectFunctionCanisterBalance128: Rust = generateIcObjectFunctionCanisterBalance128();
-    const icObjectFunctionId: Rust = generateIcObjectFunctionId();
-    const icObjectFunctionMethodName: Rust = generateIcObjectFunctionMethodName();
-    const icObjectFunctionPrint: Rust = generateIcObjectFunctionPrint();
-    const icObjectFunctionTime: Rust = generateIcObjectFunctionTime();
-    const icObjectFunctionTrap: Rust = generateIcObjectFunctionTrap();
+    const icObjectFunctions: Rust = generateIcObjectFunctions();
 
     const azleIntoJsValueTrait: Rust = generateAzleIntoJsValueTrait();
     const azleTryFromJsValueTrait: Rust = generateAzleTryFromJsValueTrait();
@@ -98,15 +82,7 @@ export async function generateLibFile(
 
         ${handleGeneratorResultFunction}
 
-        ${icObjectFunctionAcceptMessage}
-        ${icObjectFunctionCaller}
-        ${icObjectFunctionCanisterBalance}
-        ${icObjectFunctionCanisterBalance128}
-        ${icObjectFunctionId}
-        ${icObjectFunctionMethodName}
-        ${icObjectFunctionPrint}
-        ${icObjectFunctionTime}
-        ${icObjectFunctionTrap}
+        ${icObjectFunctions}
 
         ${callFunctionInfos.map((callFunctionInfo) => callFunctionInfo.text).join('\n')}
     `;

--- a/src/compiler/typescript_to_rust/generators/lib_file.ts
+++ b/src/compiler/typescript_to_rust/generators/lib_file.ts
@@ -1,23 +1,15 @@
+import { generateAzleIntoJsValueTrait } from './azle_into_js_value_trait';
+import { generateAzleTryFromJsValueTrait } from './azle_try_from_js_value_trait';
+import { generateCallFunctions } from './call_functions';
+import { generateSystemCanisterMethods } from './canister_methods';
 import { generateCanisterMethodsDeveloperDefined } from './canister_methods/developer_defined';
-import { generateCanisterMethodInit } from './canister_methods/init';
-import { generateCanisterMethodInspectMessage } from './canister_methods/inspect_message';
+import { generateHandleGeneratorResultFunction } from './canister_methods/developer_defined/return_value_handler';
 import { generateHead } from './head';
 import { generateIcObjectFunctions } from './ic_object/functions';
-import { generateAzleTryFromJsValueTrait } from './azle_try_from_js_value_trait';
-import { generateAzleIntoJsValueTrait } from './azle_into_js_value_trait';
 import { modifyRustCandidTypes } from './modified_rust_candid_types';
-import {
-    CallFunctionInfo,
-    JavaScript,
-    Rust
-} from '../../../types';
-import { generateCallFunctions } from './call_functions';
-import * as tsc from 'typescript';
-import { generateCanisterMethodHeartbeat } from './canister_methods/heartbeat';
-import { generateHandleGeneratorResultFunction } from './canister_methods/developer_defined/return_value_handler';
-import { generateCanisterMethodPreUpgrade } from './canister_methods/pre_upgrade';
-import { generateCanisterMethodPostUpgrade } from './canister_methods/post_upgrade';
 import { bundle_and_transpile_ts } from '../../typescript_to_javascript';
+import { CallFunctionInfo, JavaScript, Rust } from '../../../types';
+import * as tsc from 'typescript';
 
 export async function generateLibFile(
     js: JavaScript,
@@ -41,14 +33,8 @@ export async function generateLibFile(
         principal_js
     );
 
-    const canisterMethodInit: Rust = generateCanisterMethodInit(
-        js,
-        sourceFiles
-    );
-    const canisterMethodInspectMessage: Rust = generateCanisterMethodInspectMessage(sourceFiles);
-    const canisterMethodPreUpgrade: Rust = generateCanisterMethodPreUpgrade(sourceFiles);
-    const canisterMethodPostUpgrade: Rust = generateCanisterMethodPostUpgrade(sourceFiles);
-    const canisterMethodHeartbeat: Rust = generateCanisterMethodHeartbeat(sourceFiles);
+    const systemCanisterMethods: Rust =
+        generateSystemCanisterMethods(sourceFiles);
 
     const callFunctionInfos: CallFunctionInfo[] = generateCallFunctions(sourceFiles);
 
@@ -73,11 +59,8 @@ export async function generateLibFile(
         ${azleIntoJsValueTrait}
         ${azleTryFromJsValueTrait}
 
-        ${canisterMethodInit}
-        ${canisterMethodInspectMessage}
-        ${canisterMethodPreUpgrade}
-        ${canisterMethodPostUpgrade}
-        ${canisterMethodHeartbeat}
+        ${systemCanisterMethods}
+
         ${canisterMethodsDeveloperDefined}
 
         ${handleGeneratorResultFunction}


### PR DESCRIPTION
System canister methods and IC Object functions were two clear groups and each were growing rather large. So, this pulls them out into separate files, making the lib file easier to reason about.

Resolves #425 