### PR TITLE
Added bitcoin types to management canister

### DIFF
--- a/canisters/management/bitcoin.ts
+++ b/canisters/management/bitcoin.ts
@@ -1,0 +1,71 @@
+import { blob, nat32, nat64, Opt, Variant } from '../../index';
+
+export type BitcoinAddress = string;
+export type BlockHash = blob;
+
+export type GetBalanceArgs = {
+    address: BitcoinAddress;
+    min_confirmations: Opt<nat32>;
+    network: BitcoinNetwork;
+};
+
+export type GetCurrentFeePercentilesArgs = {
+    network: BitcoinNetwork;
+};
+
+export type GetUtxosArgs = {
+    address: BitcoinAddress;
+    filter: Opt<UtxosFilter>;
+    network: BitcoinNetwork;
+};
+
+export type GetUtxosResult = {
+    next_page: Opt<Page>;
+    tip_block_hash: BlockHash;
+    tip_height: nat32;
+    utxos: Utxo[];
+};
+
+export type MillisatoshiPerByte = nat64;
+
+export const BitcoinNetwork = {
+    Mainnet: { Mainnet: null },
+    Regtest: { Regtest: null },
+    Testnet: { Testnet: null }
+};
+
+export type BitcoinNetwork = Variant<{
+    Mainnet: null;
+    Regtest: null;
+    Testnet: null;
+}>;
+
+export type Outpoint = {
+    txid: blob;
+    vout: nat32;
+};
+
+export type Page = blob;
+
+export type Utxo = {
+    height: nat32;
+    outpoint: Outpoint;
+    value: Satoshi;
+};
+
+export type UtxosFilter = Variant<{
+    MinConfirmations: nat32;
+    Page: Page;
+}>;
+
+export type Satoshi = nat64;
+
+export type SendTransactionArgs = {
+    transaction: blob;
+    network: BitcoinNetwork;
+};
+
+export type SendTransactionError = Variant<{
+    MalformedTransaction: null;
+    QueueFull: null;
+}>;

--- a/canisters/management/index.ts
+++ b/canisters/management/index.ts
@@ -26,7 +26,35 @@ import {
     Opt,
     Principal,
     Variant
-} from '../index';
+} from '../../index';
+
+import {
+    GetBalanceArgs,
+    GetCurrentFeePercentilesArgs,
+    GetUtxosArgs,
+    GetUtxosResult,
+    MillisatoshiPerByte,
+    Satoshi,
+    SendTransactionArgs
+} from './bitcoin';
+
+export {
+    BitcoinAddress,
+    BitcoinNetwork,
+    BlockHash,
+    GetBalanceArgs,
+    GetCurrentFeePercentilesArgs,
+    GetUtxosArgs,
+    GetUtxosResult,
+    MillisatoshiPerByte,
+    Outpoint,
+    Page,
+    Satoshi,
+    SendTransactionArgs,
+    SendTransactionError,
+    Utxo,
+    UtxosFilter
+} from './bitcoin';
 
 export type CanisterId = Principal;
 export type UserId = Principal;
@@ -151,6 +179,12 @@ export type HttpResponse = {
 };
 
 export type Management = Canister<{
+    bitcoin_get_balance(args: GetBalanceArgs): CanisterResult<Satoshi>;
+    bitcoin_get_current_fee_percentiles(
+        args: GetCurrentFeePercentilesArgs
+    ): CanisterResult<MillisatoshiPerByte[]>;
+    bitcoin_get_utxos(args: GetUtxosArgs): CanisterResult<GetUtxosResult>;
+    bitcoin_send_transaction(args: SendTransactionArgs): CanisterResult<null>;
     create_canister(
         args: CreateCanisterArgs
     ): CanisterResult<CreateCanisterResult>;


### PR DESCRIPTION
This adds types to the management canister. These types have been tested locally but because testing isn't straightforward, I'm proposing that we merge these in for right now and then add solid tests afterwards.

Some things complicating the testing include:
- `bitcoind` and `bitcoin-cli` must be installed locally
- `bitcoind` must be running at the time the dfx replica is started
- `bitcoin-cli` must be used to get the blockchain into a specific state before the tests are run

For these reasons I'm proposing we merge just these types in for now.

I've tested all of these APIs and verified that they in addition to not erring out, they also return data correctly.

Partial implementation of #565