### PR TITLE
Added `reply_raw` support to new compiler

### DIFF
--- a/examples/manual_reply/src/manual_reply.did
+++ b/examples/manual_reply/src/manual_reply.did
@@ -1,52 +1,36 @@
-type Element = record {
-    "id": text;
-    "orbitals": vec Orbital;
-    "state": State;
+type Gas = variant { Elemental; Mixed; Toxic };
+type ManualReply = record { id : text; orbitals : vec Orbital; state : State };
+type ManualReply_1 = record {
+  "int" : int;
+  "blob" : vec nat8;
+  "bool" : bool;
+  "text" : text;
+  "variant" : Options;
 };
-
-type RawReply = record {
-    "int": int;
-    "text": text;
-    "bool": bool;
-    "blob": blob;
-    "variant": Options;
-};
-
-type Orbital = record {
-    "layer": nat8;
-    "electrons": nat8;
-};
-
-type Solid = record {
-    "element": text;
-};
-
-type Gas = variant { "Elemental": null; "Mixed": null; "Toxic": null };
-
-type State = variant { "Gas": Gas; "Liquid": null; "Solid": Solid };
-
-type Options = variant { "Small": null; "Medium": null; "Large": null };
-
-service: {
-    "manual_query": (text) -> (text) query;
-    "query_blob": () -> (blob) query;
-    "query_float32": () -> (float32) query;
-    "query_int8": () -> (int8) query;
-    "query_nat": () -> (nat) query;
-    "query_null": () -> (null) query;
-    "query_record": () -> (Element) query;
-    "query_reserved": () -> (reserved) query;
-    "query_string": () -> (text) query;
-    "query_variant": () -> (Gas) query;
-    "manual_update": (text) -> (text);
-    "update_blob": () -> (blob);
-    "update_float32": () -> (float32);
-    "update_int8": () -> (int8);
-    "update_nat": () -> (nat);
-    "update_null": () -> (null);
-    "update_record": () -> (Element);
-    "update_reserved": () -> (reserved);
-    "update_string": () -> (text);
-    "update_variant": () -> (Gas);
-    "reply_raw": () -> (RawReply);
+type Options = variant { Large; Small; Medium };
+type Orbital = record { electrons : nat8; layer : nat8 };
+type Solid = record { element : text };
+type State = variant { Gas : Gas; Solid : Solid; Liquid };
+service : () -> {
+  manual_query : (text) -> (text) query;
+  manual_update : (text) -> (text);
+  query_blob : () -> (vec nat8) query;
+  query_float32 : () -> (float32) query;
+  query_int8 : () -> (int8) query;
+  query_nat : () -> (nat) query;
+  query_null : () -> (null) query;
+  query_record : () -> (ManualReply) query;
+  query_reserved : () -> (reserved) query;
+  query_string : () -> (text) query;
+  query_variant : () -> (Gas) query;
+  reply_raw : () -> (ManualReply_1);
+  update_blob : () -> (vec nat8);
+  update_float32 : () -> (float32);
+  update_int8 : () -> (int8);
+  update_nat : () -> (nat);
+  update_null : () -> (null);
+  update_record : () -> (ManualReply);
+  update_reserved : () -> (reserved);
+  update_string : () -> (text);
+  update_variant : () -> (Gas);
 }

--- a/src/compiler/typescript_to_rust_redesign/azle_generate/src/generators/ic_object/functions/mod.rs
+++ b/src/compiler/typescript_to_rust_redesign/azle_generate/src/generators/ic_object/functions/mod.rs
@@ -16,6 +16,7 @@ mod performance_counter;
 mod print;
 mod reject;
 mod reply;
+mod reply_raw;
 mod set_certified_data;
 mod stable64_grow;
 mod stable64_read;
@@ -48,6 +49,7 @@ pub fn generate_ic_object_functions(fn_decls: &Vec<FnDecl>) -> proc_macro2::Toke
     let print = print::generate_ic_object_function_print();
     let reject = reject::generate_ic_object_function_reject();
     let reply = reply::generate_ic_object_function_reply(fn_decls);
+    let reply_raw = reply_raw::generate_ic_object_function_reply_raw();
     let set_certified_data = set_certified_data::generate_ic_object_function_set_certified_data();
     let stable64_grow = stable64_grow::generate_ic_object_function_stable64_grow();
     let stable64_read = stable64_read::generate_ic_object_function_stable64_read();
@@ -78,6 +80,7 @@ pub fn generate_ic_object_functions(fn_decls: &Vec<FnDecl>) -> proc_macro2::Toke
         #print
         #reject
         #reply
+        #reply_raw
         #set_certified_data
         #stable64_grow
         #stable64_read

--- a/src/compiler/typescript_to_rust_redesign/azle_generate/src/generators/ic_object/functions/reply_raw.rs
+++ b/src/compiler/typescript_to_rust_redesign/azle_generate/src/generators/ic_object/functions/reply_raw.rs
@@ -1,0 +1,16 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub fn generate_ic_object_function_reply_raw() -> TokenStream {
+    quote! {
+        fn _azle_ic_reply_raw(
+            _this: &boa_engine::JsValue,
+            _aargs: &[boa_engine::JsValue],
+            _context: &mut boa_engine::Context,
+        ) -> boa_engine::JsResult<boa_engine::JsValue> {
+            let buf_js_value: boa_engine::JsValue = _aargs.get(0).unwrap().clone();
+            let buf_vec: Vec<u8> = buf_js_value.azle_try_from_js_value(_context).unwrap();
+            Ok(ic_cdk::api::call::reply_raw(&buf_vec).azle_into_js_value(_context))
+        }
+    }
+}

--- a/src/compiler/typescript_to_rust_redesign/azle_generate/src/generators/ic_object/mod.rs
+++ b/src/compiler/typescript_to_rust_redesign/azle_generate/src/generators/ic_object/mod.rs
@@ -84,6 +84,11 @@ pub fn generate_ic_object() -> proc_macro2::TokenStream {
                 0
             )
             .function(
+                _azle_ic_reply_raw,
+                "reply_raw",
+                0
+            )
+            .function(
                 _azle_ic_set_certified_data,
                 "set_certified_data",
                 0


### PR DESCRIPTION
This is the last piece for the `manual_reply` example to fully work.

Note: some of the generated candid types aren't correct. We should look into that.

Closes #665 