### PR TITLE
Surface spawnSync JS errors

### DIFF
--- a/src/azle.ts
+++ b/src/azle.ts
@@ -390,11 +390,21 @@ function runAzleGenerate(
         }
     );
 
+    const suggestion =
+        'If you are unable to decipher the error above, reach out in the #typescript\nchannel of the DFINITY DEV OFFICIAL discord: https://discord.gg/zuUEzSf4mV';
+
+    if (executionResult.error) {
+        const exitCode = executionResult.error.errno ?? 13;
+        return Err({
+            error: `Azle encountered an error: ${executionResult.error.message}`,
+            suggestion,
+            exitCode
+        });
+    }
+
     if (executionResult.status !== 0) {
         const generalErrorMessage =
             "Something about your TypeScript violates Azle's requirements";
-        const suggestion =
-            'If you are unable to decipher the error above, reach out in the #typescript\nchannel of the DFINITY DEV OFFICIAL discord: https://discord.gg/zuUEzSf4mV';
         const stdErr = executionResult.stderr.toString();
         const longErrorMessage = `The underlying cause is likely at the bottom of the following output:\n\n${stdErr}`;
         if (isVerboseMode()) {


### PR DESCRIPTION
When calling spawnSync it has a chance to "throw" a JS error in addition to successfully executing a command but the command itself having a non- zero exit code. Now both errors will be surfaced to end users.

For example:
```ts
import { Motoko } from 'motoko/versions/latest/moc.min.js';

console.log(Motoko);
```
Now results in:
```
Building canister counter

[1/3] 🔨 Compiling TypeScript...

💣 Azle encountered an error: spawnSync cargo ENOBUFS

If you are unable to decipher the error above, reach out in the #typescript
channel of the DFINITY DEV OFFICIAL discord: https://discord.gg/zuUEzSf4mV

💀 Build failed
```