### PR TITLE
Changed Manual return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2053,9 +2053,9 @@ Examples:
 -   [rejections](/examples/rejections)
 
 ```typescript
-import { empty, ic, QueryManual } from 'azle';
+import { empty, ic, Manual, Query } from 'azle';
 
-export function reject(message: string): QueryManual<empty> {
+export function reject(message: string): Query<Manual<empty>> {
     ic.reject(message);
 }
 ```
@@ -2120,9 +2120,9 @@ Examples:
 -   [manual_reply](/examples/manual_reply)
 
 ```typescript
-import { ic, UpdateManual } from 'azle';
+import { ic, Manual, Update } from 'azle';
 
-export function manual_update(message: string): UpdateManual<string> {
+export function manual_update(message: string): Update<Manual<string>> {
     if (message === 'reject') {
         ic.reject(message);
         return;
@@ -2139,7 +2139,7 @@ Examples:
 -   [manual_reply](/examples/manual_reply)
 
 ```typescript
-import { blob, ic, int, UpdateManual, Variant } from 'azle';
+import { blob, ic, int, Manual, Update, Variant } from 'azle';
 
 type RawReply = {
     int: int;
@@ -2155,7 +2155,7 @@ type Options = Variant<{
     Large: null;
 }>;
 
-export function reply_raw(): UpdateManual<RawReply> {
+export function reply_raw(): Update<Manual<RawReply>> {
     ic.reply_raw(
         ic.candid_encode(
             '(record { "int" = 42; "text" = "text"; "bool" = true; "blob" = blob "Surprise!"; "variant" = variant { Medium } })'

--- a/examples/ic_api/src/ic_api.ts
+++ b/examples/ic_api/src/ic_api.ts
@@ -3,13 +3,13 @@ import {
     empty,
     ic,
     int8,
+    Manual,
     nat,
     nat32,
     nat64,
     Opt,
     Principal,
     Query,
-    QueryManual,
     Update
 } from 'azle';
 
@@ -109,7 +109,7 @@ export function print(message: string): Query<boolean> {
     return true;
 }
 
-export function reject(message: string): QueryManual<empty> {
+export function reject(message: string): Query<Manual<empty>> {
     ic.reject(message);
 }
 

--- a/examples/manual_reply/src/manual_reply.ts
+++ b/examples/manual_reply/src/manual_reply.ts
@@ -4,11 +4,12 @@ import {
     ic,
     int,
     int8,
+    Manual,
     nat,
     nat8,
-    QueryManual,
+    Query,
     reserved,
-    UpdateManual,
+    Update,
     Variant
 } from 'azle';
 
@@ -55,7 +56,7 @@ type Gas = Variant<{
 
 // Updates
 
-export function manual_update(message: string): UpdateManual<string> {
+export function manual_update(message: string): Update<Manual<string>> {
     if (message === 'reject') {
         ic.reject(message);
         return;
@@ -64,33 +65,33 @@ export function manual_update(message: string): UpdateManual<string> {
     ic.reply(message);
 }
 
-export function update_blob(): UpdateManual<blob> {
+export function update_blob(): Update<Manual<blob>> {
     ic.reply(new Uint8Array([83, 117, 114, 112, 114, 105, 115, 101, 33]));
 }
 
-export function update_float32(): UpdateManual<float32> {
+export function update_float32(): Update<Manual<float32>> {
     ic.reply(1245.678);
 }
 
 // TODO: Inline Types not currently supported.
 // See https://github.com/demergent-labs/azle/issues/474
-// export function update_inline_type(): UpdateManual<{ prop: string }> {
+// export function update_inline_type(): Update<Manual<{ prop: string }>> {
 //     ic.reply({ prop: 'prop' });
 // }
 
-export function update_int8(): UpdateManual<int8> {
+export function update_int8(): Update<Manual<int8>> {
     ic.reply(-100);
 }
 
-export function update_nat(): UpdateManual<nat> {
+export function update_nat(): Update<Manual<nat>> {
     ic.reply(184467440737095516150n);
 }
 
-export function update_null(): UpdateManual<null> {
+export function update_null(): Update<Manual<null>> {
     ic.reply(null);
 }
 
-export function update_record(): UpdateManual<Element> {
+export function update_record(): Update<Manual<Element>> {
     const element: Element = {
         id: 'b0283eb7-9c0e-41e5-8089-3345e6a8fa6a',
         orbitals: [
@@ -110,22 +111,22 @@ export function update_record(): UpdateManual<Element> {
     ic.reply(element);
 }
 
-export function update_reserved(): UpdateManual<reserved> {
+export function update_reserved(): Update<Manual<reserved>> {
     ic.reply(undefined);
 }
 
-export function update_string(): UpdateManual<string> {
+export function update_string(): Update<Manual<string>> {
     ic.reply('hello');
 }
 
-export function update_variant(): UpdateManual<Gas> {
+export function update_variant(): Update<Manual<Gas>> {
     const gas = { Toxic: null };
     ic.reply(gas);
 }
 
 // Queries
 
-export function manual_query(message: string): QueryManual<string> {
+export function manual_query(message: string): Query<Manual<string>> {
     if (message === 'reject') {
         ic.reject(message);
         return;
@@ -134,33 +135,33 @@ export function manual_query(message: string): QueryManual<string> {
     ic.reply(message);
 }
 
-export function query_blob(): QueryManual<blob> {
+export function query_blob(): Query<Manual<blob>> {
     ic.reply(new Uint8Array([83, 117, 114, 112, 114, 105, 115, 101, 33]));
 }
 
-export function query_float32(): QueryManual<float32> {
+export function query_float32(): Query<Manual<float32>> {
     ic.reply(1245.678);
 }
 
 // TODO: Inline Types not currently supported.
 // See https://github.com/demergent-labs/azle/issues/474
-// export function query_inline_type(): QueryManual<{ prop: string }> {
+// export function query_inline_type(): Query<Manual<{> prop: string }> {
 //     ic.reply({ prop: 'prop' });
 // }
 
-export function query_int8(): QueryManual<int8> {
+export function query_int8(): Query<Manual<int8>> {
     ic.reply(-100);
 }
 
-export function query_nat(): QueryManual<nat> {
+export function query_nat(): Query<Manual<nat>> {
     ic.reply(184_467_440_737_095_516_150n);
 }
 
-export function query_null(): QueryManual<null> {
+export function query_null(): Query<Manual<null>> {
     ic.reply(null);
 }
 
-export function query_record(): QueryManual<Element> {
+export function query_record(): Query<Manual<Element>> {
     const element: Element = {
         id: 'b0283eb7-9c0e-41e5-8089-3345e6a8fa6a',
         orbitals: [
@@ -180,20 +181,20 @@ export function query_record(): QueryManual<Element> {
     ic.reply(element);
 }
 
-export function query_reserved(): QueryManual<reserved> {
+export function query_reserved(): Query<Manual<reserved>> {
     ic.reply(undefined);
 }
 
-export function query_string(): QueryManual<string> {
+export function query_string(): Query<Manual<string>> {
     ic.reply('hello');
 }
 
-export function query_variant(): QueryManual<Gas> {
+export function query_variant(): Query<Manual<Gas>> {
     const gas = { Toxic: null };
     ic.reply(gas);
 }
 
-export function reply_raw(): UpdateManual<RawReply> {
+export function reply_raw(): Update<Manual<RawReply>> {
     ic.reply_raw(
         ic.candid_encode(
             '(record { "int" = 42; "text" = "text"; "bool" = true; "blob" = blob "Surprise!"; "variant" = variant { Medium } })'

--- a/examples/outgoing_http_requests/src/index.ts
+++ b/examples/outgoing_http_requests/src/index.ts
@@ -1,4 +1,4 @@
-import { ic, ok, Principal, Query, Update, UpdateManual } from 'azle';
+import { ic, Manual, ok, Principal, Query, Update } from 'azle';
 import {
     HttpResponse,
     HttpTransformArgs,
@@ -38,7 +38,7 @@ export async function xkcd(): Promise<Update<HttpResponse>> {
     return http_result.ok;
 }
 
-export async function xkcd_raw(): Promise<UpdateManual<HttpResponse>> {
+export async function xkcd_raw(): Promise<Update<Manual<HttpResponse>>> {
     const max_response_bytes = 1_000n;
 
     // TODO this is just a hueristic for cost, might change when the feature is officially released: https://forum.dfinity.org/t/enable-canisters-to-make-http-s-requests/9670/130

--- a/examples/rejections/canisters/some_service/some_service.ts
+++ b/examples/rejections/canisters/some_service/some_service.ts
@@ -1,13 +1,13 @@
-import { empty, ic, Query, QueryManual } from 'azle';
+import { empty, ic, Manual, Query } from 'azle';
 
 export function accept(): Query<boolean> {
     return true;
 }
 
-export function error(): QueryManual<empty> {
+export function error(): Query<Manual<empty>> {
     // This errors because neither ic.reject nor ic.reply were called
 }
 
-export function reject(message: string): QueryManual<empty> {
+export function reject(message: string): Query<Manual<empty>> {
     ic.reject(message);
 }

--- a/index.ts
+++ b/index.ts
@@ -156,9 +156,8 @@ export type Heartbeat = void;
 export type Init = void;
 export type InspectMessage = void;
 export type Query<T> = T;
-export type QueryManual<T> = void;
+export type Manual<T> = void;
 export type Update<T> = T;
-export type UpdateManual<T> = void;
 export type Oneway = void;
 
 // TODO see if we can get the T here to have some more information, like the func type

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/errors.rs
@@ -75,7 +75,7 @@ impl AzleFnDecl<'_> {
     }
 
     pub(super) fn build_non_type_ref_return_type_error_msg(&self) -> String {
-        "Canister method return types must be one of: Init, InspectMessage, Oneway, PostUpgrade, PreUpgrade, Promise, Query, QueryManual, Update, UpdateManual".to_string()
+        "Canister method return types must be one of: Init, InspectMessage, Oneway, PostUpgrade, PreUpgrade, Promise, Query, Update".to_string()
     }
 
     pub(super) fn build_object_destructure_error_msg(&self, param: &Param) -> ErrorMessage {

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_fn_decl/mod.rs
@@ -31,27 +31,20 @@ impl AzleFnDecl<'_> {
     }
 
     pub fn get_return_type_ref(&self) -> &TsTypeRef {
-        if self.is_promise() {
-            match &self.fn_decl.function.return_type {
-                Some(ts_type_ann) => match &*ts_type_ann.type_ann {
-                    TsType::TsTypeRef(type_ref) => {
-                        let type_params = &type_ref.type_params.as_ref().unwrap().params;
-                        let return_type_ref = type_params[0].as_ts_type_ref().unwrap();
+        let outermost_type_ref = match &self.fn_decl.function.return_type {
+            Some(ts_type_ann) => match &*ts_type_ann.type_ann {
+                TsType::TsTypeRef(type_ref) => type_ref,
+                _ => panic!("{}", self.build_non_type_ref_return_type_error_msg()),
+            },
+            None => panic!("{}", self.build_missing_return_annotation_error_msg()),
+        };
 
-                        return_type_ref
-                    }
-                    _ => panic!("{}", self.build_non_type_ref_return_type_error_msg()),
-                },
-                None => panic!("{}", self.build_missing_return_annotation_error_msg()),
-            }
+        if self.is_promise() {
+            outermost_type_ref.type_params.as_ref().unwrap().params[0]
+                .as_ts_type_ref()
+                .unwrap()
         } else {
-            match &self.fn_decl.function.return_type {
-                Some(ts_type_ann) => match &*ts_type_ann.type_ann {
-                    TsType::TsTypeRef(type_ref) => &type_ref,
-                    _ => panic!("{}", self.build_non_type_ref_return_type_error_msg()),
-                },
-                None => panic!("{}", self.build_missing_return_annotation_error_msg()),
-            }
+            outermost_type_ref
         }
     }
 
@@ -61,7 +54,16 @@ impl AzleFnDecl<'_> {
         match &type_ref.type_params {
             Some(type_param_instantiation) => {
                 let return_type = &*type_param_instantiation.params[0];
-                return_type
+                if self.is_manual() {
+                    match return_type {
+                        TsType::TsTypeRef(ts_type_ref) => {
+                            &ts_type_ref.type_params.as_ref().unwrap().params[0]
+                        }
+                        _ => panic!("Manual types must specify an inner type"),
+                    }
+                } else {
+                    return_type
+                }
             }
             None => {
                 let canister_method_type = self.get_canister_method_type();
@@ -149,12 +151,8 @@ impl AzleFnDecl<'_> {
                                 }
                                 CanisterMethodType::PostUpgrade => method_type == "PostUpgrade",
                                 CanisterMethodType::PreUpgrade => method_type == "PreUpgrade",
-                                CanisterMethodType::Query => {
-                                    method_type == "Query" || method_type == "QueryManual"
-                                }
-                                CanisterMethodType::Update => {
-                                    method_type == "Update" || method_type == "UpdateManual"
-                                }
+                                CanisterMethodType::Query => method_type == "Query",
+                                CanisterMethodType::Update => method_type == "Update",
                             }
                         }
                         TsEntityName::TsQualifiedName(_) => {
@@ -175,9 +173,29 @@ impl AzleFnDecl<'_> {
     }
 
     pub fn is_manual(&self) -> bool {
-        let canister_method_type = self.get_canister_method_type();
+        let return_type_ref = self.get_return_type_ref();
 
-        canister_method_type == "QueryManual" || canister_method_type == "UpdateManual"
+        match &return_type_ref.type_params {
+            Some(ts_type_param_instantiation) => {
+                match ts_type_param_instantiation.params.get(0) {
+                    Some(param) => {
+                        match &**param {
+                            TsType::TsTypeRef(ts_type_ref) => {
+                                match &ts_type_ref.type_name {
+                                    TsEntityName::Ident(ident) => {
+                                        ident.get_name() == "Manual"
+                                    },
+                                    TsEntityName::TsQualifiedName(_) => panic!("Namespace-qualified identifiers are not currently supported in canister methods"),
+                                }
+                            },
+                            _ => false
+                        }
+                    },
+                    None => false
+                }
+            }
+            None => false,
+        }
     }
 
     pub fn is_promise(&self) -> bool {


### PR DESCRIPTION
To make a manual return type you now need to declare your function like this:

```ts
import { ic, Manual, Update } from 'azle';

export function my_method(): Update<Manual<string>> {
    ic.reply('hello);
}
```

Closes #838 