### PR TITLE
Hooked up Source maps to Fn Decl errors

### DIFF
--- a/examples/compiler_errors/src/index.ts
+++ b/examples/compiler_errors/src/index.ts
@@ -1,6 +1,9 @@
-import { Func, Opt, Query, Variant } from 'azle';
+import { empty, Func, Opt, Query, Update, Variant } from 'azle';
 import { int } from 'azle';
 
+type User = {
+    id: string;
+};
 type VariantNotProperties = Variant<{}>;
 // export function qualified_name(param: azle.query.values.int): Query<void> {}
 
@@ -124,3 +127,51 @@ type VariantNotProperties = Variant<{}>;
 //     get thing_two(): void;
 // };
 // export function recGet(record: RecordWithGet): Query<void> {}
+
+// #region FnDecl Errors
+
+// export function array_destructure(
+//     [firstUser]: User[],
+//     user: User
+// ): Query<empty> {
+//     throw "This function uses array destructuring, which isn't currently supported";
+// }
+
+// export function missing_return_type(): Update {
+//     throw 'This method is missing a return type inside `Query`';
+// }
+
+// export function object_destructure({ name }: User): Query<empty> {
+//     throw "This function uses object destructuring, which isn't currently supported";
+// }
+
+// export function assignment_pattern(
+//     first: User,
+//     thing: String = 'default',
+//     third: User
+// ): Query<empty> {
+//     throw "This function uses an assignment pattern, which isn't currently supported";
+// }
+
+// export function assignment_pattern_with_assignment_on_new_line(
+//     first: User,
+//     thing: String
+//         = 'default',
+//     third: User
+// ): Query<empty> {
+//     throw "This function uses an assignment pattern, which isn't currently supported";
+// }
+
+// export function rest_param(first: User, ...rest: any[]): Query<empty> {
+//     throw "This function uses a rest parameter, which can't be represented in candid";
+// }
+
+// export function using_namespace_qualified_return_type_inside_query(): Query<Azle.empty> {
+//     throw 'This function namespace qualifies the return type inside of Query';
+// }
+
+// export function untyped_param(thing): Query<empty> {
+//     throw "This function's parameter does not have a type specified";
+// }
+
+// #endregion FnDecl Errors

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/errors.rs
@@ -12,7 +12,7 @@ impl AzleFnDecl<'_> {
         let array_pat = param.pat.as_array().expect("Oops! Looks like we introduced a bug while refactoring. Please open a ticket at https://github.com/demergent-labs/azle/issues/new");
 
         let range = param.get_destructure_range(self.source_map);
-        let replacement_name = "myParam"; // TODO: Come up with a better name from the ts_type_ann
+        let replacement_name = "myParam".to_string(); // TODO: Come up with a better name from the ts_type_ann
 
         ErrorMessage {
             title: "Array destructuring in parameters is unsupported at this time".to_string(),
@@ -23,12 +23,12 @@ impl AzleFnDecl<'_> {
             annotation: "Attempted to destructure here".to_string(),
             suggestion: Some(Suggestion {
                 title: "Remove destructuring in favor of a concrete name".to_string(),
-                source: format!(
-                    "{}{}...",
-                    self.source_map.get_well_formed_line(array_pat.span),
-                    replacement_name
-                ), // TODO: Use the new source_map.get_modified_source(replacement_name)
-                range: (range.0, range.0 + replacement_name.len()), // TODO: Use the new source_map.get_modified_range(replacement_name)
+                source: self.source_map.generate_source_with_range_replaced(
+                    array_pat.span,
+                    range,
+                    &replacement_name,
+                ),
+                range: (range.0, range.0 + replacement_name.len()),
                 annotation: None,
                 import_suggestion: None,
             }),
@@ -50,6 +50,7 @@ impl AzleFnDecl<'_> {
     ) -> ErrorMessage {
         let range = self.source_map.get_range(span);
         let example_type_param = "<null>".to_string();
+        let example_return_type = format!("{}{}", canister_method_type, example_type_param);
 
         ErrorMessage {
             title: "Missing return type".to_string(),
@@ -63,12 +64,9 @@ impl AzleFnDecl<'_> {
                     "Specify a return type as a type argument to `{}`. E.g.:",
                     canister_method_type
                 ),
-                source: format!(
-                    "{}{}{} {{}}",
-                    self.source_map.get_well_formed_line(span),
-                    canister_method_type,
-                    example_type_param
-                ), // TODO: Use the new source_map.get_modified_source(replacement_name)
+                source: self
+                    .source_map
+                    .generate_modified_source(span, &example_return_type),
                 range: (range.1, range.1 + example_type_param.len()),
                 annotation: None,
                 import_suggestion: None,
@@ -84,7 +82,7 @@ impl AzleFnDecl<'_> {
         let object_pat = param.pat.as_object().expect("Oops! Looks like we introduced a bug while refactoring. Please open a ticket at https://github.com/demergent-labs/azle/issues/new");
 
         let range = param.get_destructure_range(self.source_map);
-        let replacement_name = "myParam"; // TODO: Come up with a better name from the ts_type_ann
+        let replacement_name = "myParam".to_string(); // TODO: Come up with a better name from the ts_type_ann
 
         ErrorMessage {
             title: "Object destructuring in parameters is unsupported at this time".to_string(),
@@ -95,12 +93,12 @@ impl AzleFnDecl<'_> {
             annotation: "Attempted to destructure here".to_string(),
             suggestion: Some(Suggestion {
                 title: "Remove destructuring in favor of a concrete name".to_string(),
-                source: format!(
-                    "{}{}...",
-                    self.source_map.get_well_formed_line(object_pat.span),
-                    replacement_name
-                ), // TODO: Use the new source_map.get_modified_source(replacement_name)
-                range: (range.0, range.0 + replacement_name.len()), // TODO: Use the new source_map.get_modified_range(replacement_name)
+                source: self.source_map.generate_source_with_range_replaced(
+                    object_pat.span,
+                    range,
+                    &replacement_name,
+                ),
+                range: (range.0, range.0 + replacement_name.len()),
                 annotation: None,
                 import_suggestion: None,
             }),
@@ -165,7 +163,7 @@ impl AzleFnDecl<'_> {
             source: self.source_map.get_source(span),
             range: self.source_map.get_range(span),
             annotation: "Namespace specified here".to_string(),
-            suggestion: None, // This is caught first by src/compiler/typescript_to_rust/azle_generate/src/ts_ast/ast_traits/get_name.rs
+            suggestion: None, // This is caught first by src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_ref/errors.rs
         }
     }
 
@@ -173,7 +171,7 @@ impl AzleFnDecl<'_> {
         let rest_pat = param.pat.as_rest().expect("Oops! Looks like we introduced a bug while refactoring. Please open a ticket at https://github.com/demergent-labs/azle/issues/new");
 
         let range = param.get_destructure_range(self.source_map);
-        let replacement_name = "myParam"; // TODO: Come up with a better name from the ts_type_ann
+        let replacement_name = "myParam".to_string(); // TODO: Come up with a better name from the ts_type_ann
 
         ErrorMessage {
             title: "Rest parameters are not supported in canister method signatures".to_string(),
@@ -184,11 +182,11 @@ impl AzleFnDecl<'_> {
             annotation: "Attempted parameter spread here".to_string(), // TODO
             suggestion: Some(Suggestion {
                 title: "Specify each parameter individually with a concrete type".to_string(),
-                source: format!(
-                    "{}{}...",
-                    self.source_map.get_well_formed_line(rest_pat.span),
-                    replacement_name
-                ), // TODO: Use the new source_map.get_modified_source(replacement_name)
+                source: self.source_map.generate_source_with_range_replaced(
+                    rest_pat.span,
+                    range,
+                    &replacement_name,
+                ),
                 range: (range.0, range.0 + replacement_name.len()), // TODO: Use the new source_map.get_modified_range(replacement_name)
                 annotation: None,
                 import_suggestion: None,

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/errors.rs
@@ -179,7 +179,7 @@ impl AzleFnDecl<'_> {
             line_number: self.source_map.get_line_number(rest_pat.span),
             source: self.source_map.get_source(rest_pat.span),
             range,
-            annotation: "Attempted parameter spread here".to_string(), // TODO
+            annotation: "Attempted parameter spread here".to_string(),
             suggestion: Some(Suggestion {
                 title: "Specify each parameter individually with a concrete type".to_string(),
                 source: self.source_map.generate_source_with_range_replaced(
@@ -187,7 +187,7 @@ impl AzleFnDecl<'_> {
                     range,
                     &replacement_name,
                 ),
-                range: (range.0, range.0 + replacement_name.len()), // TODO: Use the new source_map.get_modified_range(replacement_name)
+                range: (range.0, range.0 + replacement_name.len()),
                 annotation: None,
                 import_suggestion: None,
             }),
@@ -200,19 +200,18 @@ impl AzleFnDecl<'_> {
     ) -> ErrorMessage {
         let range = self.source_map.get_range(binding_ident.span);
         let raw_source = self.source_map.get_source(binding_ident.span);
-        let example_type_ann = ": ParamType"; // TODO: Come up with a better name from the source
+        let example_type_ann = ": ParamType".to_string(); // TODO: Come up with a better name from the source
         let source = if raw_source.len() <= range.1 + 1 {
             format!("{} ", raw_source)
         } else {
             raw_source
         };
 
-        let corrected_source: String = source
-            .chars()
-            .take(range.1)
-            .chain(example_type_ann.to_string().chars())
-            .chain(source.chars().skip(range.1))
-            .collect();
+        let corrected_source = self.source_map.generate_source_with_range_replaced(
+            binding_ident.span,
+            (range.1, range.1),
+            &example_type_ann,
+        );
 
         ErrorMessage {
             title: "Untyped parameter".to_string(),

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/errors.rs
@@ -157,22 +157,15 @@ impl AzleFnDecl<'_> {
         }
     }
 
-    pub(super) fn build_qualified_type_error_msg(&self) -> ErrorMessage {
+    pub(super) fn build_qualified_type_error_msg(&self, span: Span) -> ErrorMessage {
         ErrorMessage {
             title: "Namespace-qualified types are not currently supported".to_string(),
-            origin: "index.ts".to_string(), // TODO: Get this from the source map
-            line_number: 1,                 // TODO: Get this from the source map
-            source: "export function example(): Query<Namespace.MyType> {}".to_string(), // TODO: Get this from the source map
-            range: (33, 43), // TODO: Get this from the source map
-            annotation: "Namespace specified here".to_string(), // TODO
-            suggestion: Some(Suggestion {
-                title: "Either declare the import locally or remove the wildcard import"
-                    .to_string(),
-                source: "export function example(): Query<MyType> {}".to_string(), // TODO: Get this from the source map
-                range: (33, 39), // TODO: Get this from the source map
-                annotation: None,
-                import_suggestion: None,
-            }),
+            origin: self.source_map.get_origin(span),
+            line_number: self.source_map.get_line_number(span),
+            source: self.source_map.get_source(span),
+            range: self.source_map.get_range(span),
+            annotation: "Namespace specified here".to_string(),
+            suggestion: None, // This is caught first by src/compiler/typescript_to_rust/azle_generate/src/ts_ast/ast_traits/get_name.rs
         }
     }
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/errors.rs
@@ -111,10 +111,13 @@ impl AzleFnDecl<'_> {
         &self,
         assign_pat: &AssignPat,
     ) -> ErrorMessage {
+        let title = "Setting default values for parameters is unsupported at this time".to_string();
+        let origin = self.source_map.get_origin(assign_pat.span);
+        let line_number = self.source_map.get_line_number(assign_pat.span);
         let source = self.source_map.get_source(assign_pat.span);
         let range = self.source_map.get_range(assign_pat.span);
-        eprintln!("The source code is: {}", source);
         let equals_index_option = source.find('=');
+
         match equals_index_option {
             Some(equals_index) => {
                 let equals_sign_and_right_hand_range = (equals_index, range.1);
@@ -126,28 +129,26 @@ impl AzleFnDecl<'_> {
                     .collect();
 
                 ErrorMessage {
-                    title: "Setting default values for parameters is unsupported at this time"
-                        .to_string(),
-                    origin: self.source_map.get_origin(assign_pat.span),
-                    line_number: self.source_map.get_line_number(assign_pat.span),
+                    title,
+                    origin,
+                    line_number,
                     source,
                     range: equals_sign_and_right_hand_range,
                     annotation: "Attempted to set a default value here".to_string(),
                     suggestion: Some(Suggestion {
                         title: "Remove the default value or set it inside the function body"
                             .to_string(),
-                        source: corrected_source, // TODO: Use the new source_map.get_modified_source(replacement_name)
-                        range: (range.0, equals_index), // TODO: Use the new source_map.get_modified_range(replacement_name)
+                        source: corrected_source,
+                        range: (range.0, equals_index),
                         annotation: None,
                         import_suggestion: None,
                     }),
                 }
             }
             None => ErrorMessage {
-                title: "Setting default values for parameters is unsupported at this time"
-                    .to_string(),
-                origin: self.source_map.get_origin(assign_pat.span),
-                line_number: self.source_map.get_line_number(assign_pat.span),
+                title,
+                origin,
+                line_number,
                 source: source.clone(),
                 range: (range.0, source.len()),
                 annotation: "Attempted to assign a default value to this parameter".to_string(),

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
@@ -67,7 +67,7 @@ impl AzleFnDecl<'_> {
             .map(|param| match &param.pat {
                 Pat::Ident(ident) => ident,
                 Pat::Array(_) => panic!("{}", self.build_array_destructure_error_msg(param)),
-                Pat::Rest(_) => panic!("{}", self.build_rest_param_error_msg()),
+                Pat::Rest(_) => panic!("{}", self.build_rest_param_error_msg(param)),
                 Pat::Object(_) => panic!("{}", self.build_object_destructure_error_msg(param)),
                 Pat::Assign(_) => panic!("{}", self.build_param_default_value_error_msg()),
                 Pat::Invalid(_) => panic!("{}", self.build_invalid_param_error_msg()),

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
@@ -66,17 +66,9 @@ impl AzleFnDecl<'_> {
             .iter()
             .map(|param| match &param.pat {
                 Pat::Ident(ident) => ident,
-                Pat::Array(array_pat) => match &array_pat.type_ann {
-                    Some(ts_type_ann) => {
-                        panic!(
-                            "{}",
-                            self.build_array_destructure_error_msg(array_pat, ts_type_ann)
-                        )
-                    }
-                    None => panic!("{}", self.build_untyped_param_error_msg()),
-                },
+                Pat::Array(_) => panic!("{}", self.build_array_destructure_error_msg(param)),
                 Pat::Rest(_) => panic!("{}", self.build_rest_param_error_msg()),
-                Pat::Object(_) => panic!("{}", self.build_object_destructure_error_msg()),
+                Pat::Object(_) => panic!("{}", self.build_object_destructure_error_msg(param)),
                 Pat::Assign(_) => panic!("{}", self.build_param_default_value_error_msg()),
                 Pat::Invalid(_) => panic!("{}", self.build_invalid_param_error_msg()),
                 Pat::Expr(_) => panic!("{}", self.build_invalid_param_error_msg()),

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
@@ -17,9 +17,15 @@ pub struct AzleFnDecl<'a> {
 
 impl AzleFnDecl<'_> {
     pub fn get_canister_method_type(&self) -> &str {
-        match &self.get_return_type_ref().type_name {
+        let return_type_ref = self.get_return_type_ref();
+        match &return_type_ref.type_name {
             TsEntityName::Ident(ident) => ident.get_name(),
-            TsEntityName::TsQualifiedName(_) => panic!("{}", self.build_qualified_type_error_msg()),
+            TsEntityName::TsQualifiedName(_) => {
+                panic!(
+                    "{}",
+                    self.build_qualified_type_error_msg(return_type_ref.span)
+                )
+            }
         }
     }
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
@@ -39,7 +39,8 @@ impl AzleFnDecl<'_> {
             Some(type_param_instantiation) => &*type_param_instantiation.params[0],
             None => {
                 let canister_method_type = self.get_canister_method_type();
-                let error_message = self.build_missing_return_type_error_msg(canister_method_type);
+                let error_message =
+                    self.build_missing_return_type_error_msg(type_ref.span, canister_method_type);
                 panic!("{}", error_message)
             }
         }

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
@@ -91,7 +91,7 @@ impl AzleFnDecl<'_> {
             .iter()
             .fold(vec![], |acc, ident| match &ident.type_ann {
                 Some(ts_type_ann) => vec![acc, vec![&ts_type_ann.type_ann]].concat(),
-                None => panic!("{}", self.build_untyped_param_error_msg()),
+                None => panic!("{}", self.build_untyped_param_error_msg(*ident)),
             })
     }
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
@@ -69,7 +69,9 @@ impl AzleFnDecl<'_> {
                 Pat::Array(_) => panic!("{}", self.build_array_destructure_error_msg(param)),
                 Pat::Rest(_) => panic!("{}", self.build_rest_param_error_msg(param)),
                 Pat::Object(_) => panic!("{}", self.build_object_destructure_error_msg(param)),
-                Pat::Assign(_) => panic!("{}", self.build_param_default_value_error_msg()),
+                Pat::Assign(assign_pat) => {
+                    panic!("{}", self.build_param_default_value_error_msg(assign_pat))
+                }
                 Pat::Invalid(_) => panic!("{}", self.build_invalid_param_error_msg()),
                 Pat::Expr(_) => panic!("{}", self.build_invalid_param_error_msg()),
             })

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
@@ -65,7 +65,15 @@ impl AzleFnDecl<'_> {
             .iter()
             .map(|param| match &param.pat {
                 Pat::Ident(ident) => ident,
-                Pat::Array(_) => panic!("{}", self.build_array_destructure_error_msg()),
+                Pat::Array(array_pat) => match &array_pat.type_ann {
+                    Some(ts_type_ann) => {
+                        panic!(
+                            "{}",
+                            self.build_array_destructure_error_msg(array_pat, ts_type_ann)
+                        )
+                    }
+                    None => panic!("{}", self.build_untyped_param_error_msg()),
+                },
                 Pat::Rest(_) => panic!("{}", self.build_rest_param_error_msg()),
                 Pat::Object(_) => panic!("{}", self.build_object_destructure_error_msg()),
                 Pat::Assign(_) => panic!("{}", self.build_param_default_value_error_msg()),

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/mod.rs
@@ -23,4 +23,5 @@ mod ts_type_ann;
 
 pub mod azle_type;
 pub mod azle_type_alias_decls;
+pub mod param;
 pub mod program;

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/param.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/param.rs
@@ -21,7 +21,16 @@ impl GetParamRange for Param {
                 let range_without_type_annotation = (full_param_span_range.0, type_ann_range.0);
                 range_without_type_annotation
             }
-            Pat::Rest(_) => todo!(),
+            Pat::Rest(rest_pat) => {
+                let full_param_span_range = source_map.get_range(rest_pat.span);
+                if rest_pat.type_ann.is_none() {
+                    return full_param_span_range;
+                }
+                let ts_type_ann = rest_pat.type_ann.as_ref().unwrap();
+                let type_ann_range = source_map.get_range(ts_type_ann.span);
+                let range_without_type_annotation = (full_param_span_range.0, type_ann_range.0);
+                range_without_type_annotation
+            }
             Pat::Object(object_pat) => {
                 let full_param_span_range = source_map.get_range(object_pat.span);
                 if object_pat.type_ann.is_none() {

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/param.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/param.rs
@@ -1,0 +1,40 @@
+use swc_common::SourceMap;
+use swc_ecma_ast::{Param, Pat};
+
+use crate::ts_ast::source_map::{GetSourceFileInfo, Range};
+
+pub trait GetParamRange {
+    fn get_destructure_range(&self, source_map: &SourceMap) -> Range;
+}
+
+impl GetParamRange for Param {
+    fn get_destructure_range(&self, source_map: &SourceMap) -> Range {
+        match &self.pat {
+            Pat::Ident(ident) => source_map.get_range(ident.span),
+            Pat::Array(array_pat) => {
+                let full_param_span_range = source_map.get_range(array_pat.span);
+                if array_pat.type_ann.is_none() {
+                    return full_param_span_range;
+                }
+                let ts_type_ann = array_pat.type_ann.as_ref().unwrap();
+                let type_ann_range = source_map.get_range(ts_type_ann.span);
+                let range_without_type_annotation = (full_param_span_range.0, type_ann_range.0);
+                range_without_type_annotation
+            }
+            Pat::Rest(_) => todo!(),
+            Pat::Object(object_pat) => {
+                let full_param_span_range = source_map.get_range(object_pat.span);
+                if object_pat.type_ann.is_none() {
+                    return full_param_span_range;
+                }
+                let ts_type_ann = object_pat.type_ann.as_ref().unwrap();
+                let type_ann_range = source_map.get_range(ts_type_ann.span);
+                let range_without_type_annotation = (full_param_span_range.0, type_ann_range.0);
+                range_without_type_annotation
+            }
+            Pat::Assign(assign) => source_map.get_range(assign.span),
+            Pat::Invalid(invalid) => source_map.get_range(invalid.span),
+            Pat::Expr(_) => panic!("Something's very wrong with your parameters"), // TODO: handle this better
+        }
+    }
+}

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/param.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/param.rs
@@ -41,7 +41,7 @@ impl GetParamRange for Param {
                 let range_without_type_annotation = (full_param_span_range.0, type_ann_range.0);
                 range_without_type_annotation
             }
-            Pat::Assign(assign) => source_map.get_range(assign.span),
+            Pat::Assign(assign_pat) => source_map.get_range(assign_pat.span),
             Pat::Invalid(invalid) => source_map.get_range(invalid.span),
             Pat::Expr(_) => panic!("Something's very wrong with your parameters"), // TODO: handle this better
         }

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/source_map/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/source_map/mod.rs
@@ -1,3 +1,4 @@
 pub mod source_map;
 
 pub use source_map::GetSourceFileInfo;
+pub use source_map::Range;

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/source_map/source_map.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/source_map/source_map.rs
@@ -10,8 +10,14 @@ pub trait GetSourceFileInfo {
     fn generate_line_highlight(&self, span: Span) -> String;
     fn generate_highlighted_line(&self, span: Span) -> String;
     fn get_range(&self, span: Span) -> Range;
+    fn generate_source_with_range_replaced(
+        &self,
+        span: Span,
+        range: Range,
+        replacement: &String,
+    ) -> String;
     fn generate_modified_source(&self, span: Span, replacement: &String) -> String;
-    fn generate_modified_range(&self, span: Span, replacement: &String) -> (usize, usize);
+    fn generate_modified_range(&self, span: Span, replacement: &String) -> Range;
 }
 
 trait PrivateGetSourceFileInfo {
@@ -100,6 +106,21 @@ impl GetSourceFileInfo for SourceMap {
         highlight
     }
 
+    fn generate_source_with_range_replaced(
+        &self,
+        span: Span,
+        range: Range,
+        replacement: &String,
+    ) -> String {
+        let source = self.get_source(span);
+        source
+            .chars()
+            .take(range.0)
+            .chain(replacement.to_string().chars())
+            .chain(source.chars().skip(range.1))
+            .collect()
+    }
+
     fn generate_modified_source(&self, span: Span, replacement: &String) -> String {
         format!(
             "{}{}{}",
@@ -109,7 +130,7 @@ impl GetSourceFileInfo for SourceMap {
         )
     }
 
-    fn generate_modified_range(&self, span: Span, replacement: &String) -> (usize, usize) {
+    fn generate_modified_range(&self, span: Span, replacement: &String) -> Range {
         (
             self.get_start_col(span),
             self.get_start_col(span) + replacement.len(),

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/source_map/source_map.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/source_map/source_map.rs
@@ -1,5 +1,7 @@
 use swc_common::{Loc, SourceMap, Span};
 
+pub type Range = (usize, usize);
+
 pub trait GetSourceFileInfo {
     fn get_text(&self, span: Span) -> String;
     fn get_origin(&self, span: Span) -> String;
@@ -7,7 +9,7 @@ pub trait GetSourceFileInfo {
     fn get_line_number(&self, span: Span) -> usize;
     fn generate_line_highlight(&self, span: Span) -> String;
     fn generate_highlighted_line(&self, span: Span) -> String;
-    fn get_range(&self, span: Span) -> (usize, usize);
+    fn get_range(&self, span: Span) -> Range;
     fn generate_modified_source(&self, span: Span, replacement: &String) -> String;
     fn generate_modified_range(&self, span: Span, replacement: &String) -> (usize, usize);
 }
@@ -52,7 +54,7 @@ impl GetSourceFileInfo for SourceMap {
         line[self.get_start_col(span)..self.get_end_col(span)].to_string()
     }
 
-    fn get_range(&self, span: Span) -> (usize, usize) {
+    fn get_range(&self, span: Span) -> Range {
         let start = self.get_start_col(span);
         let end = self.get_end_col(span);
         (start, end)

--- a/src/result.ts
+++ b/src/result.ts
@@ -41,6 +41,6 @@ function exitWithError(payload: AzleError): never {
     if (payload.suggestion) {
         console.error(`\n${payload.suggestion}`);
     }
-    console.error(`\n💀 Build failed`);
+    console.log(`\n💀 Build failed`);
     process.exit(payload.exitCode ?? 0);
 }


### PR DESCRIPTION
After #733, the functions were returning snippets, but they weren't actual source code, they were just examples. This finishes hooking up the errors, getting them to print actual snippets from the user's source code.