### PR TITLE
Add candid metadata using ic-wasm

### DIFF
--- a/src/azle.ts
+++ b/src/azle.ts
@@ -22,6 +22,7 @@ import { Err, ok, Ok, Result, unwrap } from './result';
 import { red, yellow, green, blue, purple, dim } from './colors';
 import * as tsc from 'typescript';
 import * as path from 'path';
+import { version } from '../package.json';
 
 azle();
 
@@ -48,6 +49,10 @@ function azle() {
 function addCandidToWasmMetaData(candidPath: string, wasmPath: string): void {
     execSync(
         `ic-wasm ${wasmPath} -o ${wasmPath} metadata candid:service -f ${candidPath} -v public`
+    );
+
+    execSync(
+        `ic-wasm ${wasmPath} -o ${wasmPath} metadata cdk -d "azle ${version}" -v public`
     );
 }
 
@@ -257,7 +262,7 @@ function getCanisterName(args: string[]): Result<string, AzleError> {
     const canisterNames = args.slice(2).filter((arg) => !isCliFlag(arg));
 
     if (canisterNames.length === 0) {
-        return Err({ suggestion: `azle v0.7.0\n\n${getUsageInfo()}` });
+        return Err({ suggestion: `azle v${version}\n\n${getUsageInfo()}` });
     }
 
     if (canisterNames.length > 1) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "target": "ES2020",
         "moduleResolution": "node",
         "allowJs": true,
-        "outDir": "HACK_BECAUSE_OF_ALLOW_JS"
+        "outDir": "HACK_BECAUSE_OF_ALLOW_JS",
+        "resolveJsonModule": true
     }
 }


### PR DESCRIPTION
This adds ic-wasm as a dependency, and uses it after we optimize the canister wasm to inject custom data into the wasm metadata. It adds the contents of the `.did ` file into a `icp:public candid:service` section, and "azle 0.8.0" into a `icp:public cdk` section.

> **Note**
> `ic-wasm` adds the `icp:public` part on the front. This is needed so that the custom fields can be read from the [state tree](https://internetcomputer.org/docs/current/references/ic-interface-spec/#state-tree-canister-information).

The azle version is pulled from the package.json so we don't have to change the version in multiple places.