### PR TITLE
Improved error messages for edge-cases in cross canister calls

### DIFF
--- a/src/azle.ts
+++ b/src/azle.ts
@@ -391,7 +391,7 @@ function runAzleGenerate(
     );
 
     const suggestion =
-        'If you are unable to decipher the error above, reach out in the #typescript\nchannel of the DFINITY DEV OFFICIAL discord: https://discord.gg/zuUEzSf4mV';
+        'If you are unable to decipher the error above, reach out in the #typescript\nchannel of the DFINITY DEV OFFICIAL discord:\nhttps://discord.com/channels/748416164832608337/956466775380336680';
 
     if (executionResult.error) {
         const exitCode = executionResult.error.errno ?? 13;

--- a/src/azle.ts
+++ b/src/azle.ts
@@ -419,9 +419,13 @@ function runAzleGenerate(
         const lineWhereErrorMessageStarts = stdErrLines.findIndex((line) =>
             line.startsWith("thread 'main' panicked")
         );
-        const lineWhereErrorMessageEnds = stdErrLines.findIndex((line) =>
-            line.includes("', src/azle_generate")
-        );
+        const starts_with_quote_comma_and_contains_a_path_and_ends_with_line_and_column_number =
+            /',\s.*\/.*\.rs:\d*:\d*/;
+        const lineWhereErrorMessageEnds = stdErrLines.findIndex((line) => {
+            return starts_with_quote_comma_and_contains_a_path_and_ends_with_line_and_column_number.test(
+                line
+            );
+        });
         if (
             lineWhereErrorMessageStarts === -1 ||
             lineWhereErrorMessageEnds === -1
@@ -440,10 +444,12 @@ function runAzleGenerate(
             "thread 'main' panicked at '",
             ''
         );
-        const panicLocation = /', src\/.*/;
         errorLines[errorLines.length - 1] = errorLines[
             errorLines.length - 1
-        ].replace(panicLocation, '');
+        ].replace(
+            starts_with_quote_comma_and_contains_a_path_and_ends_with_line_and_column_number,
+            ''
+        );
 
         return Err({
             error: `${generalErrorMessage}\n\n${errorLines.join('\n')}`,

--- a/src/compiler/typescript_to_javascript/annotations.ts
+++ b/src/compiler/typescript_to_javascript/annotations.ts
@@ -59,7 +59,12 @@ export function snippetsToDisplayString(snippets: Snippet[]): string {
 
             const range = snippet.slice.annotation.range;
 
-            const sourceCodeLine = `${sourceCodeLineGutter}${snippet.slice.source}`;
+            const gutteredSourceCode = snippet.slice.source.replace(
+                /\n/g,
+                `\n${emptyLineGutter}`
+            );
+
+            const sourceCodeLine = `${sourceCodeLineGutter}${gutteredSourceCode}`;
             const marker =
                 snippet.slice.annotation.annotationType === 'Error' ? '^' : '-';
             const annotationLine = `${emptyLineGutter}${' '.repeat(

--- a/src/compiler/typescript_to_javascript/annotations.ts
+++ b/src/compiler/typescript_to_javascript/annotations.ts
@@ -10,6 +10,12 @@ export type Annotation = {
 
 export type AnnotationType = 'Error' | 'Warning' | 'Info' | 'Note' | 'Help';
 
+export type Location = {
+    path: string;
+    line: number;
+    column: number;
+};
+
 export type Range = [number, number];
 
 /**
@@ -32,7 +38,8 @@ export type Slice = {
  */
 export type Snippet = {
     title: Annotation;
-    slice: Slice;
+    location?: Location;
+    source?: string;
 };
 
 /**
@@ -50,36 +57,22 @@ export function snippetsToDisplayString(snippets: Snippet[]): string {
             const tag = snippet.title.annotationType.toLowerCase();
             const titleLine = `${tag}: ${snippet.title.label}`;
 
-            const originLine = snippet.slice.origin
-                ? ` --> ${snippet.slice.origin}:${snippet.slice.lineStart}:${snippet.slice.annotation.range[0]}`
+            const originLine = snippet.location
+                ? ` --> ${snippet.location.path}:${snippet.location.line}:${snippet.location.column}`
                 : null;
 
-            const sourceCodeLineGutter = `${snippet.slice.lineStart} | `;
-            const emptyLineGutter = '| '.padStart(sourceCodeLineGutter.length);
-
-            const range = snippet.slice.annotation.range;
-
-            const gutteredSourceCode = snippet.slice.source.replace(
-                /\n/g,
-                `\n${emptyLineGutter}`
-            );
-
-            const sourceCodeLine = `${sourceCodeLineGutter}${gutteredSourceCode}`;
-            const marker =
-                snippet.slice.annotation.annotationType === 'Error' ? '^' : '-';
-            const annotationLine = `${emptyLineGutter}${' '.repeat(
-                range[0] - 1
-            )}${marker.repeat(range[1] - range[0])} ${
-                snippet.slice.annotation.label ?? ''
-            }`;
+            const gutter = '  | ';
+            const blankLine = snippet.source ? gutter : null;
+            const sourceCodeWithSimpleGutter = snippet.source
+                ? `${gutter}${snippet.source?.replace(/\n/g, `\n${gutter}`)}`
+                : null;
 
             return [
                 titleLine,
                 originLine,
-                emptyLineGutter,
-                sourceCodeLine,
-                annotationLine,
-                emptyLineGutter
+                blankLine,
+                sourceCodeWithSimpleGutter,
+                blankLine
             ]
                 .filter((l) => l)
                 .join('\n');

--- a/src/compiler/typescript_to_javascript/annotations.ts
+++ b/src/compiler/typescript_to_javascript/annotations.ts
@@ -1,0 +1,83 @@
+/**
+ * Gives an introductory statement about the snippet to follow.
+ */
+export type Annotation = {
+    /** Will be displayed in all lowercase before the label */
+    annotationType: AnnotationType;
+    /** The text to display to the user */
+    label: string;
+};
+
+export type AnnotationType = 'Error' | 'Warning' | 'Info' | 'Note' | 'Help';
+
+export type Range = [number, number];
+
+/**
+ * Displays a section of source code and accompanying annotations which
+ * highlight (underline) specific chunks.
+ */
+export type Slice = {
+    /** The section of source code to display */
+    source: string;
+    /** The line number the source code slice starts on. This will display as the line number */
+    lineStart: number;
+    /** The path of the file this is included in. */
+    origin?: string;
+    /** An annotation for a slice */
+    annotation: SourceAnnotation;
+};
+
+/**
+ * Used for describing a section of code, and pointing out important parts
+ */
+export type Snippet = {
+    title: Annotation;
+    slice: Slice;
+};
+
+/**
+ * Is displayed within the code snippet after the highlighting markers.
+ */
+export type SourceAnnotation = {
+    label?: string;
+    range: Range;
+    annotationType: AnnotationType;
+};
+
+export function snippetsToDisplayString(snippets: Snippet[]): string {
+    return snippets
+        .map((snippet) => {
+            const tag = snippet.title.annotationType.toLowerCase();
+            const titleLine = `${tag}: ${snippet.title.label}`;
+
+            const originLine = snippet.slice.origin
+                ? ` --> ${snippet.slice.origin}:${snippet.slice.lineStart}:${snippet.slice.annotation.range[0]}`
+                : null;
+
+            const sourceCodeLineGutter = `${snippet.slice.lineStart} | `;
+            const emptyLineGutter = '| '.padStart(sourceCodeLineGutter.length);
+
+            const range = snippet.slice.annotation.range;
+
+            const sourceCodeLine = `${sourceCodeLineGutter}${snippet.slice.source}`;
+            const marker =
+                snippet.slice.annotation.annotationType === 'Error' ? '^' : '-';
+            const annotationLine = `${emptyLineGutter}${' '.repeat(
+                range[0] - 1
+            )}${marker.repeat(range[1] - range[0])} ${
+                snippet.slice.annotation.label ?? ''
+            }`;
+
+            return [
+                titleLine,
+                originLine,
+                emptyLineGutter,
+                sourceCodeLine,
+                annotationLine,
+                emptyLineGutter
+            ]
+                .filter((l) => l)
+                .join('\n');
+        })
+        .join('\n');
+}

--- a/src/compiler/typescript_to_javascript/annotations.ts
+++ b/src/compiler/typescript_to_javascript/annotations.ts
@@ -1,3 +1,5 @@
+import { SourceFile } from 'typescript';
+
 /**
  * Gives an introductory statement about the snippet to follow.
  */
@@ -78,4 +80,20 @@ export function snippetsToDisplayString(snippets: Snippet[]): string {
                 .join('\n');
         })
         .join('\n');
+}
+
+export function getLineNumber(sourceFile: SourceFile, range: Range): number {
+    const codePrecedingRange = sourceFile.text.substring(0, range[0]);
+    const numberOfNewlinesBeforeRange = (codePrecedingRange.match(/\n/g) ?? [])
+        .length;
+    return numberOfNewlinesBeforeRange + 1;
+}
+
+export function convertFileRangeToLineRange(
+    sourceFile: SourceFile,
+    range: Range
+): Range {
+    const codePrecedingRange = sourceFile.text.substring(0, range[0]);
+    const lastNewlineIndex = codePrecedingRange.lastIndexOf('\n');
+    return [range[0] - lastNewlineIndex, range[1] - lastNewlineIndex];
 }

--- a/src/compiler/typescript_to_javascript/errors/index.ts
+++ b/src/compiler/typescript_to_javascript/errors/index.ts
@@ -2,3 +2,12 @@ export { createMissingTypeArgumentErrorMessage } from './missing_type_annotation
 export { createMultipleTypeArgumentsErrorMessage } from './multiple_type_arguments';
 export { createNonTypeLiteralErrorMessage } from './non_type_literal';
 export { createNonMethodSignatureMemberErrorMessage } from './non_method_signature_member';
+
+export function createExampleCanisterDeclaration(): string {
+    const methods = [
+        'method1() => CanisterResult<void>',
+        'method2(param1: string) => CanisterResult<string>',
+        'method3(param1: boolean, param2: MyCustomType) => CanisterResult<MyCustomType[]>'
+    ];
+    return `Canister<{\n  ${methods.join('\n  ')}\n}>`;
+}

--- a/src/compiler/typescript_to_javascript/errors/index.ts
+++ b/src/compiler/typescript_to_javascript/errors/index.ts
@@ -1,0 +1,1 @@
+export { createMissingTypeArgumentErrorMessage } from './missing_type_annotation';

--- a/src/compiler/typescript_to_javascript/errors/index.ts
+++ b/src/compiler/typescript_to_javascript/errors/index.ts
@@ -1,3 +1,4 @@
 export { createMissingTypeArgumentErrorMessage } from './missing_type_annotation';
 export { createMultipleTypeArgumentsErrorMessage } from './multiple_type_arguments';
 export { createNonTypeLiteralErrorMessage } from './non_type_literal';
+export { createNonMethodSignatureMemberErrorMessage } from './non_method_signature_member';

--- a/src/compiler/typescript_to_javascript/errors/index.ts
+++ b/src/compiler/typescript_to_javascript/errors/index.ts
@@ -1,1 +1,3 @@
 export { createMissingTypeArgumentErrorMessage } from './missing_type_annotation';
+export { createMultipleTypeArgumentsErrorMessage } from './multiple_type_arguments';
+export { createNonTypeLiteralErrorMessage } from './non_type_literal';

--- a/src/compiler/typescript_to_javascript/errors/missing_type_annotation.ts
+++ b/src/compiler/typescript_to_javascript/errors/missing_type_annotation.ts
@@ -5,6 +5,7 @@ import {
     Snippet,
     snippetsToDisplayString
 } from '../annotations';
+import { createExampleCanisterDeclaration } from '.';
 
 export function createMissingTypeArgumentErrorMessage(
     typeAliasDeclaration: TypeAliasDeclaration
@@ -25,7 +26,7 @@ export function createMissingTypeArgumentErrorMessage(
     const errorSnippet: Snippet = {
         title: {
             annotationType: 'Error',
-            label: 'Generic type "Canister" requires one type argument'
+            label: 'Canister type missing type literal.'
         },
         location: {
             path: sourceFile.fileName,
@@ -41,12 +42,10 @@ export function createMissingTypeArgumentErrorMessage(
     const helpSnippet: Snippet = {
         title: {
             annotationType: 'Help',
-            label: 'Specify a type literal as a type argument to "Canister"'
-        }
+            label: 'Specify a type literal as a type argument to Canister. For example:'
+        },
+        source: createExampleCanisterDeclaration()
     };
 
-    return `Azle requirement violation.\n\n${snippetsToDisplayString([
-        errorSnippet,
-        helpSnippet
-    ])}`;
+    return `\n\n${snippetsToDisplayString([errorSnippet, helpSnippet])}`;
 }

--- a/src/compiler/typescript_to_javascript/errors/missing_type_annotation.ts
+++ b/src/compiler/typescript_to_javascript/errors/missing_type_annotation.ts
@@ -1,0 +1,115 @@
+import * as tsc from 'typescript';
+import { Range, Snippet, snippetsToDisplayString } from '../annotations';
+
+export function createMissingTypeArgumentErrorMessage(
+    typeAliasDeclaration: tsc.TypeAliasDeclaration
+): string {
+    const sourceFile = typeAliasDeclaration.getSourceFile();
+
+    const typeReferenceNode =
+        typeAliasDeclaration.type as tsc.TypeReferenceNode;
+
+    const typeAliasDeclRange: Range = [
+        typeAliasDeclaration.pos,
+        typeAliasDeclaration.end
+    ];
+    const adjustedTypeAliasDeclRange = adjustRange(
+        sourceFile,
+        typeAliasDeclRange
+    );
+    const source = getSourceCode(sourceFile, adjustedTypeAliasDeclRange);
+    const adjustedTypeAliasDeclRangeInLine = getRangeInLine(
+        sourceFile,
+        adjustRange(sourceFile, [typeReferenceNode.pos, typeReferenceNode.end])
+    );
+
+    const errorSnippet: Snippet = {
+        title: {
+            annotationType: 'Error',
+            label: 'Generic type "Canister" requires one type argument'
+        },
+        slice: {
+            source,
+            lineStart: getLineStart(sourceFile, adjustedTypeAliasDeclRange),
+            origin: sourceFile.fileName,
+            annotation: {
+                label: 'missing type argument here',
+                annotationType: 'Error',
+                range: adjustedTypeAliasDeclRangeInLine
+            }
+        }
+    };
+
+    let exampleCanisterTypeLiteral = '<{method(): CanisterResult<void>}>';
+    let typeRefRange: Range = [typeReferenceNode.pos, typeReferenceNode.end];
+    let adjustedTypeRefRange = adjustRange(sourceFile, typeRefRange);
+    let typeReferenceNodeRangeInLine = getRangeInLine(
+        sourceFile,
+        adjustedTypeRefRange
+    );
+    let exampleTypeLiteralRange: Range = [
+        typeReferenceNodeRangeInLine[1],
+        typeReferenceNodeRangeInLine[1] + exampleCanisterTypeLiteral.length
+    ];
+    const helpSnippet: Snippet = {
+        title: {
+            annotationType: 'Help',
+            label: 'Specify a type literal as a type argument to "Canister"'
+        },
+        slice: {
+            source: buildCorrectedSource(
+                source,
+                adjustedTypeAliasDeclRangeInLine[1] - 1
+            ),
+            lineStart: getLineStart(sourceFile, adjustedTypeAliasDeclRange),
+            annotation: {
+                annotationType: 'Help',
+                range: exampleTypeLiteralRange
+            }
+        }
+    };
+
+    return `Azle requirement violation.\n\n${snippetsToDisplayString([
+        errorSnippet,
+        helpSnippet
+    ])}`;
+}
+
+function getSourceCode(sourceFile: tsc.SourceFile, range: Range): string {
+    return sourceFile.text.substring(range[0], range[1]);
+}
+
+function getLineStart(sourceFile: tsc.SourceFile, range: Range): number {
+    const codePrecedingRange = sourceFile.text.substring(0, range[0]);
+    const numberOfNewlinesBeforeRange = (codePrecedingRange.match(/\n/g) ?? [])
+        .length;
+    return numberOfNewlinesBeforeRange + 1;
+}
+
+function buildCorrectedSource(source: string, index: number): string {
+    return `${source.slice(
+        0,
+        index - 1
+    )}<{method(): CanisterResult<void>}>${source.slice(index - 1)}`;
+}
+
+/** Adjusts the range to not include any leading newlines
+ *
+ * Sometimes TSC will break nodes right where the last node ended. The node
+ * doesn't really start until after the leading newlines, but TSC doesn't
+ * realize that for some reason. So it sticks the leading newlines into that
+ * node. As a result we need to remove them so that the snippet displays
+ * correctly.
+ */
+function adjustRange(sourceFile: tsc.SourceFile, range: Range): Range {
+    const rawSourceCode = sourceFile.text.substring(range[0], range[1]);
+    const leadingNewlineCount = (rawSourceCode.match(/^\n*/) ?? [''])[0].length;
+    const actualRangeStart = range[0] + leadingNewlineCount;
+    return [actualRangeStart, range[1]];
+}
+
+function getRangeInLine(sourceFile: tsc.SourceFile, range: Range): Range {
+    const codePrecedingRange = sourceFile.text.substring(0, range[0]);
+    const lastNewlineIndex = codePrecedingRange.lastIndexOf('\n') - 1;
+    return [range[0] - lastNewlineIndex, range[1] - lastNewlineIndex];
+}

--- a/src/compiler/typescript_to_javascript/errors/missing_type_annotation.ts
+++ b/src/compiler/typescript_to_javascript/errors/missing_type_annotation.ts
@@ -6,66 +6,38 @@ export function createMissingTypeArgumentErrorMessage(
 ): string {
     const sourceFile = typeAliasDeclaration.getSourceFile();
 
-    const typeReferenceNode =
-        typeAliasDeclaration.type as tsc.TypeReferenceNode;
-
-    const typeAliasDeclRange: Range = [
+    const typeAliasDeclarationSourceCode = sourceFile.text.substring(
         typeAliasDeclaration.pos,
         typeAliasDeclaration.end
-    ];
-    const adjustedTypeAliasDeclRange = adjustRange(
-        sourceFile,
-        typeAliasDeclRange
     );
-    const source = getSourceCode(sourceFile, adjustedTypeAliasDeclRange);
-    const adjustedTypeAliasDeclRangeInLine = getRangeInLine(
-        sourceFile,
-        adjustRange(sourceFile, [typeReferenceNode.pos, typeReferenceNode.end])
-    );
+
+    const typeReferenceNode =
+        typeAliasDeclaration.type as tsc.TypeReferenceNode;
+    const typeReferenceNodeLineNumber = getLineNumber(sourceFile, [
+        typeReferenceNode.pos,
+        typeReferenceNode.end
+    ]);
 
     const errorSnippet: Snippet = {
         title: {
             annotationType: 'Error',
             label: 'Generic type "Canister" requires one type argument'
         },
-        slice: {
-            source,
-            lineStart: getLineStart(sourceFile, adjustedTypeAliasDeclRange),
-            origin: sourceFile.fileName,
-            annotation: {
-                label: 'missing type argument here',
-                annotationType: 'Error',
-                range: adjustedTypeAliasDeclRangeInLine
-            }
-        }
+        location: {
+            path: sourceFile.fileName,
+            line: typeReferenceNodeLineNumber,
+            column: convertFileRangeToLineRange(sourceFile, [
+                typeReferenceNode.pos,
+                typeReferenceNode.end
+            ])[1]
+        },
+        source: typeAliasDeclarationSourceCode
     };
 
-    let exampleCanisterTypeLiteral = '<{method(): CanisterResult<void>}>';
-    let typeRefRange: Range = [typeReferenceNode.pos, typeReferenceNode.end];
-    let adjustedTypeRefRange = adjustRange(sourceFile, typeRefRange);
-    let typeReferenceNodeRangeInLine = getRangeInLine(
-        sourceFile,
-        adjustedTypeRefRange
-    );
-    let exampleTypeLiteralRange: Range = [
-        typeReferenceNodeRangeInLine[1],
-        typeReferenceNodeRangeInLine[1] + exampleCanisterTypeLiteral.length
-    ];
     const helpSnippet: Snippet = {
         title: {
             annotationType: 'Help',
             label: 'Specify a type literal as a type argument to "Canister"'
-        },
-        slice: {
-            source: buildCorrectedSource(
-                source,
-                adjustedTypeAliasDeclRangeInLine[1] - 1
-            ),
-            lineStart: getLineStart(sourceFile, adjustedTypeAliasDeclRange),
-            annotation: {
-                annotationType: 'Help',
-                range: exampleTypeLiteralRange
-            }
         }
     };
 
@@ -75,41 +47,18 @@ export function createMissingTypeArgumentErrorMessage(
     ])}`;
 }
 
-function getSourceCode(sourceFile: tsc.SourceFile, range: Range): string {
-    return sourceFile.text.substring(range[0], range[1]);
-}
-
-function getLineStart(sourceFile: tsc.SourceFile, range: Range): number {
+function getLineNumber(sourceFile: tsc.SourceFile, range: Range): number {
     const codePrecedingRange = sourceFile.text.substring(0, range[0]);
     const numberOfNewlinesBeforeRange = (codePrecedingRange.match(/\n/g) ?? [])
         .length;
     return numberOfNewlinesBeforeRange + 1;
 }
 
-function buildCorrectedSource(source: string, index: number): string {
-    return `${source.slice(
-        0,
-        index - 1
-    )}<{method(): CanisterResult<void>}>${source.slice(index - 1)}`;
-}
-
-/** Adjusts the range to not include any leading newlines
- *
- * Sometimes TSC will break nodes right where the last node ended. The node
- * doesn't really start until after the leading newlines, but TSC doesn't
- * realize that for some reason. So it sticks the leading newlines into that
- * node. As a result we need to remove them so that the snippet displays
- * correctly.
- */
-function adjustRange(sourceFile: tsc.SourceFile, range: Range): Range {
-    const rawSourceCode = sourceFile.text.substring(range[0], range[1]);
-    const leadingNewlineCount = (rawSourceCode.match(/^\n*/) ?? [''])[0].length;
-    const actualRangeStart = range[0] + leadingNewlineCount;
-    return [actualRangeStart, range[1]];
-}
-
-function getRangeInLine(sourceFile: tsc.SourceFile, range: Range): Range {
+function convertFileRangeToLineRange(
+    sourceFile: tsc.SourceFile,
+    range: Range
+): Range {
     const codePrecedingRange = sourceFile.text.substring(0, range[0]);
-    const lastNewlineIndex = codePrecedingRange.lastIndexOf('\n') - 1;
+    const lastNewlineIndex = codePrecedingRange.lastIndexOf('\n');
     return [range[0] - lastNewlineIndex, range[1] - lastNewlineIndex];
 }

--- a/src/compiler/typescript_to_javascript/errors/multiple_type_arguments.ts
+++ b/src/compiler/typescript_to_javascript/errors/multiple_type_arguments.ts
@@ -1,4 +1,4 @@
-import { TypeAliasDeclaration, TypeReferenceNode } from 'typescript';
+import * as tsc from 'typescript';
 import {
     convertFileRangeToLineRange,
     getLineNumber,
@@ -6,8 +6,8 @@ import {
     snippetsToDisplayString
 } from '../annotations';
 
-export function createMissingTypeArgumentErrorMessage(
-    typeAliasDeclaration: TypeAliasDeclaration
+export function createMultipleTypeArgumentsErrorMessage(
+    typeAliasDeclaration: tsc.TypeAliasDeclaration
 ): string {
     const sourceFile = typeAliasDeclaration.getSourceFile();
 
@@ -16,7 +16,8 @@ export function createMissingTypeArgumentErrorMessage(
         typeAliasDeclaration.end
     );
 
-    const typeReferenceNode = typeAliasDeclaration.type as TypeReferenceNode;
+    const typeReferenceNode =
+        typeAliasDeclaration.type as tsc.TypeReferenceNode;
     const typeReferenceNodeLineNumber = getLineNumber(sourceFile, [
         typeReferenceNode.pos,
         typeReferenceNode.end
@@ -25,7 +26,7 @@ export function createMissingTypeArgumentErrorMessage(
     const errorSnippet: Snippet = {
         title: {
             annotationType: 'Error',
-            label: 'Generic type "Canister" requires one type argument'
+            label: 'Generic type "Canister" accepts only one type argument'
         },
         location: {
             path: sourceFile.fileName,
@@ -33,7 +34,7 @@ export function createMissingTypeArgumentErrorMessage(
             column: convertFileRangeToLineRange(sourceFile, [
                 typeReferenceNode.pos,
                 typeReferenceNode.end
-            ])[1]
+            ])[0]
         },
         source: typeAliasDeclarationSourceCode
     };
@@ -41,7 +42,7 @@ export function createMissingTypeArgumentErrorMessage(
     const helpSnippet: Snippet = {
         title: {
             annotationType: 'Help',
-            label: 'Specify a type literal as a type argument to "Canister"'
+            label: 'Remove all but one type argument.'
         }
     };
 

--- a/src/compiler/typescript_to_javascript/errors/multiple_type_arguments.ts
+++ b/src/compiler/typescript_to_javascript/errors/multiple_type_arguments.ts
@@ -1,4 +1,5 @@
 import * as tsc from 'typescript';
+import { createExampleCanisterDeclaration } from '.';
 import {
     convertFileRangeToLineRange,
     getLineNumber,
@@ -26,7 +27,7 @@ export function createMultipleTypeArgumentsErrorMessage(
     const errorSnippet: Snippet = {
         title: {
             annotationType: 'Error',
-            label: 'Generic type "Canister" accepts only one type argument'
+            label: 'Too many type arguments passed to Canister type'
         },
         location: {
             path: sourceFile.fileName,
@@ -42,12 +43,10 @@ export function createMultipleTypeArgumentsErrorMessage(
     const helpSnippet: Snippet = {
         title: {
             annotationType: 'Help',
-            label: 'Remove all but one type argument.'
-        }
+            label: 'The Canister type accepts only one type argument, which must be a type literal. For example:'
+        },
+        source: createExampleCanisterDeclaration()
     };
 
-    return `Azle requirement violation.\n\n${snippetsToDisplayString([
-        errorSnippet,
-        helpSnippet
-    ])}`;
+    return `\n\n${snippetsToDisplayString([errorSnippet, helpSnippet])}`;
 }

--- a/src/compiler/typescript_to_javascript/errors/non_method_signature_member.ts
+++ b/src/compiler/typescript_to_javascript/errors/non_method_signature_member.ts
@@ -1,4 +1,5 @@
 import { TypeElement } from 'typescript';
+import { createExampleCanisterDeclaration } from '.';
 import {
     convertFileRangeToLineRange,
     getLineNumber,
@@ -24,7 +25,7 @@ export function createNonMethodSignatureMemberErrorMessage(
     const errorSnippet: Snippet = {
         title: {
             annotationType: 'Error',
-            label: 'Invalid member. Generic type "Canister" requires all members of it\'s enclosed type to be method signatures.'
+            label: 'Invalid member in Canister type argument.'
         },
         location: {
             path: sourceFile.fileName,
@@ -40,12 +41,10 @@ export function createNonMethodSignatureMemberErrorMessage(
     const helpSnippet: Snippet = {
         title: {
             annotationType: 'Help',
-            label: 'Remove this member or make it a method signature'
-        }
+            label: 'The Canister type requires all members of its enclosed type to be method signatures. For example:'
+        },
+        source: createExampleCanisterDeclaration()
     };
 
-    return `Azle requirement violation.\n\n${snippetsToDisplayString([
-        errorSnippet,
-        helpSnippet
-    ])}`;
+    return `\n\n${snippetsToDisplayString([errorSnippet, helpSnippet])}`;
 }

--- a/src/compiler/typescript_to_javascript/errors/non_method_signature_member.ts
+++ b/src/compiler/typescript_to_javascript/errors/non_method_signature_member.ts
@@ -1,0 +1,51 @@
+import { TypeElement } from 'typescript';
+import {
+    convertFileRangeToLineRange,
+    getLineNumber,
+    Range,
+    Snippet,
+    snippetsToDisplayString
+} from '../annotations';
+
+export function createNonMethodSignatureMemberErrorMessage(
+    typeElement: TypeElement
+): string {
+    const sourceFile = typeElement.getSourceFile();
+
+    const typeAliasDeclarationSourceCode = sourceFile.text.substring(
+        typeElement.pos,
+        typeElement.end
+    );
+
+    const range: Range = [typeElement.pos, typeElement.end];
+
+    const line = getLineNumber(sourceFile, range);
+
+    const errorSnippet: Snippet = {
+        title: {
+            annotationType: 'Error',
+            label: 'Invalid member. Generic type "Canister" requires all members of it\'s enclosed type to be method signatures.'
+        },
+        location: {
+            path: sourceFile.fileName,
+            line,
+            column: convertFileRangeToLineRange(sourceFile, [
+                typeElement.pos,
+                typeElement.end
+            ])[0]
+        },
+        source: typeAliasDeclarationSourceCode
+    };
+
+    const helpSnippet: Snippet = {
+        title: {
+            annotationType: 'Help',
+            label: 'Remove this member or make it a method signature'
+        }
+    };
+
+    return `Azle requirement violation.\n\n${snippetsToDisplayString([
+        errorSnippet,
+        helpSnippet
+    ])}`;
+}

--- a/src/compiler/typescript_to_javascript/errors/non_type_literal.ts
+++ b/src/compiler/typescript_to_javascript/errors/non_type_literal.ts
@@ -1,4 +1,5 @@
 import * as tsc from 'typescript';
+import { createExampleCanisterDeclaration } from '.';
 import {
     convertFileRangeToLineRange,
     getLineNumber,
@@ -26,7 +27,7 @@ export function createNonTypeLiteralErrorMessage(
     const errorSnippet: Snippet = {
         title: {
             annotationType: 'Error',
-            label: 'Generic type "Canister" currently requires an inline object literal as a type argument'
+            label: 'Non-type literal passed as type argument to Canister type.'
         },
         location: {
             path: sourceFile.fileName,
@@ -42,12 +43,10 @@ export function createNonTypeLiteralErrorMessage(
     const helpSnippet: Snippet = {
         title: {
             annotationType: 'Help',
-            label: 'Define your canister shape inline. E.g. Canister<{method(): CanisterResult<string>}>'
-        }
+            label: 'The Canister type accepts one type argument, which must be a type literal. For example:'
+        },
+        source: createExampleCanisterDeclaration()
     };
 
-    return `Azle requirement violation.\n\n${snippetsToDisplayString([
-        errorSnippet,
-        helpSnippet
-    ])}`;
+    return `\n\n${snippetsToDisplayString([errorSnippet, helpSnippet])}`;
 }

--- a/src/compiler/typescript_to_javascript/errors/non_type_literal.ts
+++ b/src/compiler/typescript_to_javascript/errors/non_type_literal.ts
@@ -1,4 +1,4 @@
-import { TypeAliasDeclaration, TypeReferenceNode } from 'typescript';
+import * as tsc from 'typescript';
 import {
     convertFileRangeToLineRange,
     getLineNumber,
@@ -6,8 +6,8 @@ import {
     snippetsToDisplayString
 } from '../annotations';
 
-export function createMissingTypeArgumentErrorMessage(
-    typeAliasDeclaration: TypeAliasDeclaration
+export function createNonTypeLiteralErrorMessage(
+    typeAliasDeclaration: tsc.TypeAliasDeclaration
 ): string {
     const sourceFile = typeAliasDeclaration.getSourceFile();
 
@@ -16,7 +16,8 @@ export function createMissingTypeArgumentErrorMessage(
         typeAliasDeclaration.end
     );
 
-    const typeReferenceNode = typeAliasDeclaration.type as TypeReferenceNode;
+    const typeReferenceNode =
+        typeAliasDeclaration.type as tsc.TypeReferenceNode;
     const typeReferenceNodeLineNumber = getLineNumber(sourceFile, [
         typeReferenceNode.pos,
         typeReferenceNode.end
@@ -25,7 +26,7 @@ export function createMissingTypeArgumentErrorMessage(
     const errorSnippet: Snippet = {
         title: {
             annotationType: 'Error',
-            label: 'Generic type "Canister" requires one type argument'
+            label: 'Generic type "Canister" currently requires an inline object literal as a type argument'
         },
         location: {
             path: sourceFile.fileName,
@@ -33,7 +34,7 @@ export function createMissingTypeArgumentErrorMessage(
             column: convertFileRangeToLineRange(sourceFile, [
                 typeReferenceNode.pos,
                 typeReferenceNode.end
-            ])[1]
+            ])[0]
         },
         source: typeAliasDeclarationSourceCode
     };
@@ -41,7 +42,7 @@ export function createMissingTypeArgumentErrorMessage(
     const helpSnippet: Snippet = {
         title: {
             annotationType: 'Help',
-            label: 'Specify a type literal as a type argument to "Canister"'
+            label: 'Define your canister shape inline. E.g. Canister<{method(): CanisterResult<string>}>'
         }
     };
 

--- a/src/compiler/typescript_to_javascript/index.ts
+++ b/src/compiler/typescript_to_javascript/index.ts
@@ -3,7 +3,11 @@ import * as tsc from 'typescript';
 import { buildSync } from 'esbuild';
 import { JavaScript, TypeScript } from '../../types';
 import { Result } from '../../result';
-import { createMissingTypeArgumentErrorMessage } from './errors';
+import {
+    createMissingTypeArgumentErrorMessage,
+    createMultipleTypeArgumentsErrorMessage,
+    createNonTypeLiteralErrorMessage
+} from './errors';
 import * as ts from 'typescript';
 
 export function compileTypeScriptToJavaScript(
@@ -176,17 +180,19 @@ function generateICCanisterFromTypeAliasDeclaration(
     }
 
     if (typeReferenceNode.typeArguments.length > 1) {
-        throw new Error(
-            `Generic type "Canister" in type alias "${canisterName}" requires one type argument.\nHelp: Remove all but one type argument.`
-        );
+        const errorMessage =
+            createMultipleTypeArgumentsErrorMessage(typeAliasDeclaration);
+
+        throw new Error(errorMessage);
     }
 
     const firstTypeArgument = typeReferenceNode.typeArguments[0];
 
     if (firstTypeArgument.kind !== tsc.SyntaxKind.TypeLiteral) {
-        throw new Error(
-            `Generic type "Canister" in type alias "${canisterName}" currently requires a type literal as an argument.\nHelp: Define your canister shape inline. E.g. Canister<{method(): CanisterResult<string>}>`
-        );
+        const errorMessage =
+            createNonTypeLiteralErrorMessage(typeAliasDeclaration);
+
+        throw new Error(errorMessage);
     }
 
     const typeLiteralNode = firstTypeArgument as tsc.TypeLiteralNode;

--- a/src/compiler/typescript_to_javascript/index.ts
+++ b/src/compiler/typescript_to_javascript/index.ts
@@ -156,6 +156,8 @@ function generateICCanistersFromTypeAliasDeclarations(
 function generateICCanisterFromTypeAliasDeclaration(
     typeAliasDeclaration: tsc.TypeAliasDeclaration
 ): JavaScript {
+    const canisterName = typeAliasDeclaration.name.escapedText;
+
     if (typeAliasDeclaration.type.kind !== tsc.SyntaxKind.TypeReference) {
         throw new Error('This cannot happen');
     }
@@ -163,13 +165,23 @@ function generateICCanisterFromTypeAliasDeclaration(
     const typeRefenceNode = typeAliasDeclaration.type as tsc.TypeReferenceNode;
 
     if (typeRefenceNode.typeArguments === undefined) {
-        throw new Error('This cannot happen');
+        throw new Error(
+            `Generic type "Canister" in type alias "${canisterName}" requires one type argument.\nHelp: Specify a type argument. E.g. Canister<string>.`
+        );
+    }
+
+    if (typeRefenceNode.typeArguments.length > 1) {
+        throw new Error(
+            `Generic type "Canister" in type alias "${canisterName}" requires one type argument.\nHelp: Remove all but one type argument.`
+        );
     }
 
     const firstTypeArgument = typeRefenceNode.typeArguments[0];
 
     if (firstTypeArgument.kind !== tsc.SyntaxKind.TypeLiteral) {
-        throw new Error('This cannot happen');
+        throw new Error(
+            `Generic type "Canister" in type alias "${canisterName}" currently requires a type literal as an argument.\nHelp: Define your canister shape inline. E.g. Canister<{method(): CanisterResult<string>}>`
+        );
     }
 
     const typeLiteralNode = firstTypeArgument as tsc.TypeLiteralNode;

--- a/src/compiler/typescript_to_javascript/index.ts
+++ b/src/compiler/typescript_to_javascript/index.ts
@@ -9,7 +9,6 @@ import {
     createNonTypeLiteralErrorMessage,
     createNonMethodSignatureMemberErrorMessage
 } from './errors';
-import * as ts from 'typescript';
 
 export function compileTypeScriptToJavaScript(
     ts_path: string
@@ -177,14 +176,14 @@ function generateICCanisterFromTypeAliasDeclaration(
         const errorMessage =
             createMissingTypeArgumentErrorMessage(typeAliasDeclaration);
 
-        throw new Error(errorMessage);
+        throw errorMessage;
     }
 
     if (typeReferenceNode.typeArguments.length > 1) {
         const errorMessage =
             createMultipleTypeArgumentsErrorMessage(typeAliasDeclaration);
 
-        throw new Error(errorMessage);
+        throw errorMessage;
     }
 
     const firstTypeArgument = typeReferenceNode.typeArguments[0];
@@ -193,7 +192,7 @@ function generateICCanisterFromTypeAliasDeclaration(
         const errorMessage =
             createNonTypeLiteralErrorMessage(typeAliasDeclaration);
 
-        throw new Error(errorMessage);
+        throw errorMessage;
     }
 
     let typeLiteralNode = firstTypeArgument as tsc.TypeLiteralNode;
@@ -235,7 +234,7 @@ function generateCanisterMethodFromTypeElement(
     if (typeElement.kind !== tsc.SyntaxKind.MethodSignature) {
         const errorMessage =
             createNonMethodSignatureMemberErrorMessage(typeElement);
-        throw new Error(errorMessage);
+        throw errorMessage;
     }
 
     const methodSignature = typeElement as tsc.MethodSignature;

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_binding_ident/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_binding_ident/mod.rs
@@ -1,0 +1,29 @@
+use cdk_framework::{ActDataType, ToActDataType};
+use proc_macro2::Ident;
+use quote::format_ident;
+use swc_common::SourceMap;
+use swc_ecma_ast::BindingIdent;
+
+use crate::ts_ast::{ast_traits::get_name::GetName, azle_type::AzleType};
+
+mod to_token_stream;
+
+#[derive(Clone)]
+pub struct AzleBindingIdent<'a> {
+    pub binding_ident: BindingIdent,
+    pub source_map: &'a SourceMap,
+}
+
+impl AzleBindingIdent<'_> {
+    pub fn name_as_ident(&self) -> Ident {
+        let param_name = self.binding_ident.id.get_name().to_string();
+
+        format_ident!("{}", param_name)
+    }
+
+    pub fn data_type(&self) -> ActDataType {
+        let param_ts_type = &*self.binding_ident.type_ann.as_ref().unwrap().type_ann; // TODO: Properly handle this unwrap. Combine with duplicate code above
+        let param_azle_type = AzleType::from_ts_type(param_ts_type.clone(), self.source_map);
+        param_azle_type.to_act_data_type(&None)
+    }
+}

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_binding_ident/to_token_stream.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_binding_ident/to_token_stream.rs
@@ -1,0 +1,8 @@
+impl cdk_framework::ToTokenStream for crate::ts_ast::AzleBindingIdent<'_> {
+    fn to_token_stream(&self) -> proc_macro2::TokenStream {
+        let name = self.name_as_ident();
+        let data_type = self.data_type().to_token_stream();
+
+        quote::quote! { #name: #data_type }
+    }
+}

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_functions_and_methods/ts_fn_param.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_functions_and_methods/ts_fn_param.rs
@@ -20,9 +20,13 @@ impl GetTsType for TsFnParam {
                 Some(param_type) => param_type.get_ts_type(),
                 None => panic!("Function parameter must have a type"),
             },
-            TsFnParam::Array(_) => todo!(),
-            TsFnParam::Rest(_) => todo!(),
-            TsFnParam::Object(_) => todo!(),
+            TsFnParam::Array(_) => {
+                panic!("Array destructuring in parameters is unsupported at this time")
+            }
+            TsFnParam::Rest(_) => panic!("Rest parameters are not supported at this time"),
+            TsFnParam::Object(_) => {
+                panic!("Object destructuring in parameters is unsupported at this time")
+            }
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_functions_and_methods/ts_fn_param.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_functions_and_methods/ts_fn_param.rs
@@ -18,7 +18,7 @@ impl GetTsType for TsFnParam {
         match self {
             TsFnParam::Ident(identifier) => match &identifier.type_ann {
                 Some(param_type) => param_type.get_ts_type(),
-                None => panic!("Function parameter must have a type"),
+                None => panic!("Function parameters must have a type"),
             },
             TsFnParam::Array(_) => {
                 panic!("Array destructuring in parameters is unsupported at this time")

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/mod.rs
@@ -7,11 +7,13 @@ use azle_type::AzleArrayType;
 use azle_type::AzleFnOrConstructorType;
 
 pub use ast_traits::GetName;
+pub use azle_binding_ident::AzleBindingIdent;
 pub use azle_fn_decl::AzleFnDecl;
 pub use azle_type_alias_decls::AzleTypeAliasDecl;
 pub use ts_ast::TsAst;
 
 mod ast_traits;
+mod azle_binding_ident;
 mod azle_fn_decl;
 mod azle_functions_and_methods;
 mod azle_method_signature;


### PR DESCRIPTION
This updates the error messages for edges cases when building cross-canister calls.

This catches the following errors:

- "Canister" type missing a type param
- "Canister" type having more than one type param
- "Canister" type param not being a type literal
- Non-method-signature members in the enclosed type literal

The error messages for above are surfaced from the TS layer. They don't include inline annotations but they look similar to this:

```plaintext
💣 Unable to compile TS to JS: Error: Azle requirement violation.

error: Generic type "Canister" requires one type argument
 --> canisters/errors/02_multiple_type_params.ts:3:58
  | 
  | 
  | 
  | export type MultipleTypeParams = Canister<string, string>;
  | 
help: Remove all but one type argument.
```

Additionally, this has very simple (one-line) messages for

- Array destructuring in parameters inside the "Canister" type
- Object destructing "
- Rest parameters "
- Missing paramater types "

These aren't nearly as nice. They don't include line numbers, nor even snippets. But they used to just say "Not yet implemented", so it's a step in the right direction.

Closes #773 