### PR TITLE
Improve compilation error messages

### DIFF
--- a/src/compiler/typescript_to_rust/azle_generate/src/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/errors.rs
@@ -1,0 +1,15 @@
+pub struct ErrorWithExampleDiff<'a> {
+    pub error: &'a str,
+    pub help: &'a str,
+    pub remove: &'a str,
+    pub add: &'a str,
+}
+
+impl<'a> ErrorWithExampleDiff<'a> {
+    pub fn to_string(&'a self) -> String {
+        format!(
+            "{}\n\nHelp: {}\n\nExample:\n-|    {}\n+|    {}",
+            self.error, self.help, self.remove, self.add
+        )
+    }
+}

--- a/src/compiler/typescript_to_rust/azle_generate/src/generators/canister_methods/method_body.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/generators/canister_methods/method_body.rs
@@ -38,7 +38,7 @@ pub fn maybe_generate_call_to_js_function(
 }
 
 pub fn generate_call_to_js_function(fn_decl: &FnDecl) -> proc_macro2::TokenStream {
-    let function_name = fn_decl.get_fn_decl_function_name();
+    let function_name = fn_decl.get_function_name();
     let param_name_idents = fn_decl.get_param_name_idents();
 
     quote! {
@@ -75,7 +75,7 @@ fn generate_return_expression(fn_decl: &FnDecl) -> proc_macro2::TokenStream {
         };
     }
 
-    let return_type = fn_decl.get_canister_method_return_type();
+    let return_type = fn_decl.get_return_ts_type();
 
     if type_is_null_or_void(return_type) {
         return quote! {
@@ -89,16 +89,13 @@ fn generate_return_expression(fn_decl: &FnDecl) -> proc_macro2::TokenStream {
 }
 
 /// Returns true if the return type is `null`, or `void`. Otherwise returns false.
-fn type_is_null_or_void(ts_type_option: Option<&TsType>) -> bool {
-    match ts_type_option {
-        Some(ts_type) => match ts_type {
-            TsType::TsKeywordType(keyword) => match keyword.kind {
-                // TODO: Consider handling `TsNeverKeyword` and `TsUndefinedKeyword`
-                TsNullKeyword | TsVoidKeyword => true,
-                _ => false,
-            },
+fn type_is_null_or_void(ts_type: &TsType) -> bool {
+    match ts_type {
+        TsType::TsKeywordType(keyword) => match keyword.kind {
+            // TODO: Consider handling `TsNeverKeyword` and `TsUndefinedKeyword`
+            TsNullKeyword | TsVoidKeyword => true,
             _ => false,
         },
-        None => false,
+        _ => false,
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/lib.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/lib.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 mod cdk_act;
+mod errors;
 mod ts_ast;
 
 pub mod generators;

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/fn_decl/canister_method_builder.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/fn_decl/canister_method_builder.rs
@@ -19,7 +19,7 @@ impl CanisterMethodBuilder for FnDecl {
     ) -> ActCanisterMethod {
         let body = method_body::generate_canister_method_body(&self);
         let is_manual = self.is_manual();
-        let name = self.get_fn_decl_function_name();
+        let name = self.get_function_name();
         let params = self.build_params(source_map);
         let return_type = self.build_return_type(source_map);
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/fn_decl/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/fn_decl/errors.rs
@@ -1,0 +1,103 @@
+use swc_ecma_ast::FnDecl;
+
+use crate::errors::ErrorWithExampleDiff;
+
+pub trait FnDeclErrors {
+    fn build_array_destructure_error_msg(&self) -> String;
+    fn build_invalid_param_error_msg(&self) -> String;
+    fn build_missing_return_annotation_error_msg(&self) -> String;
+    fn build_missing_return_type_error_msg(&self, canister_method_type: &str) -> String;
+    fn build_non_type_ref_return_type_error_msg(&self) -> String;
+    fn build_object_destructure_error_msg(&self) -> String;
+    fn build_param_default_value_error_msg(&self) -> String;
+    fn build_qualified_type_error_msg(&self) -> String;
+    fn build_rest_param_error_msg(&self) -> String;
+    fn build_untyped_param_error_msg(&self) -> String;
+}
+
+impl FnDeclErrors for FnDecl {
+    fn build_array_destructure_error_msg(&self) -> String {
+        let error_message = ErrorWithExampleDiff {
+            error: "Array destructuring in parameters is unsupported at this time",
+            help: "Remove destructuring in favor of a concrete name",
+            remove: "function example([i1, i2]: List) {}",
+            add: "function example(list: List) {}",
+        };
+        error_message.to_string()
+    }
+
+    fn build_invalid_param_error_msg(&self) -> String {
+        "Something is impossibly wrong with your parameters. Please open an issue showing your canister methods and this error.".to_string()
+    }
+
+    fn build_missing_return_annotation_error_msg(&self) -> String {
+        "Canister methods must specify a return type".to_string()
+    }
+
+    fn build_missing_return_type_error_msg(&self, canister_method_type: &str) -> String {
+        let error_message = ErrorWithExampleDiff {
+            error: "Missing return type",
+            help: &format!("Specify a return type inside of {}", canister_method_type),
+            remove: &format!("export function example(): {} {{}}", canister_method_type),
+            add: &format!(
+                "export function example(): {}<null> {{}}",
+                canister_method_type
+            ),
+        };
+        error_message.to_string()
+    }
+
+    fn build_non_type_ref_return_type_error_msg(&self) -> String {
+        "Canister method return types must be one of: Init, InspectMessage, Oneway, PostUpgrade, PreUpgrade, Query, QueryManual, Update, UpdateManual".to_string()
+    }
+
+    fn build_object_destructure_error_msg(&self) -> String {
+        let error_message = ErrorWithExampleDiff {
+            error: "Object destructuring in parameters is unsupported at this time",
+            help: "Remove destructuring in favor of a concrete name",
+            remove: "function example({id, name}: User) {}",
+            add: "function example(user: User) {}",
+        };
+        error_message.to_string()
+    }
+
+    fn build_param_default_value_error_msg(&self) -> String {
+        let error_message = ErrorWithExampleDiff {
+            error: "Setting default values for parameters is unsupported at this time",
+            help: "Remove the default value or set it in the function body",
+            remove: "function example(param: string = 'default') {}",
+            add: "function example(param: string) {}",
+        };
+        error_message.to_string()
+    }
+
+    fn build_qualified_type_error_msg(&self) -> String {
+        let error_message = ErrorWithExampleDiff {
+            error: "Namespace-qualified types are not currently supported",
+            help: "Either declare the import locally or remove the wildcard import",
+            remove: "export function example(): Query<Namespace.MyType> {}",
+            add: "export function example(): Query<MyType> {}",
+        };
+        error_message.to_string()
+    }
+
+    fn build_rest_param_error_msg(&self) -> String {
+        let error_message = ErrorWithExampleDiff {
+            error: "Rest parameters are not supported",
+            help: "Specify each param individually with a concrete type",
+            remove: "function example(...options: any[]) {}",
+            add: "function example(options: Options) {}",
+        };
+        error_message.to_string()
+    }
+
+    fn build_untyped_param_error_msg(&self) -> String {
+        let error_message = ErrorWithExampleDiff {
+            error: "Untyped parameter",
+            help: "Specify a type for the parameter",
+            remove: "function example(param) {}",
+            add: "function example(param: MyParam) {}",
+        };
+        error_message.to_string()
+    }
+}

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/program/azle_program.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/program/azle_program.rs
@@ -58,7 +58,7 @@ impl AzleProgramVecHelperMethods for Vec<AzleProgram> {
 
         fn_decls
             .into_iter()
-            .filter(|fn_decl| fn_decl.is_canister_method_type_fn_decl(canister_method_type))
+            .filter(|fn_decl| fn_decl.is_canister_method_type(canister_method_type))
             .collect()
     }
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/program/system_canister_method_builder/inspect_message.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/program/system_canister_method_builder/inspect_message.rs
@@ -20,7 +20,7 @@ pub fn build_canister_method_system_inspect_message(
     let inspect_message_fn_decl_option = inspect_message_fn_decls.get(0);
 
     if let Some(inspect_message_fn_decl) = inspect_message_fn_decl_option {
-        let name = inspect_message_fn_decl.get_fn_decl_function_name();
+        let name = inspect_message_fn_decl.get_function_name();
 
         let call_to_inspect_message_js_function =
             method_body::generate_call_to_js_function(inspect_message_fn_decl);

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/ts_ast.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/ts_ast.rs
@@ -44,15 +44,19 @@ impl TsAst {
 
                 let mut parser = Parser::new_from(lexer);
 
-                let program = parser.parse_program().unwrap();
-
-                if let Ok(source_map) = std::rc::Rc::try_unwrap(cm) {
-                    return AzleProgram {
-                        program,
-                        source_map,
-                    };
-                };
-                panic!("this cannot happen");
+                let parse_result = parser.parse_program();
+                match parse_result {
+                    Ok(program) => {
+                        if let Ok(source_map) = std::rc::Rc::try_unwrap(cm) {
+                            return AzleProgram {
+                                program,
+                                source_map,
+                            };
+                        };
+                        panic!("this cannot happen");
+                    }
+                    Err(error) => panic!("{}: Syntax Error: {}", ts_file_name, error.kind().msg()),
+                }
             })
             .collect();
         Self { azle_programs }

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_enum.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_enum.rs
@@ -2,6 +2,20 @@ use proc_macro2::Ident;
 use quote::{format_ident, quote};
 use syn::{DataEnum, Field, Fields};
 
+trait TryGetEnumVariantFieldIdent {
+    fn try_get_ident(&self, enum_name: &Ident, variant_name: &Ident) -> &Ident;
+}
+
+impl TryGetEnumVariantFieldIdent for Field {
+    fn try_get_ident(&self, enum_name: &Ident, variant_name: &Ident) -> &Ident {
+        let field_must_be_named = format!(
+            "All fields of variant {} in enum {} must be named. Note: If you hit this case something went very wrong.",
+            variant_name, enum_name
+        );
+        self.ident.as_ref().expect(&field_must_be_named)
+    }
+}
+
 pub fn derive_try_from_vm_value_enum(
     enum_name: &Ident,
     data_enum: &DataEnum,
@@ -119,7 +133,7 @@ fn derive_property_for_named_fields(
     object_variant_js_value_var_name: &Ident,
 ) -> proc_macro2::TokenStream {
     let named_field_js_value_result_variable_names = named_fields.iter().map(|named_field| {
-        let field_name = &named_field.ident.as_ref().unwrap();
+        let field_name = named_field.try_get_ident(enum_name, variant_name);
         let variable_name = format_ident!("{}_js_value_result", field_name);
 
         quote! {
@@ -128,7 +142,7 @@ fn derive_property_for_named_fields(
     });
 
     let named_field_js_value_result_variable_declarations = named_fields.iter().map(|named_field| {
-        let field_name = &named_field.ident.as_ref().unwrap();
+        let field_name = named_field.try_get_ident(enum_name, variant_name);
         let variable_name = format_ident!("{}_js_value_result", field_name);
 
         quote! {
@@ -137,7 +151,7 @@ fn derive_property_for_named_fields(
     });
 
     let named_field_js_value_oks = named_fields.iter().map(|named_field| {
-        let field_name = &named_field.ident.as_ref().unwrap();
+        let field_name = named_field.try_get_ident(enum_name, variant_name);
         let variable_name = format_ident!("{}_js_value", field_name);
 
         quote! {
@@ -146,7 +160,7 @@ fn derive_property_for_named_fields(
     });
 
     let named_field_variable_declarations = named_fields.iter().map(|named_field| {
-        let field_name = &named_field.ident.as_ref().unwrap();
+        let field_name = named_field.try_get_ident(enum_name, variant_name);
         let variable_name = format_ident!("{}_result", field_name);
 
         let named_field_js_value_variable_name = format_ident!("{}_js_value", field_name);
@@ -157,7 +171,7 @@ fn derive_property_for_named_fields(
     });
 
     let named_field_variable_oks = named_fields.iter().map(|named_field| {
-        let field_name = &named_field.ident.as_ref().unwrap();
+        let field_name = named_field.try_get_ident(enum_name, variant_name);
         let variable_name = format_ident!("{}_result", field_name);
 
         quote! {
@@ -166,7 +180,7 @@ fn derive_property_for_named_fields(
     });
 
     let named_field_variable_names = named_fields.iter().map(|named_field| {
-        let field_name = &named_field.ident.as_ref().unwrap();
+        let field_name = named_field.try_get_ident(enum_name, variant_name);
 
         quote! {
             Ok(#field_name)
@@ -174,7 +188,7 @@ fn derive_property_for_named_fields(
     });
 
     let tuple_struct_field_definition = named_fields.iter().map(|named_field| {
-        let field_name = &named_field.ident.as_ref().unwrap();
+        let field_name = named_field.try_get_ident(enum_name, variant_name);
 
         quote! {
             #field_name: #field_name

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_enum.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_enum.rs
@@ -61,8 +61,13 @@ fn derive_variant_branches_named_fields(
     variant_name: &Ident,
     named_fields: Vec<&Field>,
 ) -> proc_macro2::TokenStream {
+    let fields_must_be_named = format!(
+        "All fields of variant {} in enum {} must be named",
+        variant_name, enum_name
+    );
+
     let field_names = named_fields.iter().map(|named_field| {
-        let field_name = &named_field.ident.as_ref().unwrap();
+        let field_name = &named_field.ident.as_ref().expect(&fields_must_be_named);
 
         quote! {
             #field_name
@@ -70,7 +75,7 @@ fn derive_variant_branches_named_fields(
     });
 
     let named_field_variable_declarations = named_fields.iter().map(|named_field| {
-        let field_name = &named_field.ident.as_ref().unwrap();
+        let field_name = &named_field.ident.as_ref().expect(&fields_must_be_named);
         let variable_name = format_ident!("{}_js_value", field_name);
 
         quote! {
@@ -79,7 +84,7 @@ fn derive_variant_branches_named_fields(
     });
 
     let named_field_property_definitions = named_fields.iter().map(|named_field| {
-        let field_name = &named_field.ident.as_ref().unwrap();
+        let field_name = &named_field.ident.as_ref().expect(&fields_must_be_named);
         let variable_name = format_ident!("{}_js_value", field_name);
 
         quote! {


### PR DESCRIPTION
The improved messages appear in the following scenarios:

* Missing return type inside of `Query` or `Update
* spreading rest parameters
* Array destructuring in parameters
* Object destructuring in parameters
* Default value assignment in parameters
* Untyped parameters
* Syntax errors in imported (non entry-point) TS files
* Namespace qualified types (params and returns)

Example:
```ts
export function missing_return_type(): Query {
    throw 'This method is missing a return type inside `Query`';
}
```
```
Building canister compilation_errors

[1/3] 🔨 Compiling TypeScript...

💣 Something about your TypeScript violates Azle's requirements

Missing return type

Help: Specify a return type inside of Query

Example:
-|    export function example(): Query {}
+|    export function example(): Query<null> {}

If you are unable to decipher the error above, reach out in the #typescript
channel of the DFINITY DEV OFFICIAL discord: https://discord.gg/zuUEzSf4mV

💀 Build failed
```

**Note:** This doesn't currently include line numbers.

Resolves #723 