### PR TITLE
Added `Func` type aliases in new compiler

### DIFF
--- a/src/compiler/typescript_to_rust_redesign/azle_generate/src/ast_utilities.rs
+++ b/src/compiler/typescript_to_rust_redesign/azle_generate/src/ast_utilities.rs
@@ -1,0 +1,49 @@
+use swc_ecma_ast::{Module, Program, Stmt, TsTypeAliasDecl};
+
+// TODO: This may grab unintended Func declarations. Instead traverse starting
+// from the exported canister methods.
+pub fn get_ast_func_type_alias_decls_from_programs(
+    programs: &Vec<Program>,
+) -> Vec<TsTypeAliasDecl> {
+    programs.iter().fold(vec![], |acc, program| {
+        let ast_func_type_alias_decls = get_ast_func_type_alias_decls_from_program(program);
+
+        vec![acc, ast_func_type_alias_decls].concat()
+    })
+}
+
+pub fn get_ast_func_type_alias_decls_from_program(program: &Program) -> Vec<TsTypeAliasDecl> {
+    match program {
+        Program::Module(module) => get_ast_func_type_alias_decls(module),
+        Program::Script(_) => vec![],
+    }
+}
+
+fn get_ast_func_type_alias_decls(module: &Module) -> Vec<TsTypeAliasDecl> {
+    let module_statements: Vec<Stmt> = module
+        .body
+        .iter()
+        .filter(|module_item| module_item.is_stmt())
+        .map(|module_item| module_item.as_stmt().unwrap().clone())
+        .collect();
+
+    let func_type_alias_decl: Vec<TsTypeAliasDecl> = module_statements
+        .iter()
+        .filter(|module_stmt| module_stmt.is_decl())
+        .map(|module_stmt| module_stmt.as_decl().unwrap().clone())
+        .filter(|decl| decl.is_ts_type_alias())
+        .map(|decl| decl.as_ts_type_alias().unwrap().clone())
+        .filter(|ts_type_alias_decl| {
+            ts_type_alias_decl.type_ann.is_ts_type_ref()
+                && match ts_type_alias_decl.type_ann.as_ts_type_ref() {
+                    Some(ts_type_ref) => match ts_type_ref.type_name.as_ident() {
+                        Some(ident) => ident.sym.chars().as_str() == "Func",
+                        None => false,
+                    },
+                    None => false,
+                }
+        })
+        .collect();
+
+    func_type_alias_decl
+}

--- a/src/compiler/typescript_to_rust_redesign/azle_generate/src/generators/canister_methods/types.rs
+++ b/src/compiler/typescript_to_rust_redesign/azle_generate/src/generators/canister_methods/types.rs
@@ -161,10 +161,11 @@ fn parse_ts_type_ref(ts_type_ref: &TsTypeRef) -> TypeRefInfo {
             ..Default::default()
         },
         "Opt" => parse_opt_type_ref(ts_type_ref),
-        "Func" => TypeRefInfo {
-            identifier: quote!(candid::Func),
-            ..Default::default()
-        },
+        // TODO: We may want to inline the func implementation here.
+        // "Func" => TypeRefInfo {
+        //     identifier: quote!(candid::Func),
+        //     ..Default::default()
+        // },
         "Variant" => parse_variant_type_ref(ts_type_ref),
         _ => {
             let custom_type_ref_ident = format_ident!("{}", type_name);

--- a/src/compiler/typescript_to_rust_redesign/azle_generate/src/generators/funcs.rs
+++ b/src/compiler/typescript_to_rust_redesign/azle_generate/src/generators/funcs.rs
@@ -1,0 +1,264 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use swc_ecma_ast::TsEntityName::{Ident, TsQualifiedName};
+use swc_ecma_ast::TsFnOrConstructorType;
+use swc_ecma_ast::TsType;
+use swc_ecma_ast::TsType::TsTypeRef;
+use swc_ecma_ast::TsTypeAliasDecl;
+
+use crate::generators::canister_methods;
+
+pub fn generate_func_structs_and_impls(type_aliases: Vec<TsTypeAliasDecl>) -> Vec<TokenStream> {
+    let arg_token_struct_and_impl = quote! {
+        // TODO I think it's debatable whether or not we even need ArgToken
+        /// A marker type to match unconstrained callback arguments
+        #[derive(Debug, Clone, Copy, PartialEq, candid::Deserialize)]
+        pub struct ArgToken;
+
+        impl candid::CandidType for ArgToken {
+            fn _ty() -> candid::types::Type {
+                candid::types::Type::Empty
+            }
+
+            fn idl_serialize<S: candid::types::Serializer>(&self, _serializer: S) -> Result<(), S::Error> {
+                // We cannot implement serialize, since our type must be \`Empty\` in order to accept anything.
+                // Attempting to serialize this type is always an error and should be regarded as a compile time error.
+                unimplemented!("Token is not serializable")
+            }
+        }
+    };
+
+    let func_structs_and_impls: Vec<TokenStream> = type_aliases
+        .iter()
+        .map(|type_alias| generate_func_struct_and_impls(type_alias))
+        .collect();
+
+    vec![vec![arg_token_struct_and_impl], func_structs_and_impls].concat()
+}
+
+fn generate_func_struct_and_impls(type_alias: &TsTypeAliasDecl) -> TokenStream {
+    let type_alias_name = get_type_alias_name(&type_alias);
+
+    let func_type = get_func_type(&type_alias);
+    let func_mode = get_func_mode(&func_type);
+    let func_param_types = get_param_types(&func_type);
+    let func_return_type = get_return_type(&func_type);
+
+    quote! {
+        #[derive(Debug, Clone)]
+        struct #type_alias_name<ArgToken = self::ArgToken>(
+            pub candid::Func,
+            pub std::marker::PhantomData<ArgToken>,
+        );
+
+        impl AzleIntoJsValue for #type_alias_name {
+            fn azle_into_js_value(self, context: &mut boa_engine::Context) -> boa_engine::JsValue {
+                self.0.azle_into_js_value(context)
+            }
+        }
+
+        impl AzleIntoJsValue for Vec<#type_alias_name> {
+            fn azle_into_js_value(self, context: &mut boa_engine::Context) -> boa_engine::JsValue {
+                azle_into_js_value_generic_array(self, context)
+            }
+        }
+
+        impl AzleTryFromJsValue<#type_alias_name> for boa_engine::JsValue {
+            fn azle_try_from_js_value(self, context: &mut boa_engine::Context) -> Result<#type_alias_name, AzleTryFromJsValueError> {
+                let candid_func: candid::Func = self.azle_try_from_js_value(context).unwrap();
+                Ok(candid_func.into())
+            }
+        }
+
+        impl AzleTryFromJsValue<Vec<#type_alias_name>> for boa_engine::JsValue {
+            fn azle_try_from_js_value(self, context: &mut boa_engine::Context) -> Result<Vec<#type_alias_name>, AzleTryFromJsValueError> {
+                azle_try_from_js_value_generic_array(self, context)
+            }
+        }
+
+        impl candid::CandidType for #type_alias_name {
+            fn _ty() -> candid::types::Type {
+                candid::types::Type::Func(candid::types::Function {
+                    modes: vec![#func_mode],
+                    args: vec![#(#func_param_types),*],
+                    rets: vec![#func_return_type]
+                })
+            }
+
+            fn idl_serialize<S: candid::types::Serializer>(&self, serializer: S) -> Result<(), S::Error> {
+                self.0.idl_serialize(serializer)
+            }
+        }
+
+        impl<'de> candid::Deserialize<'de> for #type_alias_name {
+            fn deserialize<D: serde::de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                candid::Func::deserialize(deserializer).map(Self::from)
+            }
+        }
+
+        impl From<candid::Func> for #type_alias_name {
+            fn from(f: candid::Func) -> Self {
+                Self(f, std::marker::PhantomData)
+            }
+        }
+
+        impl From<#type_alias_name> for candid::Func {
+            fn from(c: #type_alias_name) -> Self {
+                c.0
+            }
+        }
+
+        impl std::ops::Deref for #type_alias_name {
+            type Target = candid::Func;
+            fn deref(&self) -> &candid::Func {
+                &self.0
+            }
+        }
+
+        impl std::ops::DerefMut for #type_alias_name {
+            fn deref_mut(&mut self) -> &mut candid::Func {
+                &mut self.0
+            }
+        }
+    }
+}
+
+fn get_type_alias_name(type_alias: &TsTypeAliasDecl) -> TokenStream {
+    type_alias
+        .id
+        .sym
+        .chars()
+        .as_str()
+        .parse::<TokenStream>()
+        .unwrap()
+}
+
+fn get_func_type(type_alias: &TsTypeAliasDecl) -> &swc_ecma_ast::TsFnType {
+    let type_alias_name = get_type_alias_name(type_alias);
+    match &*type_alias.type_ann {
+        TsTypeRef(type_ref) => match &type_ref.type_params {
+            Some(type_params) => {
+                if type_params.params.len() != 1 {
+                    panic!(
+                        "type {} must only specify a single type param for Func type reference",
+                        type_alias_name
+                    )
+                }
+
+                match &*type_params.params[0] {
+                    TsType::TsFnOrConstructorType(fn_or_constructor_type) => {
+                        match fn_or_constructor_type {
+                            TsFnOrConstructorType::TsFnType(fn_type) => fn_type,
+                            TsFnOrConstructorType::TsConstructorType(_) => panic!(
+                                "type {} must pass a function type as a type parameter to it's Func type reference",
+                                type_alias_name
+                            )
+                        }
+                    },
+                    _ => panic!(
+                        "type {} must pass a function type as a type parameter to it's Func type reference",
+                        type_alias_name
+                    )
+                }
+            }
+            None => panic!(
+                "type {} must include a function signature as a type parameter to Func",
+                type_alias_name
+            ),
+        },
+        _ => panic!("Func types must be declared using Azle's Func type with a type parameter"),
+    }
+}
+
+fn get_func_mode(function_type: &swc_ecma_ast::TsFnType) -> TokenStream {
+    match &*function_type.type_ann.type_ann {
+        TsTypeRef(type_reference) => match &type_reference.type_name {
+            TsQualifiedName(_) => panic!("Unsupported qualified name. Func return type must directly be Query, Update, or Oneway"),
+            Ident(identifier) => {
+                let mode = identifier.sym.chars().as_str();
+                if mode != "Query" && mode != "Update" && mode != "Oneway" {
+                    panic!("Func return type must be Query, Update, or Oneway")
+                }
+
+                if mode == "Query" {
+                    quote! {candid::parser::types::FuncMode::Query }
+                } else if mode == "Oneway" {
+                    quote! {candid::parser::types::FuncMode::Oneway }
+                } else {
+                    quote! {}
+                }
+            }
+        },
+        _ => panic!("Func return type must be Query, Update, or Oneway"),
+    }
+}
+
+fn get_param_types(function_type: &swc_ecma_ast::TsFnType) -> Vec<TokenStream> {
+    function_type
+        .params
+        .iter()
+        .map(|param| match param {
+            swc_ecma_ast::TsFnParam::Ident(identifier) => match &identifier.type_ann {
+                Some(param_type) => {
+                    let rust_type =
+                        canister_methods::ts_type_to_rust_type(&*param_type.type_ann, None)
+                            .get_type_ident()
+                            .to_string();
+
+                    let modified_rust_type = if rust_type.starts_with("Vec") {
+                        format!("Vec::<{}", rust_type.replacen("Vec<", "", 1))
+                    } else {
+                        rust_type
+                    };
+
+                    let modified_rust_type_token_stream: TokenStream =
+                        modified_rust_type.parse().unwrap();
+
+                    quote! {#modified_rust_type_token_stream::_ty()}
+                }
+                None => panic!("Function parameter must have a return type"),
+            },
+            _ => panic!("Func parameter must be an identifier"),
+        })
+        .collect()
+}
+
+fn get_return_type(function_type: &swc_ecma_ast::TsFnType) -> TokenStream {
+    match &*function_type.type_ann.type_ann {
+        TsTypeRef(type_reference) => match &type_reference.type_name {
+            TsQualifiedName(_) => panic!("Unsupported qualified name. Func return type must directly be Query, Update, or Oneway"),
+            Ident(identifier) => {
+                let mode = identifier.sym.chars().as_str();
+                if mode != "Query" && mode != "Update" && mode != "Oneway" {
+                    panic!("Func return type must be Query, Update, or Oneway")
+                }
+
+                if mode == "Oneway" {
+                    quote! {}
+                } else {
+                    match &type_reference.type_params {
+                        Some(type_param_inst) => {
+                            if type_param_inst.params.len() != 1 {
+                                panic!("Func must specify exactly one return type")
+                            }
+                            match type_param_inst.params.get(0) {
+                                Some(param) => {
+                                    let return_type = canister_methods::ts_type_to_rust_type(&**param, None).get_type_ident().to_string();
+                                    if return_type == "()" {
+                                        quote! {}
+                                    } else {
+                                        let return_type_token_stream: TokenStream = return_type.parse().unwrap();
+                                        quote! { #return_type_token_stream::_ty()}
+                                    }
+                                },
+                                None => panic!("Func must specify exactly one return type"),
+                            }
+                        },
+                        None => panic!("Func must specify a return type"),
+                    }
+                }
+            }
+        },
+        _ => panic!("Func return type must be Query, Update, or Oneway"),
+    }
+}

--- a/src/compiler/typescript_to_rust_redesign/azle_generate/src/lib.rs
+++ b/src/compiler/typescript_to_rust_redesign/azle_generate/src/lib.rs
@@ -48,6 +48,8 @@ use generators::{
 use crate::generators::canister_methods::generate_record_token_streams;
 use crate::generators::ic_object::functions::generate_ic_object_functions;
 
+mod ast_utilities;
+
 fn collect_function_type_dependencies(function_info: &Vec<FunctionInformation>) -> HashSet<String> {
     let dependencies = function_info.iter().fold(vec![], |acc, fun_info| {
         vec![acc, fun_info.type_alias_dependant_types.clone()].concat()


### PR DESCRIPTION
This gets basic `Func` type aliases working. This works with basic funcs (funcs without records/variants) whether as canister method params or return types. They also have been tested and work as arrays.

Known Issues: Records as parameters to funcs are not currently supported. There is an issue where we don't create structs for these unless they are references in a parameter. We will need to work on that separately.

Closes #657 