### PR TITLE
Added snippet annotations to StableBTreeMap error messages

### DIFF
--- a/examples/stable_structures/src/invalid_declarations.ts
+++ b/examples/stable_structures/src/invalid_declarations.ts
@@ -21,11 +21,11 @@ let with_out_of_range_memory_id = new StableBTreeMap<string, string>(
 let with_float_memory_id = new StableBTreeMap<string, string>(100.5, 10, 100);
 let with_large_second_param = new StableBTreeMap<string, string>(
     0,
-    4_294_967_295,
+    4_294_967_296,
     100
 );
 let with_large_third_param = new StableBTreeMap<string, string>(
     0,
     100,
-    4_294_967_295
+    4_294_967_296
 );

--- a/src/azle.ts
+++ b/src/azle.ts
@@ -472,7 +472,7 @@ function runAzleGenerate(
         );
 
         return Err({
-            error: `${generalErrorMessage}\n\n${errorLines.join('\n')}`,
+            error: errorLines.join('\n'),
             suggestion,
             exitCode: 12
         });

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
@@ -3,7 +3,7 @@ use swc_common::SourceMap;
 use swc_ecma_ast::{BindingIdent, FnDecl, Pat, TsEntityName, TsType, TsTypeRef};
 use syn::Ident;
 
-use crate::ts_ast::{azle_type::AzleType, GetName};
+use crate::ts_ast::GetName;
 use cdk_framework::CanisterMethodType;
 
 pub mod canister_method_builder;

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
@@ -1,6 +1,44 @@
 use super::AzleNewExpr;
+use crate::{
+    errors::{ErrorMessage, Suggestion},
+    ts_ast::source_map::GetSourceFileInfo,
+};
 
 impl AzleNewExpr<'_> {
+    pub fn build_missing_type_args_error_message(&self) -> ErrorMessage {
+        let source = self.source_map.get_source(self.new_expr.span);
+
+        let type_params_start_index =
+            source.find("StableBTreeMap").unwrap() + "StableBTreeMap".len();
+        let type_params_end_index = source.find("(").unwrap();
+
+        let modified_source = [
+            source.get(..type_params_start_index).unwrap(),
+            "<KeyType, ValueType>",
+            source.get(type_params_end_index..).unwrap(),
+        ]
+        .join("");
+
+        ErrorMessage {
+            title: "missing type arguments".to_string(),
+            origin: self.source_map.get_origin(self.new_expr.span),
+            line_number: self.source_map.get_line_number(self.new_expr.span),
+            source,
+            range: (type_params_start_index, type_params_end_index + 1),
+            annotation: "Expected exactly 2 type arguments here".to_string(),
+            suggestion: Some(Suggestion {
+                title: "Specify a key and value type".to_string(),
+                source: modified_source,
+                range: (
+                    type_params_start_index,
+                    type_params_start_index + "<KeyType, ValueType>".len(),
+                ),
+                annotation: None,
+                import_suggestion: None,
+            }),
+        }
+    }
+
     pub fn build_type_arg_error_message(&self) -> String {
         let example = "\n    new StableBTreeMap<CustomKeyType, CustomValueType>(0, 100, 1000)";
         format!("The \"StableBTreeMap\" type requires exactly 2 type arguments: the key datatype, and the value datatype. E.g.\n{}", example)

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
@@ -6,21 +6,14 @@ use crate::{
 
 impl AzleNewExpr<'_> {
     pub fn build_missing_type_args_error_message(&self) -> ErrorMessage {
-        let title = "missing type arguments".to_string();
-        let source = self.get_source();
-        let range = (
-            source.find("StableBTreeMap").unwrap() + "StableBTreeMap".len(),
-            source.find("(").unwrap(),
-        );
-        let annotation = "expected exactly 2 type arguments here".to_string();
-        let help = "specify a key and value type. E.g.:".to_string();
-        let suggestion = "<KeyType, ValueType>".to_string();
-
-        self.create_error_message(title, range, annotation, help, suggestion)
+        self.build_type_arg_error_message("missing type arguments".to_string())
     }
 
     pub fn build_incorrect_type_args_error_message(&self) -> ErrorMessage {
-        let title = "wrong number of type arguments".to_string();
+        self.build_type_arg_error_message("wrong number of type arguments".to_string())
+    }
+
+    fn build_type_arg_error_message(&self, title: String) -> ErrorMessage {
         let source = self.get_source();
         let range = (
             source.find("StableBTreeMap").unwrap() + "StableBTreeMap".len(),
@@ -30,7 +23,7 @@ impl AzleNewExpr<'_> {
         let help = "specify a key and value type. E.g.:".to_string();
         let suggestion = "<KeyType, ValueType>".to_string();
 
-        self.create_error_message(title, range, annotation, help, suggestion)
+        self.build_error_message(title, range, annotation, help, suggestion)
     }
 
     pub fn build_arg_spread_error_message(&self) -> ErrorMessage {
@@ -41,23 +34,18 @@ impl AzleNewExpr<'_> {
         let help = "specify each argument individually. E.g.:".to_string();
         let suggestion = "memory_id, max_key_size, max_value_size".to_string();
 
-        self.create_error_message(title, range, annotation, help, suggestion)
+        self.build_error_message(title, range, annotation, help, suggestion)
     }
 
     pub fn build_missing_args_error_message(&self) -> ErrorMessage {
-        let title = "missing arguments".to_string();
-        let source = self.get_source();
-        let range = (source.find("(").unwrap() + 1, source.find(")").unwrap());
-        let annotation = "expected 3 arguments here".to_string();
-        let help =
-            "specify a memory id, the max key size, and the max value size. E.g.:".to_string();
-        let suggestion = "memory_id, max_key_size, max_value_size".to_string();
-
-        self.create_error_message(title, range, annotation, help, suggestion)
+        self.build_arg_error_message("missing arguments".to_string())
     }
 
     pub fn build_incorrect_number_of_args_error_message(&self) -> ErrorMessage {
-        let title = "incorrect arguments".to_string();
+        self.build_arg_error_message("incorrect arguments".to_string())
+    }
+
+    pub fn build_arg_error_message(&self, title: String) -> ErrorMessage {
         let source = self.get_source();
         let range = (source.find("(").unwrap() + 1, source.find(")").unwrap());
         let annotation = "expected exactly 3 arguments here".to_string();
@@ -65,7 +53,7 @@ impl AzleNewExpr<'_> {
             "specify a memory id, the max key size, and the max value size. E.g.:".to_string();
         let suggestion = "memory_id, max_key_size, max_value_size".to_string();
 
-        self.create_error_message(title, range, annotation, help, suggestion)
+        self.build_error_message(title, range, annotation, help, suggestion)
     }
 
     pub fn build_invalid_arg_error_message(&self, arg_name: ArgName) -> ErrorMessage {
@@ -87,7 +75,6 @@ impl AzleNewExpr<'_> {
             .find(|(i, c)| *i > open_paren_index && !c.is_whitespace())
             .map(|(i, _)| i)
             .unwrap();
-
         let message_id_end_index = source
             .char_indices()
             .find(|(i, c)| *i > message_id_start_index && c == &',')
@@ -100,7 +87,6 @@ impl AzleNewExpr<'_> {
             .find(|(i, c)| *i > message_id_end_index && !c.is_whitespace())
             .map(|(i, _)| i)
             .unwrap();
-
         let max_key_size_end_index = source
             .char_indices()
             .find(|(i, c)| *i > max_key_size_start_index && c == &',')
@@ -113,7 +99,6 @@ impl AzleNewExpr<'_> {
             .find(|(i, c)| *i > max_key_size_end_index && !c.is_whitespace())
             .map(|(i, _)| i)
             .unwrap();
-
         let max_value_size_end_index = source
             .char_indices()
             .find(|(i, c)| *i > max_value_size_start_index && (c.is_whitespace() || c == &')'))
@@ -134,10 +119,10 @@ impl AzleNewExpr<'_> {
             ArgName::MaxValueSize => "1_000".to_string(),
         };
 
-        self.create_error_message(title, range, annotation, help, suggestion)
+        self.build_error_message(title, range, annotation, help, suggestion)
     }
 
-    fn create_error_message(
+    fn build_error_message(
         &self,
         title: String,
         range: (usize, usize),

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
@@ -25,10 +25,9 @@ impl AzleNewExpr<'_> {
             line_number: self.source_map.get_line_number(self.new_expr.span),
             source,
             range: (type_params_start_index, type_params_end_index + 1),
-            annotation: "expected exactly 2 type arguments here: the key and value types"
-                .to_string(),
+            annotation: "expected exactly 2 type arguments here".to_string(),
             suggestion: Some(Suggestion {
-                title: "specify a key and value type".to_string(),
+                title: "specify a key and value type. E.g.:".to_string(),
                 source: modified_source,
                 range: (
                     type_params_start_index,
@@ -60,10 +59,9 @@ impl AzleNewExpr<'_> {
             line_number: self.source_map.get_line_number(self.new_expr.span),
             source,
             range: (type_params_start_index, type_params_end_index),
-            annotation: "expected exactly 2 type arguments here: the key and value types"
-                .to_string(),
+            annotation: "expected exactly 2 type arguments here".to_string(),
             suggestion: Some(Suggestion {
-                title: "specify a key and value type".to_string(),
+                title: "specify a key and value type. E.g.:".to_string(),
                 source: modified_source,
                 range: (
                     type_params_start_index,
@@ -75,9 +73,36 @@ impl AzleNewExpr<'_> {
         }
     }
 
-    pub fn build_arg_spread_error_message(&self) -> String {
-        let example = "\n    new StableBTreeMap<CustomKeyType, CustomValueType>(0, 100, 1000)";
-        format!("The \"StableBTreeMap\" type does not currently support argument spreading. Instead, pass each argument individually. E.g.\n{}", example)
+    pub fn build_arg_spread_error_message(&self) -> ErrorMessage {
+        let source = self.source_map.get_source(self.new_expr.span);
+
+        let args_start_index = source.find("(").unwrap() + 1;
+        let args_end_index = source.find(")").unwrap();
+
+        let args_suggestion = "memory_id, max_key_size, max_value_size".to_string();
+
+        let modified_source = [
+            source.get(..args_start_index).unwrap(),
+            &args_suggestion,
+            source.get(args_end_index..).unwrap(),
+        ]
+        .join("");
+
+        ErrorMessage {
+            title: "StableBTreeMap does not currently support argument spreading".to_string(),
+            origin: self.source_map.get_origin(self.new_expr.span),
+            line_number: self.source_map.get_line_number(self.new_expr.span),
+            source,
+            range: (args_start_index, args_end_index),
+            annotation: "attempted to spread arguments here".to_string(),
+            suggestion: Some(Suggestion {
+                title: "specify each argument individually. E.g.:".to_string(),
+                source: modified_source,
+                range: (args_start_index, args_start_index + &args_suggestion.len()),
+                annotation: None,
+                import_suggestion: None,
+            }),
+        }
     }
 
     pub fn build_arg_error_message(&self) -> String {

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
@@ -25,9 +25,10 @@ impl AzleNewExpr<'_> {
             line_number: self.source_map.get_line_number(self.new_expr.span),
             source,
             range: (type_params_start_index, type_params_end_index + 1),
-            annotation: "Expected exactly 2 type arguments here".to_string(),
+            annotation: "expected exactly 2 type arguments here: the key and value types"
+                .to_string(),
             suggestion: Some(Suggestion {
-                title: "Specify a key and value type".to_string(),
+                title: "specify a key and value type".to_string(),
                 source: modified_source,
                 range: (
                     type_params_start_index,
@@ -39,9 +40,39 @@ impl AzleNewExpr<'_> {
         }
     }
 
-    pub fn build_type_arg_error_message(&self) -> String {
-        let example = "\n    new StableBTreeMap<CustomKeyType, CustomValueType>(0, 100, 1000)";
-        format!("The \"StableBTreeMap\" type requires exactly 2 type arguments: the key datatype, and the value datatype. E.g.\n{}", example)
+    pub fn build_incorrect_type_args_error_message(&self) -> ErrorMessage {
+        let source = self.source_map.get_source(self.new_expr.span);
+
+        let type_params_start_index =
+            source.find("StableBTreeMap").unwrap() + "StableBTreeMap".len();
+        let type_params_end_index = source.find("(").unwrap();
+
+        let modified_source = [
+            source.get(..type_params_start_index).unwrap(),
+            "<KeyType, ValueType>",
+            source.get(type_params_end_index..).unwrap(),
+        ]
+        .join("");
+
+        ErrorMessage {
+            title: "wrong number of type arguments".to_string(),
+            origin: self.source_map.get_origin(self.new_expr.span),
+            line_number: self.source_map.get_line_number(self.new_expr.span),
+            source,
+            range: (type_params_start_index, type_params_end_index),
+            annotation: "expected exactly 2 type arguments here: the key and value types"
+                .to_string(),
+            suggestion: Some(Suggestion {
+                title: "specify a key and value type".to_string(),
+                source: modified_source,
+                range: (
+                    type_params_start_index,
+                    type_params_start_index + "<KeyType, ValueType>".len(),
+                ),
+                annotation: None,
+                import_suggestion: None,
+            }),
+        }
     }
 
     pub fn build_arg_spread_error_message(&self) -> String {

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
@@ -1,0 +1,42 @@
+use super::AzleNewExpr;
+
+impl AzleNewExpr<'_> {
+    pub fn build_type_arg_error_message(&self) -> String {
+        let example = "\n    new StableBTreeMap<CustomKeyType, CustomValueType>(0, 100, 1000)";
+        format!("The \"StableBTreeMap\" type requires exactly 2 type arguments: the key datatype, and the value datatype. E.g.\n{}", example)
+    }
+
+    pub fn build_arg_spread_error_message(&self) -> String {
+        let example = "\n    new StableBTreeMap<CustomKeyType, CustomValueType>(0, 100, 1000)";
+        format!("The \"StableBTreeMap\" type does not currently support argument spreading. Instead, pass each argument individually. E.g.\n{}", example)
+    }
+
+    pub fn build_arg_error_message(&self) -> String {
+        let example = "\n    new StableBTreeMap<CustomKeyType, CustomValueType>(0, 100, 1000)";
+        format!("The \"StableBTreeMap\" type requires exactly 3 arguments: an identifier, the max key length, and the max value length. E.g.\n{}", example)
+    }
+
+    pub fn build_memory_id_error_message(&self) -> String {
+        let example = "\n    new StableBTreeMap<CustomKeyType, CustomValueType>(0, 100, 1000)";
+        format!(
+            "The first argument to StableBTreeMap must be an integer literal between 0 and 255. E.g.\n{}",
+            example
+        )
+    }
+
+    pub fn build_second_argument_size_error_message(&self) -> String {
+        let example = "\n    new StableBTreeMap<CustomKeyType, CustomValueType>(0, 100, 1000)";
+        format!(
+            "The second argument to StableBTreeMap must be an integer literal between 0 and 4,294,967,295. E.g.\n{}",
+            example
+        )
+    }
+
+    pub fn build_third_argument_size_error_message(&self) -> String {
+        let example = "\n    new StableBTreeMap<CustomKeyType, CustomValueType>(0, 100, 1000)";
+        format!(
+            "The third argument to StableBTreeMap must be an integer literal between 0 and 4,294,967,295. E.g.\n{}",
+            example
+        )
+    }
+}

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
@@ -1,12 +1,12 @@
 use super::AzleNewExpr;
 use crate::{
     errors::{ErrorMessage, Suggestion},
-    ts_ast::source_map::GetSourceFileInfo,
+    ts_ast::ast_traits::GetSourceInfo,
 };
 
 impl AzleNewExpr<'_> {
     pub fn build_missing_type_args_error_message(&self) -> ErrorMessage {
-        let source = self.source_map.get_source(self.new_expr.span);
+        let source = self.get_source();
 
         let type_params_start_index =
             source.find("StableBTreeMap").unwrap() + "StableBTreeMap".len();
@@ -21,8 +21,8 @@ impl AzleNewExpr<'_> {
 
         ErrorMessage {
             title: "missing type arguments".to_string(),
-            origin: self.source_map.get_origin(self.new_expr.span),
-            line_number: self.source_map.get_line_number(self.new_expr.span),
+            origin: self.get_origin(),
+            line_number: self.get_line_number(),
             source,
             range: (type_params_start_index, type_params_end_index + 1),
             annotation: "expected exactly 2 type arguments here".to_string(),
@@ -40,7 +40,7 @@ impl AzleNewExpr<'_> {
     }
 
     pub fn build_incorrect_type_args_error_message(&self) -> ErrorMessage {
-        let source = self.source_map.get_source(self.new_expr.span);
+        let source = self.get_source();
 
         let type_params_start_index =
             source.find("StableBTreeMap").unwrap() + "StableBTreeMap".len();
@@ -55,8 +55,8 @@ impl AzleNewExpr<'_> {
 
         ErrorMessage {
             title: "wrong number of type arguments".to_string(),
-            origin: self.source_map.get_origin(self.new_expr.span),
-            line_number: self.source_map.get_line_number(self.new_expr.span),
+            origin: self.get_origin(),
+            line_number: self.get_line_number(),
             source,
             range: (type_params_start_index, type_params_end_index),
             annotation: "expected exactly 2 type arguments here".to_string(),
@@ -74,7 +74,7 @@ impl AzleNewExpr<'_> {
     }
 
     pub fn build_arg_spread_error_message(&self) -> ErrorMessage {
-        let source = self.source_map.get_source(self.new_expr.span);
+        let source = self.get_source();
 
         let args_start_index = source.find("(").unwrap() + 1;
         let args_end_index = source.find(")").unwrap();
@@ -90,8 +90,8 @@ impl AzleNewExpr<'_> {
 
         ErrorMessage {
             title: "StableBTreeMap does not currently support argument spreading".to_string(),
-            origin: self.source_map.get_origin(self.new_expr.span),
-            line_number: self.source_map.get_line_number(self.new_expr.span),
+            origin: self.get_origin(),
+            line_number: self.get_line_number(),
             source,
             range: (args_start_index, args_end_index),
             annotation: "attempted to spread arguments here".to_string(),
@@ -106,7 +106,7 @@ impl AzleNewExpr<'_> {
     }
 
     pub fn build_missing_args_error_message(&self) -> ErrorMessage {
-        let source = self.source_map.get_source(self.new_expr.span);
+        let source = self.get_source();
 
         let args_start_index = source.find("(").unwrap() + 1;
         let args_end_index = source.find(")").unwrap();
@@ -122,8 +122,8 @@ impl AzleNewExpr<'_> {
 
         ErrorMessage {
             title: "missing arguments".to_string(),
-            origin: self.source_map.get_origin(self.new_expr.span),
-            line_number: self.source_map.get_line_number(self.new_expr.span),
+            origin: self.get_origin(),
+            line_number: self.get_line_number(),
             source,
             range: (args_start_index - 1, args_end_index + 1),
             annotation: "expected 3 arguments here".to_string(),

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
@@ -138,9 +138,37 @@ impl AzleNewExpr<'_> {
         }
     }
 
-    pub fn build_arg_error_message(&self) -> String {
-        let example = "\n    new StableBTreeMap<CustomKeyType, CustomValueType>(0, 100, 1000)";
-        format!("The \"StableBTreeMap\" type requires exactly 3 arguments: an identifier, the max key length, and the max value length. E.g.\n{}", example)
+    pub fn build_incorrect_number_of_args_error_message(&self) -> ErrorMessage {
+        let source = self.get_source();
+
+        let args_start_index = source.find("(").unwrap() + 1;
+        let args_end_index = source.find(")").unwrap();
+
+        let args_suggestion = "memory_id, max_key_size, max_value_size".to_string();
+
+        let modified_source = [
+            source.get(..args_start_index).unwrap(),
+            &args_suggestion,
+            source.get(args_end_index..).unwrap(),
+        ]
+        .join("");
+
+        ErrorMessage {
+            title: "incorrect arguments".to_string(),
+            origin: self.get_origin(),
+            line_number: self.get_line_number(),
+            source,
+            range: (args_start_index - 1, args_end_index + 1),
+            annotation: "expected exactly 3 arguments here".to_string(),
+            suggestion: Some(Suggestion {
+                title: "specify a memory id, the max key size, and the max value size. E.g.:"
+                    .to_string(),
+                source: modified_source,
+                range: (args_start_index, args_start_index + &args_suggestion.len()),
+                annotation: None,
+                import_suggestion: None,
+            }),
+        }
     }
 
     pub fn build_memory_id_error_message(&self) -> String {

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/errors.rs
@@ -6,175 +6,82 @@ use crate::{
 
 impl AzleNewExpr<'_> {
     pub fn build_missing_type_args_error_message(&self) -> ErrorMessage {
+        let title = "missing type arguments".to_string();
         let source = self.get_source();
+        let range = (
+            source.find("StableBTreeMap").unwrap() + "StableBTreeMap".len(),
+            source.find("(").unwrap(),
+        );
+        let annotation = "expected exactly 2 type arguments here".to_string();
+        let help = "specify a key and value type. E.g.:".to_string();
+        let suggestion = "<KeyType, ValueType>".to_string();
 
-        let type_params_start_index =
-            source.find("StableBTreeMap").unwrap() + "StableBTreeMap".len();
-        let type_params_end_index = source.find("(").unwrap();
-
-        let modified_source = [
-            source.get(..type_params_start_index).unwrap(),
-            "<KeyType, ValueType>",
-            source.get(type_params_end_index..).unwrap(),
-        ]
-        .join("");
-
-        ErrorMessage {
-            title: "missing type arguments".to_string(),
-            origin: self.get_origin(),
-            line_number: self.get_line_number(),
-            source,
-            range: (type_params_start_index, type_params_end_index + 1),
-            annotation: "expected exactly 2 type arguments here".to_string(),
-            suggestion: Some(Suggestion {
-                title: "specify a key and value type. E.g.:".to_string(),
-                source: modified_source,
-                range: (
-                    type_params_start_index,
-                    type_params_start_index + "<KeyType, ValueType>".len(),
-                ),
-                annotation: None,
-                import_suggestion: None,
-            }),
-        }
+        self.create_error_message(title, range, annotation, help, suggestion)
     }
 
     pub fn build_incorrect_type_args_error_message(&self) -> ErrorMessage {
+        let title = "wrong number of type arguments".to_string();
         let source = self.get_source();
+        let range = (
+            source.find("StableBTreeMap").unwrap() + "StableBTreeMap".len(),
+            source.find("(").unwrap(),
+        );
+        let annotation = "expected exactly 2 type arguments here".to_string();
+        let help = "specify a key and value type. E.g.:".to_string();
+        let suggestion = "<KeyType, ValueType>".to_string();
 
-        let type_params_start_index =
-            source.find("StableBTreeMap").unwrap() + "StableBTreeMap".len();
-        let type_params_end_index = source.find("(").unwrap();
-
-        let modified_source = [
-            source.get(..type_params_start_index).unwrap(),
-            "<KeyType, ValueType>",
-            source.get(type_params_end_index..).unwrap(),
-        ]
-        .join("");
-
-        ErrorMessage {
-            title: "wrong number of type arguments".to_string(),
-            origin: self.get_origin(),
-            line_number: self.get_line_number(),
-            source,
-            range: (type_params_start_index, type_params_end_index),
-            annotation: "expected exactly 2 type arguments here".to_string(),
-            suggestion: Some(Suggestion {
-                title: "specify a key and value type. E.g.:".to_string(),
-                source: modified_source,
-                range: (
-                    type_params_start_index,
-                    type_params_start_index + "<KeyType, ValueType>".len(),
-                ),
-                annotation: None,
-                import_suggestion: None,
-            }),
-        }
+        self.create_error_message(title, range, annotation, help, suggestion)
     }
 
     pub fn build_arg_spread_error_message(&self) -> ErrorMessage {
+        let title = "StableBTreeMap does not currently support argument spreading".to_string();
         let source = self.get_source();
+        let range = (source.find("(").unwrap() + 1, source.find(")").unwrap());
+        let annotation = "attempted to spread arguments here".to_string();
+        let help = "specify each argument individually. E.g.:".to_string();
+        let suggestion = "memory_id, max_key_size, max_value_size".to_string();
 
-        let args_start_index = source.find("(").unwrap() + 1;
-        let args_end_index = source.find(")").unwrap();
-
-        let args_suggestion = "memory_id, max_key_size, max_value_size".to_string();
-
-        let modified_source = [
-            source.get(..args_start_index).unwrap(),
-            &args_suggestion,
-            source.get(args_end_index..).unwrap(),
-        ]
-        .join("");
-
-        ErrorMessage {
-            title: "StableBTreeMap does not currently support argument spreading".to_string(),
-            origin: self.get_origin(),
-            line_number: self.get_line_number(),
-            source,
-            range: (args_start_index, args_end_index),
-            annotation: "attempted to spread arguments here".to_string(),
-            suggestion: Some(Suggestion {
-                title: "specify each argument individually. E.g.:".to_string(),
-                source: modified_source,
-                range: (args_start_index, args_start_index + &args_suggestion.len()),
-                annotation: None,
-                import_suggestion: None,
-            }),
-        }
+        self.create_error_message(title, range, annotation, help, suggestion)
     }
 
     pub fn build_missing_args_error_message(&self) -> ErrorMessage {
+        let title = "missing arguments".to_string();
         let source = self.get_source();
+        let range = (source.find("(").unwrap() + 1, source.find(")").unwrap());
+        let annotation = "expected 3 arguments here".to_string();
+        let help =
+            "specify a memory id, the max key size, and the max value size. E.g.:".to_string();
+        let suggestion = "memory_id, max_key_size, max_value_size".to_string();
 
-        let args_start_index = source.find("(").unwrap() + 1;
-        let args_end_index = source.find(")").unwrap();
-
-        let args_suggestion = "memory_id, max_key_size, max_value_size".to_string();
-
-        let modified_source = [
-            source.get(..args_start_index).unwrap(),
-            &args_suggestion,
-            source.get(args_end_index..).unwrap(),
-        ]
-        .join("");
-
-        ErrorMessage {
-            title: "missing arguments".to_string(),
-            origin: self.get_origin(),
-            line_number: self.get_line_number(),
-            source,
-            range: (args_start_index - 1, args_end_index + 1),
-            annotation: "expected 3 arguments here".to_string(),
-            suggestion: Some(Suggestion {
-                title: "specify a memory id, the max key size, and the max value size. E.g.:"
-                    .to_string(),
-                source: modified_source,
-                range: (args_start_index, args_start_index + &args_suggestion.len()),
-                annotation: None,
-                import_suggestion: None,
-            }),
-        }
+        self.create_error_message(title, range, annotation, help, suggestion)
     }
 
     pub fn build_incorrect_number_of_args_error_message(&self) -> ErrorMessage {
+        let title = "incorrect arguments".to_string();
         let source = self.get_source();
+        let range = (source.find("(").unwrap() + 1, source.find(")").unwrap());
+        let annotation = "expected exactly 3 arguments here".to_string();
+        let help =
+            "specify a memory id, the max key size, and the max value size. E.g.:".to_string();
+        let suggestion = "memory_id, max_key_size, max_value_size".to_string();
 
-        let args_start_index = source.find("(").unwrap() + 1;
-        let args_end_index = source.find(")").unwrap();
-
-        let args_suggestion = "memory_id, max_key_size, max_value_size".to_string();
-
-        let modified_source = [
-            source.get(..args_start_index).unwrap(),
-            &args_suggestion,
-            source.get(args_end_index..).unwrap(),
-        ]
-        .join("");
-
-        ErrorMessage {
-            title: "incorrect arguments".to_string(),
-            origin: self.get_origin(),
-            line_number: self.get_line_number(),
-            source,
-            range: (args_start_index - 1, args_end_index + 1),
-            annotation: "expected exactly 3 arguments here".to_string(),
-            suggestion: Some(Suggestion {
-                title: "specify a memory id, the max key size, and the max value size. E.g.:"
-                    .to_string(),
-                source: modified_source,
-                range: (args_start_index, args_start_index + &args_suggestion.len()),
-                annotation: None,
-                import_suggestion: None,
-            }),
-        }
+        self.create_error_message(title, range, annotation, help, suggestion)
     }
 
     pub fn build_invalid_arg_error_message(&self, arg_name: ArgName) -> ErrorMessage {
-        let source = self.get_source();
+        let max_size = match arg_name {
+            ArgName::MessageId => "255".to_string(),
+            ArgName::MaxKeySize => "4,294,967,295".to_string(),
+            ArgName::MaxValueSize => "4,294,967,295".to_string(),
+        };
+        let title = format!(
+            "invalid argument: must be an integer literal between 0 and {} inclusive",
+            max_size
+        );
 
+        let source = self.get_source();
         let open_paren_index = source.find("(").unwrap();
+
         let message_id_start_index = source
             .char_indices()
             .find(|(i, c)| *i > open_paren_index && !c.is_whitespace())
@@ -186,6 +93,7 @@ impl AzleNewExpr<'_> {
             .find(|(i, c)| *i > message_id_start_index && c == &',')
             .map(|(i, _)| i)
             .unwrap();
+        let message_id_range = (message_id_start_index, message_id_end_index);
 
         let max_key_size_start_index = source
             .char_indices()
@@ -198,6 +106,7 @@ impl AzleNewExpr<'_> {
             .find(|(i, c)| *i > max_key_size_start_index && c == &',')
             .map(|(i, _)| i)
             .unwrap();
+        let max_key_size_range = (max_key_size_start_index, max_key_size_end_index);
 
         let max_value_size_start_index = source
             .char_indices()
@@ -210,73 +119,57 @@ impl AzleNewExpr<'_> {
             .find(|(i, c)| *i > max_value_size_start_index && (c.is_whitespace() || c == &')'))
             .map(|(i, _)| i)
             .unwrap();
+        let max_value_size_range = (max_value_size_start_index, max_value_size_end_index);
 
-        let suggested_replacement = match arg_name {
+        let range = match arg_name {
+            ArgName::MessageId => message_id_range,
+            ArgName::MaxKeySize => max_key_size_range,
+            ArgName::MaxValueSize => max_value_size_range,
+        };
+        let annotation = "expected here".to_string();
+        let help = "use a valid integer literal. E.g.:".to_string();
+        let suggestion = match arg_name {
             ArgName::MessageId => "0".to_string(),
             ArgName::MaxKeySize => "100".to_string(),
             ArgName::MaxValueSize => "1_000".to_string(),
         };
 
-        let modified_source = match arg_name {
-            ArgName::MessageId => [
-                source.get(..message_id_start_index).unwrap(),
-                &suggested_replacement,
-                source.get(message_id_end_index..).unwrap(),
-            ]
-            .join(""),
-            ArgName::MaxKeySize => [
-                source.get(..max_key_size_start_index).unwrap(),
-                &suggested_replacement,
-                source.get(max_key_size_end_index..).unwrap(),
-            ]
-            .join(""),
-            ArgName::MaxValueSize => [
-                source.get(..max_value_size_start_index).unwrap(),
-                &suggested_replacement,
-                source.get(max_value_size_end_index..).unwrap(),
-            ]
-            .join(""),
+        self.create_error_message(title, range, annotation, help, suggestion)
+    }
+
+    fn create_error_message(
+        &self,
+        title: String,
+        range: (usize, usize),
+        annotation: String,
+        help: String,
+        suggestion: String,
+    ) -> ErrorMessage {
+        let source = self.get_source();
+        let adjusted_range = if range.0 == range.1 {
+            (range.0, range.1 + 1)
+        } else {
+            range
         };
 
-        let range = match arg_name {
-            ArgName::MessageId => (message_id_start_index, message_id_end_index),
-            ArgName::MaxKeySize => (max_key_size_start_index, max_key_size_end_index),
-            ArgName::MaxValueSize => (max_value_size_start_index, max_value_size_end_index),
-        };
+        let modified_source = [
+            source.get(..range.0).unwrap(),
+            &suggestion,
+            source.get(range.1..).unwrap(),
+        ]
+        .join("");
 
-        let suggestion_range = match arg_name {
-            ArgName::MessageId => (
-                message_id_start_index,
-                message_id_start_index + &suggested_replacement.len(),
-            ),
-            ArgName::MaxKeySize => (
-                max_key_size_start_index,
-                max_key_size_start_index + &suggested_replacement.len(),
-            ),
-            ArgName::MaxValueSize => (
-                max_value_size_start_index,
-                max_value_size_start_index + &suggested_replacement.len(),
-            ),
-        };
-
-        let max_size = match arg_name {
-            ArgName::MessageId => "255".to_string(),
-            ArgName::MaxKeySize => "4,294,967,295".to_string(),
-            ArgName::MaxValueSize => "4,294,967,295".to_string(),
-        };
+        let suggestion_range = (range.0, range.0 + &suggestion.len());
 
         ErrorMessage {
-            title: format!(
-                "invalid argument: must be an integer literal between 0 and {} inclusive",
-                max_size
-            ),
+            title,
             origin: self.get_origin(),
             line_number: self.get_line_number(),
-            source,
-            range,
-            annotation: "expected here".to_string(),
+            source: self.get_source(),
+            range: adjusted_range,
+            annotation,
             suggestion: Some(Suggestion {
-                title: "use a valid integer literal. E.g.:".to_string(),
+                title: help,
                 source: modified_source,
                 range: suggestion_range,
                 annotation: None,

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/get_source_info.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/get_source_info.rs
@@ -1,0 +1,20 @@
+use super::AzleNewExpr;
+use crate::ts_ast::{ast_traits::GetSourceInfo, source_map::GetSourceFileInfo};
+
+impl GetSourceInfo for AzleNewExpr<'_> {
+    fn get_source(&self) -> String {
+        self.source_map.get_source(self.new_expr.span)
+    }
+
+    fn get_line_number(&self) -> usize {
+        self.source_map.get_line_number(self.new_expr.span)
+    }
+
+    fn get_origin(&self) -> String {
+        self.source_map.get_origin(self.new_expr.span)
+    }
+
+    fn get_range(&self) -> (usize, usize) {
+        self.source_map.get_range(self.new_expr.span)
+    }
+}

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/get_source_info.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/get_source_info.rs
@@ -3,7 +3,8 @@ use crate::ts_ast::{ast_traits::GetSourceInfo, source_map::GetSourceFileInfo};
 
 impl GetSourceInfo for AzleNewExpr<'_> {
     fn get_source(&self) -> String {
-        self.source_map.get_source(self.new_expr.span)
+        self.source_map
+            .get_source_from_range((self.new_expr.span.lo, self.new_expr.span.hi))
     }
 
     fn get_line_number(&self) -> usize {

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/mod.rs
@@ -2,6 +2,7 @@ use swc_common::SourceMap;
 use swc_ecma_ast::NewExpr;
 
 mod errors;
+mod get_source_info;
 mod to_stable_b_tree_map;
 
 #[derive(Clone)]

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/mod.rs
@@ -1,6 +1,7 @@
 use swc_common::SourceMap;
 use swc_ecma_ast::NewExpr;
 
+mod errors;
 mod to_stable_b_tree_map;
 
 #[derive(Clone)]

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
@@ -29,7 +29,7 @@ impl AzleNewExpr<'_> {
                         }
 
                         if args.len() != 3 {
-                            return Err(arg_error_message);
+                            return Err(self.build_missing_args_error_message().to_string());
                         }
 
                         let memory_id = match &args.get(0).unwrap().expr.to_u8() {

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
@@ -4,11 +4,14 @@ use crate::{
     AzleStableBTreeMapNode,
 };
 
+pub enum ArgName {
+    MessageId,
+    MaxKeySize,
+    MaxValueSize,
+}
+
 impl AzleNewExpr<'_> {
     pub fn to_azle_stable_b_tree_map_node(&self) -> Result<AzleStableBTreeMapNode, String> {
-        let second_argument_size_error_message = self.build_second_argument_size_error_message();
-        let third_argument_size_error_message = self.build_third_argument_size_error_message();
-
         match &self.new_expr.type_args {
             Some(type_args) => {
                 if type_args.params.len() != 2 {
@@ -38,17 +41,29 @@ impl AzleNewExpr<'_> {
 
                         let memory_id = match &args.get(0).unwrap().expr.to_u8() {
                             Ok(value) => *value,
-                            Err(_) => return Err(self.build_memory_id_error_message().to_string()),
+                            Err(_) => {
+                                return Err(self
+                                    .build_invalid_arg_error_message(ArgName::MessageId)
+                                    .to_string())
+                            }
                         };
 
                         let max_key_size = match &args.get(1).unwrap().expr.to_u32() {
                             Ok(value) => *value,
-                            Err(_) => return Err(second_argument_size_error_message),
+                            Err(_) => {
+                                return Err(self
+                                    .build_invalid_arg_error_message(ArgName::MaxKeySize)
+                                    .to_string())
+                            }
                         };
 
                         let max_value_size = match &args.get(2).unwrap().expr.to_u32() {
                             Ok(value) => *value,
-                            Err(_) => return Err(third_argument_size_error_message),
+                            Err(_) => {
+                                return Err(self
+                                    .build_invalid_arg_error_message(ArgName::MaxValueSize)
+                                    .to_string())
+                            }
                         };
 
                         Ok(AzleStableBTreeMapNode {

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
@@ -6,7 +6,6 @@ use crate::{
 
 impl AzleNewExpr<'_> {
     pub fn to_azle_stable_b_tree_map_node(&self) -> Result<AzleStableBTreeMapNode, String> {
-        let arg_spread_error_message = self.build_arg_spread_error_message();
         let arg_error_message = self.build_arg_error_message();
         let memory_id_error_message = self.build_memory_id_error_message();
         let second_argument_size_error_message = self.build_second_argument_size_error_message();
@@ -25,7 +24,7 @@ impl AzleNewExpr<'_> {
                     Some(args) => {
                         for arg in args {
                             if arg.spread.is_some() {
-                                return Err(arg_spread_error_message);
+                                return Err(self.build_arg_spread_error_message().to_string());
                             }
                         }
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
@@ -6,8 +6,6 @@ use crate::{
 
 impl AzleNewExpr<'_> {
     pub fn to_azle_stable_b_tree_map_node(&self) -> Result<AzleStableBTreeMapNode, String> {
-        let missing_type_args_error_message = self.build_missing_type_args_error_message();
-        let type_arg_error_message = self.build_type_arg_error_message();
         let arg_spread_error_message = self.build_arg_spread_error_message();
         let arg_error_message = self.build_arg_error_message();
         let memory_id_error_message = self.build_memory_id_error_message();
@@ -17,7 +15,7 @@ impl AzleNewExpr<'_> {
         match &self.new_expr.type_args {
             Some(type_args) => {
                 if type_args.params.len() != 2 {
-                    return Err(type_arg_error_message);
+                    return Err(self.build_incorrect_type_args_error_message().to_string());
                 }
 
                 let key_type = *type_args.params.get(0).unwrap().clone();
@@ -61,7 +59,7 @@ impl AzleNewExpr<'_> {
                     None => Err(arg_error_message),
                 }
             }
-            None => Err(missing_type_args_error_message.to_string()),
+            None => Err(self.build_missing_type_args_error_message().to_string()),
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
@@ -6,7 +6,6 @@ use crate::{
 
 impl AzleNewExpr<'_> {
     pub fn to_azle_stable_b_tree_map_node(&self) -> Result<AzleStableBTreeMapNode, String> {
-        let arg_error_message = self.build_arg_error_message();
         let memory_id_error_message = self.build_memory_id_error_message();
         let second_argument_size_error_message = self.build_second_argument_size_error_message();
         let third_argument_size_error_message = self.build_third_argument_size_error_message();
@@ -22,6 +21,10 @@ impl AzleNewExpr<'_> {
 
                 match &self.new_expr.args {
                     Some(args) => {
+                        if args.len() == 0 {
+                            return Err(self.build_missing_args_error_message().to_string());
+                        }
+
                         for arg in args {
                             if arg.spread.is_some() {
                                 return Err(self.build_arg_spread_error_message().to_string());
@@ -29,7 +32,9 @@ impl AzleNewExpr<'_> {
                         }
 
                         if args.len() != 3 {
-                            return Err(self.build_missing_args_error_message().to_string());
+                            return Err(self
+                                .build_incorrect_number_of_args_error_message()
+                                .to_string());
                         }
 
                         let memory_id = match &args.get(0).unwrap().expr.to_u8() {
@@ -55,7 +60,7 @@ impl AzleNewExpr<'_> {
                             max_value_size,
                         })
                     }
-                    None => Err(arg_error_message),
+                    None => Err(self.build_missing_args_error_message().to_string()),
                 }
             }
             None => Err(self.build_missing_type_args_error_message().to_string()),

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
@@ -6,6 +6,7 @@ use crate::{
 
 impl AzleNewExpr<'_> {
     pub fn to_azle_stable_b_tree_map_node(&self) -> Result<AzleStableBTreeMapNode, String> {
+        let missing_type_args_error_message = self.build_missing_type_args_error_message();
         let type_arg_error_message = self.build_type_arg_error_message();
         let arg_spread_error_message = self.build_arg_spread_error_message();
         let arg_error_message = self.build_arg_error_message();
@@ -60,7 +61,7 @@ impl AzleNewExpr<'_> {
                     None => Err(arg_error_message),
                 }
             }
-            None => Err(type_arg_error_message),
+            None => Err(missing_type_args_error_message.to_string()),
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
@@ -6,22 +6,12 @@ use crate::{
 
 impl AzleNewExpr<'_> {
     pub fn to_azle_stable_b_tree_map_node(&self) -> Result<AzleStableBTreeMapNode, String> {
-        let example = "\n    new StableBTreeMap<CustomKeyType, CustomValueType>(0, 100, 1000)";
-        let type_arg_error_message = format!("The \"StableBTreeMap\" type requires exactly 2 type arguments: the key datatype, and the value datatype. E.g.\n{}", example);
-        let arg_spread_error_message = format!("The \"StableBTreeMap\" type does not currently support argument spreading. Instead, pass each argument individually. E.g.\n{}", example);
-        let arg_error_message = format!("The \"StableBTreeMap\" type requires exactly 3 arguments: an identifier, the max key length, and the max value length. E.g.\n{}", example);
-        let memory_id_error_message = format!(
-            "The first argument to StableBTreeMap must be an integer literal between 0 and 255. E.g.\n{}",
-            example
-        );
-        let second_argument_size_error_message = format!(
-            "The second argument to StableBTreeMap must be an integer literal between 0 and 4,294,967,295. E.g.\n{}",
-            example
-        );
-        let third_argument_size_error_message = format!(
-            "The third argument to StableBTreeMap must be an integer literal between 0 and 4,294,967,295. E.g.\n{}",
-            example
-        );
+        let type_arg_error_message = self.build_type_arg_error_message();
+        let arg_spread_error_message = self.build_arg_spread_error_message();
+        let arg_error_message = self.build_arg_error_message();
+        let memory_id_error_message = self.build_memory_id_error_message();
+        let second_argument_size_error_message = self.build_second_argument_size_error_message();
+        let third_argument_size_error_message = self.build_third_argument_size_error_message();
 
         match &self.new_expr.type_args {
             Some(type_args) => {

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
@@ -1,5 +1,6 @@
 use super::AzleNewExpr;
 use crate::{
+    errors::ErrorMessage,
     utils::{ToU32, ToU8},
     AzleStableBTreeMapNode,
 };
@@ -11,11 +12,11 @@ pub enum ArgName {
 }
 
 impl AzleNewExpr<'_> {
-    pub fn to_azle_stable_b_tree_map_node(&self) -> Result<AzleStableBTreeMapNode, String> {
+    pub fn to_azle_stable_b_tree_map_node(&self) -> Result<AzleStableBTreeMapNode, ErrorMessage> {
         match &self.new_expr.type_args {
             Some(type_args) => {
                 if type_args.params.len() != 2 {
-                    return Err(self.build_incorrect_type_args_error_message().to_string());
+                    return Err(self.build_incorrect_type_args_error_message());
                 }
 
                 let key_type = *type_args.params.get(0).unwrap().clone();
@@ -24,45 +25,41 @@ impl AzleNewExpr<'_> {
                 match &self.new_expr.args {
                     Some(args) => {
                         if args.len() == 0 {
-                            return Err(self.build_missing_args_error_message().to_string());
+                            return Err(self.build_missing_args_error_message());
                         }
 
                         for arg in args {
                             if arg.spread.is_some() {
-                                return Err(self.build_arg_spread_error_message().to_string());
+                                return Err(self.build_arg_spread_error_message());
                             }
                         }
 
                         if args.len() != 3 {
-                            return Err(self
-                                .build_incorrect_number_of_args_error_message()
-                                .to_string());
+                            return Err(self.build_incorrect_number_of_args_error_message());
                         }
 
                         let memory_id = match &args.get(0).unwrap().expr.to_u8() {
                             Ok(value) => *value,
                             Err(_) => {
-                                return Err(self
-                                    .build_invalid_arg_error_message(ArgName::MessageId)
-                                    .to_string())
+                                return Err(self.build_invalid_arg_error_message(ArgName::MessageId))
                             }
                         };
 
                         let max_key_size = match &args.get(1).unwrap().expr.to_u32() {
                             Ok(value) => *value,
                             Err(_) => {
-                                return Err(self
-                                    .build_invalid_arg_error_message(ArgName::MaxKeySize)
-                                    .to_string())
+                                return Err(
+                                    self.build_invalid_arg_error_message(ArgName::MaxKeySize)
+                                )
                             }
                         };
 
                         let max_value_size = match &args.get(2).unwrap().expr.to_u32() {
                             Ok(value) => *value,
                             Err(_) => {
-                                return Err(self
-                                    .build_invalid_arg_error_message(ArgName::MaxValueSize)
-                                    .to_string())
+                                return Err(
+                                    self.build_invalid_arg_error_message(ArgName::MaxValueSize)
+                                )
                             }
                         };
 
@@ -74,10 +71,10 @@ impl AzleNewExpr<'_> {
                             max_value_size,
                         })
                     }
-                    None => Err(self.build_missing_args_error_message().to_string()),
+                    None => Err(self.build_missing_args_error_message()),
                 }
             }
-            None => Err(self.build_missing_type_args_error_message().to_string()),
+            None => Err(self.build_missing_type_args_error_message()),
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_new_expr/to_stable_b_tree_map.rs
@@ -6,7 +6,6 @@ use crate::{
 
 impl AzleNewExpr<'_> {
     pub fn to_azle_stable_b_tree_map_node(&self) -> Result<AzleStableBTreeMapNode, String> {
-        let memory_id_error_message = self.build_memory_id_error_message();
         let second_argument_size_error_message = self.build_second_argument_size_error_message();
         let third_argument_size_error_message = self.build_third_argument_size_error_message();
 
@@ -39,7 +38,7 @@ impl AzleNewExpr<'_> {
 
                         let memory_id = match &args.get(0).unwrap().expr.to_u8() {
                             Ok(value) => *value,
-                            Err(_) => return Err(memory_id_error_message),
+                            Err(_) => return Err(self.build_memory_id_error_message().to_string()),
                         };
 
                         let max_key_size = match &args.get(1).unwrap().expr.to_u32() {


### PR DESCRIPTION
This beefs up the error messages that are displayed when a StableBTreeMap is incorrectly instantiated.

For example, given the following instantiation:

```ts
import { StableBTreeMap } from 'azle';

let without_type_params = new StableBTreeMap(0, 10, 100);
```

the compiler will output:

```ts
Building canister canister1

[1/3] 🔨 Compiling TypeScript...

💣 error: missing type arguments
 --> /home/dan/repos/demergent-labs/azle/examples/stable_structures/src/canister1/index.ts:3:45
  |
3 | let without_type_params = new StableBTreeMap(0, 10, 100);
  |                                             ^ expected exactly 2 type arguments here
  |
help: specify a key and value type. E.g.:
  |
3 | let without_type_params = new StableBTreeMap<KeyType, ValueType>(0, 10, 100);
  |                                             --------------------
  |

If you are unable to decipher the error above, reach out in the #typescript
channel of the DFINITY DEV OFFICIAL discord:
https://discord.com/channels/748416164832608337/956466775380336680

💀 Build failed
```

Closes #852 