### PR TITLE
Fixed errors for mismatched return values

### DIFF
--- a/canisters/ledger/index.ts
+++ b/canisters/ledger/index.ts
@@ -8,6 +8,7 @@ import {
     Opt,
     Principal,
     query,
+    Query,
     update,
     Variant
 } from '../../index';
@@ -182,7 +183,7 @@ export type QueryArchiveResult = Variant<{
 
 // A function that is used for fetching archived ledger blocks.
 type QueryArchiveFn = Func<
-    (get_blocks_args: GetBlocksArgs) => Query<QueryArchiveResult>
+    Query<(get_blocks_args: GetBlocksArgs) => QueryArchiveResult>
 >;
 
 // The result of a "query_blocks" call.

--- a/canisters/management/index.ts
+++ b/canisters/management/index.ts
@@ -21,10 +21,10 @@ import {
     CanisterResult,
     ExternalCanister,
     Func,
-    ic,
     nat,
     nat64,
     Opt,
+    Query,
     $query,
     Principal,
     update,
@@ -170,7 +170,7 @@ export type HttpTransform = {
 };
 
 export type HttpTransformFunc = Func<
-    (args: HttpTransformArgs) => Query<HttpResponse>
+    Query<(args: HttpTransformArgs) => HttpResponse>
 >;
 
 export type HttpTransformArgs = {

--- a/examples/func_types/canisters/func_types/func_types.ts
+++ b/examples/func_types/canisters/func_types/func_types.ts
@@ -1,5 +1,7 @@
 import {
     Func,
+    Query,
+    Update,
     $init,
     nat64,
     ok,
@@ -8,9 +10,7 @@ import {
     $query,
     StableBTreeMap,
     $update,
-    Variant,
-    Query,
-    Update
+    Variant
 } from 'azle';
 import { Notifier, NotifierFunc } from '../notifiers/types';
 
@@ -29,17 +29,19 @@ type Reaction = Variant<{
     ComplexFunc: ComplexFunc;
 }>;
 
-type BasicFunc = Func<(param1: string) => Query<string>>;
-type ComplexFunc = Func<(user: User, reaction: Reaction) => Update<nat64>>;
-type StableFunc = Func<(param1: nat64, param2: string) => Query<void>>;
+type BasicFunc = Func<Query<(param1: string) => string>>;
+type ComplexFunc = Func<Update<(user: User, reaction: Reaction) => nat64>>;
+type StableFunc = Func<Query<(param1: nat64, param2: string) => void>>;
 type NullFunc = Func<
-    (
-        param1: Opt<null>,
-        param2: null[],
-        param3: null,
-        param4: null[][],
-        param5: Opt<null>[]
-    ) => Query<null>
+    Query<
+        (
+            param1: Opt<null>,
+            param2: null[],
+            param3: null,
+            param4: null[][],
+            param5: Opt<null>[]
+        ) => null
+    >
 >;
 
 $init;

--- a/examples/func_types/canisters/notifiers/types.ts
+++ b/examples/func_types/canisters/notifiers/types.ts
@@ -8,7 +8,7 @@ import {
     query
 } from 'azle';
 
-export type NotifierFunc = Func<(message: blob) => Oneway>;
+export type NotifierFunc = Func<Oneway<(message: blob) => void>>;
 
 export type NotifierOld = Canister<{
     get_notifier(): CanisterResult<NotifierFunc>;

--- a/examples/inline_types/src/inline_types.did
+++ b/examples/inline_types/src/inline_types.did
@@ -1,68 +1,84 @@
-type AzleInline10157776775476251355 = variant {
-  v1;
-  v2;
-  v3 : AzleInline511802176825669836;
-};
-type AzleInline10500607399545802115 = variant { v1; v2 };
 type AzleInline10606854607571099350 = record { prop1 : text; prop2 : text };
+type AzleInline11103238129438584416 = record { id : text; title : text };
 type AzleInline12201226198168570047 = record {
   "variant" : AzleInline40647362636145945;
+};
+type AzleInline12567140505456452269 = record {
+  "opt" : opt text;
+  "vec" : vec text;
+  primitive : nat;
+  "func" : func () -> (text);
+  "variant" : AzleInline8892292986830439123;
+  "record" : AzleInline2796879789686904113;
+};
+type AzleInline12761259732196363186 = record {
+  optional : opt nat64;
+  prop1 : text;
+  "variant" : AzleInline8892292986830439123;
 };
 type AzleInline13053209677524063143 = variant { var1; var2; var3 };
 type AzleInline13321669397179536235 = record { prop1 : nat };
 type AzleInline13533271542184586027 = record { prop1 : text; prop2 : Thing };
+type AzleInline14349533676526529706 = record { prop1 : text };
+type AzleInline15632156002574315610 = variant {
+  v1;
+  v2;
+  v3 : AzleInline75056091434791924;
+};
 type AzleInline156501469918979835 = variant { prop1 : Test };
-type AzleInline15709029710433407382 = record { id : text; title : text };
 type AzleInline16085823266644008377 = variant {
   ok : opt AzleInline4082601158333989258;
   err : InsertError;
 };
 type AzleInline16654887267279174714 = variant { prop1 : UserVariant };
+type AzleInline17634699056210974936 = record {
+  "opt" : opt AzleInline12567140505456452269;
+  "vec" : vec AzleInline12567140505456452269;
+  primitive : text;
+  "func" : func () -> (
+      record { prop1 : text; "variant" : AzleInline6442926183131535686 },
+    ) query;
+  "variant" : AzleInline15632156002574315610;
+  "record" : AzleInline12761259732196363186;
+};
 type AzleInline18254169622384439227 = record { testVariant : TestVariant };
 type AzleInline18385892998895713480 = variant { var1; var2 : TestVariant };
-type AzleInline3116605806354637774 = record {
-  optional : opt nat64;
-  prop1 : text;
-  "variant" : AzleInline3741885802289446236;
-};
+type AzleInline2796879789686904113 = record { prop1 : text };
 type AzleInline3433198680103236386 = record { test : Test };
 type AzleInline3528821404366509568 = record { prop1 : text; prop2 : text };
-type AzleInline3741885802289446236 = variant { v1; v2 };
 type AzleInline40647362636145945 = variant { var1; var2 : TestVariant };
 type AzleInline4082601158333989258 = record {
   "variant" : AzleInline40647362636145945;
 };
-type AzleInline4802940308926078777 = record { prop1 : text };
-type AzleInline511802176825669836 = record { prop1 : text };
-type AzleInline5165610369897643930 = record {
+type AzleInline5634826154517590805 = variant { var1; var2 : TestVariant };
+type AzleInline595875284796351013 = record {
   "opt" : opt text;
   "vec" : vec text;
   primitive : nat;
   "func" : func () -> (text);
-  "variant" : AzleInline3741885802289446236;
-  "record" : AzleInline511802176825669836;
+  "variant" : AzleInline8892292986830439123;
+  "record" : AzleInline75056091434791924;
 };
-type AzleInline5634826154517590805 = variant { var1; var2 : TestVariant };
 type AzleInline5987613880488740375 = record {
   prop1 : opt text;
   prop2 : AzleInline40647362636145945;
   prop3 : opt AzleInline13321669397179536235;
 };
 type AzleInline637595233572856709 = variant { var1; var2 };
-type AzleInline666297162520119653 = variant {
+type AzleInline6442926183131535686 = variant {
   v1;
-  v2 : AzleInline511802176825669836;
+  v2 : AzleInline75056091434791924;
 };
-type AzleInline9139287954320819026 = record {
-  "opt" : opt AzleInline5165610369897643930;
-  "vec" : vec AzleInline5165610369897643930;
-  primitive : text;
-  "func" : func () -> (
-      record { prop1 : text; "variant" : AzleInline666297162520119653 },
-    ) query;
-  "variant" : AzleInline10157776775476251355;
-  "record" : AzleInline3116605806354637774;
+type AzleInline7425494474395383332 = record {
+  "opt" : opt text;
+  "vec" : vec text;
+  primitive : nat;
+  "func" : func () -> (text);
+  "variant" : AzleInline8892292986830439123;
+  "record" : AzleInline75056091434791924;
 };
+type AzleInline75056091434791924 = record { prop1 : text };
+type AzleInline8892292986830439123 = variant { v1; v2 };
 type InsertError = variant {
   ValueTooLarge : KeyTooLarge;
   KeyTooLarge : KeyTooLarge;
@@ -73,36 +89,42 @@ type Reaction = variant { one; two; three : Test };
 type Test = record { id : text };
 type TestVariant = variant { prop1 : text; prop2 : Test };
 type Thing = record { id : text };
-type User1 = record { id : text; job : AzleInline15709029710433407382 };
+type User1 = record { id : text; job : AzleInline11103238129438584416 };
 type UserVariant = variant { prop1 };
 service : () -> {
-  complex : (AzleInline9139287954320819026) -> (
-      AzleInline9139287954320819026,
+  complex : (AzleInline17634699056210974936) -> (
+      AzleInline17634699056210974936,
     ) query;
   inline_func : (
       func (
           text,
-          opt AzleInline5165610369897643930,
-          vec AzleInline5165610369897643930,
-          AzleInline3116605806354637774,
-          AzleInline10157776775476251355,
+          opt AzleInline7425494474395383332,
+          vec AzleInline7425494474395383332,
+          AzleInline12761259732196363186,
+          AzleInline15632156002574315610,
           func () -> (
-              record { prop1 : text; "variant" : AzleInline666297162520119653 },
+              record {
+                prop1 : text;
+                "variant" : AzleInline6442926183131535686;
+              },
             ) query,
         ) -> () query,
     ) -> (
       func (
           text,
-          opt AzleInline5165610369897643930,
-          vec AzleInline5165610369897643930,
-          AzleInline3116605806354637774,
-          AzleInline10157776775476251355,
+          opt AzleInline595875284796351013,
+          vec AzleInline595875284796351013,
+          AzleInline12761259732196363186,
+          AzleInline15632156002574315610,
           func () -> (
-              record { prop1 : text; "variant" : AzleInline666297162520119653 },
+              record {
+                prop1 : text;
+                "variant" : AzleInline6442926183131535686;
+              },
             ) query,
         ) -> () query,
     ) query;
-  inline_record_param : (AzleInline511802176825669836) -> (text) query;
+  inline_record_param : (AzleInline75056091434791924) -> (text) query;
   inline_record_return_type : () -> (AzleInline10606854607571099350) query;
   inline_record_return_type_as_external_canister_call : () -> (ManualReply);
   inline_variant_param : (AzleInline637595233572856709) -> (

--- a/examples/inline_types/src/inline_types.ts
+++ b/examples/inline_types/src/inline_types.ts
@@ -1,14 +1,14 @@
 import {
     Func,
+    Query,
+    Update,
     InsertError,
     nat,
     nat64,
     Opt,
     $query,
-    Query,
     StableBTreeMap,
     $update,
-    Update,
     Variant
 } from 'azle';
 import {
@@ -195,6 +195,47 @@ export async function inline_record_return_type_as_external_canister_call(): Pro
 $query;
 export function inline_func(
     callback: Func<
+        Query<
+            (
+                primitive: string,
+                opt: Opt<{
+                    primitive: nat;
+                    opt: Opt<string>;
+                    vec: string[];
+                    record: { prop1: string };
+                    variant: Variant<{ v1: null; v2: null }>;
+                    func: Func<Update<() => string>>;
+                }>,
+                vec: {
+                    primitive: nat;
+                    opt: Opt<string>;
+                    vec: string[];
+                    record: { prop1: string };
+                    variant: Variant<{ v1: null; v2: null }>;
+                    func: Func<Update<() => string>>;
+                }[],
+                record: {
+                    prop1: string;
+                    optional: Opt<nat64>;
+                    variant: Variant<{ v1: null; v2: null }>;
+                },
+                variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>,
+                func: Func<
+                    Query<
+                        () => {
+                            prop1: string;
+                            variant: Variant<{
+                                v1: null;
+                                v2: { prop1: string };
+                            }>;
+                        }
+                    >
+                >
+            ) => void
+        >
+    >
+): Func<
+    Query<
         (
             primitive: string,
             opt: Opt<{
@@ -203,7 +244,7 @@ export function inline_func(
                 vec: string[];
                 record: { prop1: string };
                 variant: Variant<{ v1: null; v2: null }>;
-                func: Func<() => Update<string>>;
+                func: Func<Update<() => string>>;
             }>,
             vec: {
                 primitive: nat;
@@ -211,7 +252,7 @@ export function inline_func(
                 vec: string[];
                 record: { prop1: string };
                 variant: Variant<{ v1: null; v2: null }>;
-                func: Func<() => Update<string>>;
+                func: Func<Update<() => string>>;
             }[],
             record: {
                 prop1: string;
@@ -220,51 +261,18 @@ export function inline_func(
             },
             variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>,
             func: Func<
-                () => Query<{
-                    prop1: string;
-                    variant: Variant<{
-                        v1: null;
-                        v2: { prop1: string };
-                    }>;
-                }>
+                Query<
+                    () => {
+                        prop1: string;
+                        variant: Variant<{
+                            v1: null;
+                            v2: { prop1: string };
+                        }>;
+                    }
+                >
             >
-        ) => Query<void>
+        ) => void
     >
-): Func<
-    (
-        primitive: string,
-        opt: Opt<{
-            primitive: nat;
-            opt: Opt<string>;
-            vec: string[];
-            record: { prop1: string };
-            variant: Variant<{ v1: null; v2: null }>;
-            func: Func<() => Update<string>>;
-        }>,
-        vec: {
-            primitive: nat;
-            opt: Opt<string>;
-            vec: string[];
-            record: { prop1: string };
-            variant: Variant<{ v1: null; v2: null }>;
-            func: Func<() => Update<string>>;
-        }[],
-        record: {
-            prop1: string;
-            optional: Opt<nat64>;
-            variant: Variant<{ v1: null; v2: null }>;
-        },
-        variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>,
-        func: Func<
-            () => Query<{
-                prop1: string;
-                variant: Variant<{
-                    v1: null;
-                    v2: { prop1: string };
-                }>;
-            }>
-        >
-    ) => Query<void>
 > {
     return callback;
 }
@@ -278,7 +286,7 @@ export function complex(record: {
         vec: string[];
         record: { prop1: string };
         variant: Variant<{ v1: null; v2: null }>;
-        func: Func<() => Update<string>>;
+        func: Func<Update<() => string>>;
     }>;
     vec: {
         primitive: nat;
@@ -286,7 +294,7 @@ export function complex(record: {
         vec: string[];
         record: { prop1: string };
         variant: Variant<{ v1: null; v2: null }>;
-        func: Func<() => Update<string>>;
+        func: Func<Update<() => string>>;
     }[];
     record: {
         prop1: string;
@@ -295,10 +303,12 @@ export function complex(record: {
     };
     variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>;
     func: Func<
-        () => Query<{
-            prop1: string;
-            variant: Variant<{ v1: null; v2: { prop1: string } }>;
-        }>
+        Query<
+            () => {
+                prop1: string;
+                variant: Variant<{ v1: null; v2: { prop1: string } }>;
+            }
+        >
     >;
 }): {
     primitive: string;
@@ -308,7 +318,7 @@ export function complex(record: {
         vec: string[];
         record: { prop1: string };
         variant: Variant<{ v1: null; v2: null }>;
-        func: Func<() => Update<string>>;
+        func: Func<Update<() => string>>;
     }>;
     vec: {
         primitive: nat;
@@ -316,7 +326,7 @@ export function complex(record: {
         vec: string[];
         record: { prop1: string };
         variant: Variant<{ v1: null; v2: null }>;
-        func: Func<() => Update<string>>;
+        func: Func<Update<() => string>>;
     }[];
     record: {
         prop1: string;
@@ -325,10 +335,12 @@ export function complex(record: {
     };
     variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>;
     func: Func<
-        () => Query<{
-            prop1: string;
-            variant: Variant<{ v1: null; v2: { prop1: string } }>;
-        }>
+        Query<
+            () => {
+                prop1: string;
+                variant: Variant<{ v1: null; v2: { prop1: string } }>;
+            }
+        >
     >;
 } {
     return record;

--- a/examples/inline_types/src/types.ts
+++ b/examples/inline_types/src/types.ts
@@ -3,8 +3,8 @@ import {
     ExternalCanister,
     InsertError,
     Func,
-    FuncQuery,
-    FuncUpdate,
+    Query,
+    Update,
     Opt,
     Principal,
     nat,
@@ -127,71 +127,93 @@ export type InlineTypesOld = Canister<{
     >;
     inline_func(
         callback: Func<
-            (
-                primitive: string,
-                opt: Opt<{
-                    primitive: nat;
-                    opt: Opt<string>;
-                    vec: string[];
-                    record: { prop1: string };
-                    variant: Variant<{ v1: null; v2: null }>;
-                    func: Func<() => Update<string>>;
-                }>,
-                vec: {
-                    primitive: nat;
-                    opt: Opt<string>;
-                    vec: string[];
-                    record: { prop1: string };
-                    variant: Variant<{ v1: null; v2: null }>;
-                    func: Func<() => Update<string>>;
-                }[],
-                record: {
-                    prop1: string;
-                    optional: Opt<nat64>;
-                    variant: Variant<{ v1: null; v2: null }>;
-                },
-                variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>,
-                func: Func<
-                    () => Query<{
+            Query<
+                (
+                    primitive: string,
+                    opt: Opt<{
+                        primitive: nat;
+                        opt: Opt<string>;
+                        vec: string[];
+                        record: { prop1: string };
+                        variant: Variant<{ v1: null; v2: null }>;
+                        func: Func<Update<() => string>>;
+                    }>,
+                    vec: {
+                        primitive: nat;
+                        opt: Opt<string>;
+                        vec: string[];
+                        record: { prop1: string };
+                        variant: Variant<{ v1: null; v2: null }>;
+                        func: Func<Update<() => string>>;
+                    }[],
+                    record: {
                         prop1: string;
-                        variant: Variant<{ v1: null; v2: { prop1: string } }>;
-                    }>
-                >
-            ) => Query<void>
+                        optional: Opt<nat64>;
+                        variant: Variant<{ v1: null; v2: null }>;
+                    },
+                    variant: Variant<{
+                        v1: null;
+                        v2: null;
+                        v3: { prop1: string };
+                    }>,
+                    func: Func<
+                        Query<
+                            () => {
+                                prop1: string;
+                                variant: Variant<{
+                                    v1: null;
+                                    v2: { prop1: string };
+                                }>;
+                            }
+                        >
+                    >
+                ) => void
+            >
         >
     ): CanisterResult<
         Func<
-            (
-                primitive: string,
-                opt: Opt<{
-                    primitive: nat;
-                    opt: Opt<string>;
-                    vec: string[];
-                    record: { prop1: string };
-                    variant: Variant<{ v1: null; v2: null }>;
-                    func: Func<() => Update<string>>;
-                }>,
-                vec: {
-                    primitive: nat;
-                    opt: Opt<string>;
-                    vec: string[];
-                    record: { prop1: string };
-                    variant: Variant<{ v1: null; v2: null }>;
-                    func: Func<() => Update<string>>;
-                }[],
-                record: {
-                    prop1: string;
-                    optional: Opt<nat64>;
-                    variant: Variant<{ v1: null; v2: null }>;
-                },
-                variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>,
-                func: Func<
-                    () => Query<{
+            Query<
+                (
+                    primitive: string,
+                    opt: Opt<{
+                        primitive: nat;
+                        opt: Opt<string>;
+                        vec: string[];
+                        record: { prop1: string };
+                        variant: Variant<{ v1: null; v2: null }>;
+                        func: Func<Update<() => string>>;
+                    }>,
+                    vec: {
+                        primitive: nat;
+                        opt: Opt<string>;
+                        vec: string[];
+                        record: { prop1: string };
+                        variant: Variant<{ v1: null; v2: null }>;
+                        func: Func<Update<() => string>>;
+                    }[],
+                    record: {
                         prop1: string;
-                        variant: Variant<{ v1: null; v2: { prop1: string } }>;
-                    }>
-                >
-            ) => Query<void>
+                        optional: Opt<nat64>;
+                        variant: Variant<{ v1: null; v2: null }>;
+                    },
+                    variant: Variant<{
+                        v1: null;
+                        v2: null;
+                        v3: { prop1: string };
+                    }>,
+                    func: Func<
+                        Query<
+                            () => {
+                                prop1: string;
+                                variant: Variant<{
+                                    v1: null;
+                                    v2: { prop1: string };
+                                }>;
+                            }
+                        >
+                    >
+                ) => void
+            >
         >
     >;
     inline_record_return_type_as_external_canister_call(): CanisterResult<
@@ -211,7 +233,7 @@ export type InlineTypesOld = Canister<{
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<() => Update<string>>;
+            func: Func<Update<() => string>>;
         }>;
         vec: {
             primitive: nat;
@@ -219,7 +241,7 @@ export type InlineTypesOld = Canister<{
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<() => Update<string>>;
+            func: Func<Update<() => string>>;
         }[];
         record: {
             prop1: string;
@@ -228,10 +250,12 @@ export type InlineTypesOld = Canister<{
         };
         variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>;
         func: Func<
-            () => Query<{
-                prop1: string;
-                variant: Variant<{ v1: null; v2: { prop1: string } }>;
-            }>
+            Query<
+                () => {
+                    prop1: string;
+                    variant: Variant<{ v1: null; v2: { prop1: string } }>;
+                }
+            >
         >;
     }): CanisterResult<{
         primitive: string;
@@ -241,7 +265,7 @@ export type InlineTypesOld = Canister<{
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<() => Update<string>>;
+            func: Func<Update<() => string>>;
         }>;
         vec: {
             primitive: nat;
@@ -249,7 +273,7 @@ export type InlineTypesOld = Canister<{
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<() => Update<string>>;
+            func: Func<Update<() => string>>;
         }[];
         record: {
             prop1: string;
@@ -258,10 +282,12 @@ export type InlineTypesOld = Canister<{
         };
         variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>;
         func: Func<
-            () => Query<{
-                prop1: string;
-                variant: Variant<{ v1: null; v2: { prop1: string } }>;
-            }>
+            Query<
+                () => {
+                    prop1: string;
+                    variant: Variant<{ v1: null; v2: { prop1: string } }>;
+                }
+            >
         >;
     }>;
 }>;
@@ -363,7 +389,7 @@ export class InlineTypes extends ExternalCanister {
     @query
     inline_func: (
         callback: Func<
-            FuncQuery<
+            Query<
                 (
                     primitive: string,
                     opt: Opt<{
@@ -372,7 +398,7 @@ export class InlineTypes extends ExternalCanister {
                         vec: string[];
                         record: { prop1: string };
                         variant: Variant<{ v1: null; v2: null }>;
-                        func: Func<FuncUpdate<() => string>>;
+                        func: Func<Update<() => string>>;
                     }>,
                     vec: {
                         primitive: nat;
@@ -380,7 +406,7 @@ export class InlineTypes extends ExternalCanister {
                         vec: string[];
                         record: { prop1: string };
                         variant: Variant<{ v1: null; v2: null }>;
-                        func: Func<FuncUpdate<() => string>>;
+                        func: Func<Update<() => string>>;
                     }[],
                     record: {
                         prop1: string;
@@ -393,7 +419,7 @@ export class InlineTypes extends ExternalCanister {
                         v3: { prop1: string };
                     }>,
                     func: Func<
-                        FuncQuery<
+                        Query<
                             () => {
                                 prop1: string;
                                 variant: Variant<{
@@ -408,7 +434,7 @@ export class InlineTypes extends ExternalCanister {
         >
     ) => CanisterResult<
         Func<
-            FuncQuery<
+            Query<
                 (
                     primitive: string,
                     opt: Opt<{
@@ -417,7 +443,7 @@ export class InlineTypes extends ExternalCanister {
                         vec: string[];
                         record: { prop1: string };
                         variant: Variant<{ v1: null; v2: null }>;
-                        func: Func<FuncUpdate<() => string>>;
+                        func: Func<Update<() => string>>;
                     }>,
                     vec: {
                         primitive: nat;
@@ -425,7 +451,7 @@ export class InlineTypes extends ExternalCanister {
                         vec: string[];
                         record: { prop1: string };
                         variant: Variant<{ v1: null; v2: null }>;
-                        func: Func<FuncUpdate<() => string>>;
+                        func: Func<Update<() => string>>;
                     }[],
                     record: {
                         prop1: string;
@@ -438,7 +464,7 @@ export class InlineTypes extends ExternalCanister {
                         v3: { prop1: string };
                     }>,
                     func: Func<
-                        FuncQuery<
+                        Query<
                             () => {
                                 prop1: string;
                                 variant: Variant<{
@@ -473,7 +499,7 @@ export class InlineTypes extends ExternalCanister {
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<FuncUpdate<() => string>>;
+            func: Func<Update<() => string>>;
         }>;
         vec: {
             primitive: nat;
@@ -481,7 +507,7 @@ export class InlineTypes extends ExternalCanister {
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<FuncUpdate<() => string>>;
+            func: Func<Update<() => string>>;
         }[];
         record: {
             prop1: string;
@@ -490,7 +516,7 @@ export class InlineTypes extends ExternalCanister {
         };
         variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>;
         func: Func<
-            FuncQuery<
+            Query<
                 () => {
                     prop1: string;
                     variant: Variant<{ v1: null; v2: { prop1: string } }>;
@@ -505,7 +531,7 @@ export class InlineTypes extends ExternalCanister {
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<FuncUpdate<() => string>>;
+            func: Func<Update<() => string>>;
         }>;
         vec: {
             primitive: nat;
@@ -513,7 +539,7 @@ export class InlineTypes extends ExternalCanister {
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<FuncUpdate<() => string>>;
+            func: Func<Update<() => string>>;
         }[];
         record: {
             prop1: string;
@@ -522,7 +548,7 @@ export class InlineTypes extends ExternalCanister {
         };
         variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>;
         func: Func<
-            FuncQuery<
+            Query<
                 () => {
                     prop1: string;
                     variant: Variant<{ v1: null; v2: { prop1: string } }>;

--- a/examples/list_of_lists/src/index.ts
+++ b/examples/list_of_lists/src/index.ts
@@ -5,6 +5,7 @@ import {
     float32,
     float64,
     Func,
+    Query,
     int,
     int16,
     int32,
@@ -16,7 +17,6 @@ import {
     nat64,
     nat8,
     Opt,
-    Query,
     $query,
     reserved,
     Variant
@@ -33,7 +33,7 @@ type State = Variant<{
     gas: null;
 }>;
 
-type BasicFunc = Func<(param1: string) => Query<string>>;
+type BasicFunc = Func<Query<(param1: string) => string>>;
 
 $query;
 export function list_of_string_one(param: string[]): string[] {

--- a/examples/motoko_examples/http_counter/src/main.ts
+++ b/examples/motoko_examples/http_counter/src/main.ts
@@ -1,12 +1,12 @@
 import {
     blob,
     Func,
+    Query,
     ic,
     nat,
     nat16,
     Opt,
     $query,
-    Query,
     StableBTreeMap,
     $update,
     Variant
@@ -28,7 +28,7 @@ type CallbackStrategy = {
     token: Token;
 };
 
-type Callback = Func<(t: Token) => Query<StreamingCallbackHttpResponse>>;
+type Callback = Func<Query<(t: Token) => StreamingCallbackHttpResponse>>;
 
 type StreamingStrategy = Variant<{
     Callback: CallbackStrategy;

--- a/examples/run_time_errors/test/tests.ts
+++ b/examples/run_time_errors/test/tests.ts
@@ -149,7 +149,7 @@ function check_error_message(actual_error: any, expected_error: string) {
         'result' in actual_error &&
         'reject_message' in actual_error.result &&
         actual_error.result.reject_message.includes(
-            `Azle runtime error: ${expected_error}`
+            `Uncaught ${expected_error}`
         )
     );
 }

--- a/index.ts
+++ b/index.ts
@@ -117,16 +117,6 @@ type ic = {
     trap: (message: string) => never;
 };
 
-export type PreUpgrade = void;
-export type PostUpgrade = void;
-export type Heartbeat = void;
-export type Init = void;
-export type InspectMessage = void;
-export type Query<T> = T;
-export type Manual<T> = void;
-export type Update<T> = T;
-export type Oneway = void;
-
 // TODO see if we can get the T here to have some more information, like the func type
 // TODO we especially want to add the possibility of an optional cycle parameter and the notify method
 export type Canister<T> = T;
@@ -206,10 +196,12 @@ export function attempt<T, E>(
     }
 }
 
-// TODO type this more strictly
-export type Func<
-    T extends (...args: any[]) => Query<any> | Update<any> | Oneway
-> = [Principal, string];
+// TODO type these more strictly
+export type Query<T extends (...args: any[]) => any> = [Principal, string];
+export type Update<T extends (...args: any[]) => any> = [Principal, string];
+export type Oneway<T extends (...args: any[]) => any> = [Principal, string];
+
+export type Func<T> = T;
 
 export { Principal } from '@dfinity/principal';
 
@@ -312,3 +304,5 @@ export const $post_upgrade = (options: { guard: string }) => {};
 export const $pre_upgrade = (options: { guard: string }) => {};
 export const $query = (options: { guard: string }) => {};
 export const $update = (options: { guard: string }) => {};
+
+export type Manual<T> = void;

--- a/src/compiler/typescript_to_rust/azle_generate/src/generators/async_await_result_handler.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/generators/async_await_result_handler.rs
@@ -15,61 +15,60 @@ pub fn generate(canister_methods: &Vec<ActCanisterMethod>) -> TokenStream {
             _azle_manual: bool
         ) -> boa_engine::JsValue {
             if
-                _azle_boa_return_value.is_object() == true &&
-                _azle_boa_return_value.as_object().unwrap().is_promise() == true
+                !_azle_boa_return_value.is_object() ||
+                !_azle_boa_return_value.as_object().unwrap().is_promise()
             {
-                // This runs all pending promises to completion
-                // TODO use the better Boa API once it's available
-                _azle_boa_context.eval("");
-
-                let object = _azle_boa_return_value.as_object().unwrap().borrow();
-                let promise = object.as_promise().unwrap();
-
-                return match &promise.promise_state {
-                    boa_engine::builtins::promise::PromiseState::Fulfilled(js_value) => {
-                        PROMISE_MAP_REF_CELL.with(|promise_map_ref_cell| {
-                            let mut promise_map = promise_map_ref_cell.borrow_mut();
-
-                            promise_map.remove(_azle_uuid);
-                        });
-
-                        if _azle_manual == true {
-                            return _azle_boa_return_value.clone();
-                        }
-
-                        match _azle_method_name {
-                            #(#match_arms)*
-                            "_AZLE_TIMER" => {},
-                            _ => panic!("method name was not found")
-                        };
-
-                        return _azle_boa_return_value.clone();
-                    },
-                    boa_engine::builtins::promise::PromiseState::Rejected(js_value) => {
-                        PROMISE_MAP_REF_CELL.with(|promise_map_ref_cell| {
-                            let mut promise_map = promise_map_ref_cell.borrow_mut();
-
-                            promise_map.remove(_azle_uuid);
-                        });
-
-                        let error_message = _azle_handle_boa_error(js_value.clone(), _azle_boa_context);
-
-                        panic!("Azle runtime error: {}", error_message);
-                    },
-                    boa_engine::builtins::promise::PromiseState::Pending => {
-                        PROMISE_MAP_REF_CELL.with(|promise_map_ref_cell| {
-                            let mut promise_map = promise_map_ref_cell.borrow_mut();
-
-                            promise_map.insert(_azle_uuid.to_string(), _azle_boa_return_value.clone());
-                        });
-
-                        return _azle_boa_return_value.clone();
-                    }
-                };
-            }
-            else {
                 return _azle_boa_return_value.clone();
             }
+
+            // This runs all pending promises to completion
+            // TODO use the better Boa API once it's available
+            _azle_boa_context.eval("");
+
+            let object = _azle_boa_return_value.as_object().unwrap().borrow();
+            let promise = object.as_promise().unwrap();
+
+            return match &promise.promise_state {
+                boa_engine::builtins::promise::PromiseState::Fulfilled(js_value) => {
+                    PROMISE_MAP_REF_CELL.with(|promise_map_ref_cell| {
+                        let mut promise_map = promise_map_ref_cell.borrow_mut();
+
+                        promise_map.remove(_azle_uuid);
+                    });
+
+                    if _azle_manual == true {
+                        return _azle_boa_return_value.clone();
+                    }
+
+                    match _azle_method_name {
+                        #(#match_arms)*
+                        "_AZLE_TIMER" => {},
+                        _ => panic!("method name was not found")
+                    };
+
+                    return _azle_boa_return_value.clone();
+                },
+                boa_engine::builtins::promise::PromiseState::Rejected(js_value) => {
+                    PROMISE_MAP_REF_CELL.with(|promise_map_ref_cell| {
+                        let mut promise_map = promise_map_ref_cell.borrow_mut();
+
+                        promise_map.remove(_azle_uuid);
+                    });
+
+                    let error_message = _azle_handle_boa_error(js_value.clone(), _azle_boa_context);
+
+                    panic!("Azle runtime error: {}", error_message);
+                },
+                boa_engine::builtins::promise::PromiseState::Pending => {
+                    PROMISE_MAP_REF_CELL.with(|promise_map_ref_cell| {
+                        let mut promise_map = promise_map_ref_cell.borrow_mut();
+
+                        promise_map.insert(_azle_uuid.to_string(), _azle_boa_return_value.clone());
+                    });
+
+                    return _azle_boa_return_value.clone();
+                }
+            };
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/generators/async_await_result_handler.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/generators/async_await_result_handler.rs
@@ -55,7 +55,7 @@ pub fn generate(canister_methods: &Vec<ActCanisterMethod>) -> TokenStream {
                         promise_map.remove(_azle_uuid);
                     });
 
-                    let error_message = _azle_handle_boa_error(js_value.clone(), _azle_boa_context);
+                    let error_message = _azle_js_value_to_string(js_value.clone(), _azle_boa_context);
 
                     panic!("Azle runtime error: {}", error_message);
                 },

--- a/src/compiler/typescript_to_rust/azle_generate/src/generators/async_await_result_handler.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/generators/async_await_result_handler.rs
@@ -57,7 +57,7 @@ pub fn generate(canister_methods: &Vec<ActCanisterMethod>) -> TokenStream {
 
                     let error_message = _azle_js_value_to_string(js_value.clone(), _azle_boa_context);
 
-                    panic!("Azle runtime error: {}", error_message);
+                    ic_cdk::api::trap(&format!("Uncaught {}", error_message));
                 },
                 boa_engine::builtins::promise::PromiseState::Pending => {
                     PROMISE_MAP_REF_CELL.with(|promise_map_ref_cell| {

--- a/src/compiler/typescript_to_rust/azle_generate/src/generators/boa_error_handlers.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/generators/boa_error_handlers.rs
@@ -3,7 +3,7 @@ use quote::quote;
 
 pub fn generate() -> TokenStream {
     quote! {
-        pub fn _azle_handle_boa_result(
+        pub fn _azle_unwrap_boa_result(
             boa_result: boa_engine::JsResult<boa_engine::JsValue>,
             context: &mut boa_engine::Context
         ) -> boa_engine::JsValue {

--- a/src/compiler/typescript_to_rust/azle_generate/src/generators/boa_error_handlers.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/generators/boa_error_handlers.rs
@@ -10,14 +10,14 @@ pub fn generate() -> TokenStream {
             match boa_result {
                 Ok(_azle_boa_return_value) => _azle_boa_return_value,
                 Err(_azle_boa_error) => {
-                    let error_message = _azle_handle_boa_error(_azle_boa_error.to_opaque(context), context);
+                    let error_message = _azle_js_value_to_string(_azle_boa_error.to_opaque(context), context);
 
                     panic!("Azle runtime error: {}", error_message);
                 },
             }
         }
 
-        fn _azle_handle_boa_error(error_value: boa_engine::JsValue, context: &mut boa_engine::Context) -> String {
+        fn _azle_js_value_to_string(error_value: boa_engine::JsValue, context: &mut boa_engine::Context) -> String {
             match &error_value {
                 boa_engine::JsValue::BigInt(bigint) => bigint.to_string(),
                 boa_engine::JsValue::Boolean(boolean) => boolean.to_string(),

--- a/src/compiler/typescript_to_rust/azle_generate/src/generators/boa_error_handlers.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/generators/boa_error_handlers.rs
@@ -12,7 +12,7 @@ pub fn generate() -> TokenStream {
                 Err(_azle_boa_error) => {
                     let error_message = _azle_js_value_to_string(_azle_boa_error.to_opaque(context), context);
 
-                    panic!("Azle runtime error: {}", error_message);
+                    ic_cdk::api::trap(&format!("Uncaught {}", error_message));
                 },
             }
         }

--- a/src/compiler/typescript_to_rust/azle_generate/src/generators/canister_methods/init.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/generators/canister_methods/init.rs
@@ -23,7 +23,7 @@ pub fn generate_init_method_body(
 
             _azle_register_ic_object(&mut _azle_boa_context);
 
-            _azle_handle_boa_result(_azle_boa_context.eval(format!(
+            _azle_unwrap_boa_result(_azle_boa_context.eval(format!(
                 "let exports = {{}}; {compiled_js}",
                 compiled_js = MAIN_JS
             )), &mut _azle_boa_context);

--- a/src/compiler/typescript_to_rust/azle_generate/src/generators/canister_methods/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/generators/canister_methods/mod.rs
@@ -28,13 +28,13 @@ pub fn generate_call_to_js_function(fn_decl: &AzleFnDecl) -> TokenStream {
         .collect();
 
     quote! {
-        let _azle_exports_js_value = _azle_handle_boa_result(_azle_boa_context.eval("exports"), &mut _azle_boa_context);
+        let _azle_exports_js_value = _azle_unwrap_boa_result(_azle_boa_context.eval("exports"), &mut _azle_boa_context);
         let _azle_exports_js_object = _azle_exports_js_value.as_object().unwrap();
 
         let _azle_function_js_value = _azle_exports_js_object.get(#function_name, &mut _azle_boa_context).unwrap();
         let _azle_function_js_object = _azle_function_js_value.as_object().unwrap();
 
-        let _azle_boa_return_value = _azle_handle_boa_result(
+        let _azle_boa_return_value = _azle_unwrap_boa_result(
             _azle_function_js_object.call(
                 &boa_engine::JsValue::Null,
                 &[

--- a/src/compiler/typescript_to_rust/azle_generate/src/generators/canister_methods/post_upgrade.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/generators/canister_methods/post_upgrade.rs
@@ -25,7 +25,7 @@ pub fn generate_post_upgrade_method_body(
 
             _azle_register_ic_object(&mut _azle_boa_context);
 
-            _azle_handle_boa_result(_azle_boa_context.eval(format!(
+            _azle_unwrap_boa_result(_azle_boa_context.eval(format!(
                 "let exports = {{}}; {compiled_js}",
                 compiled_js = MAIN_JS
             )), &mut _azle_boa_context);

--- a/src/compiler/typescript_to_rust/azle_generate/src/generators/ic_object/functions/set_timer.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/generators/ic_object/functions/set_timer.rs
@@ -36,7 +36,7 @@ pub fn generate() -> proc_macro2::TokenStream {
                         *manual_mut = false;
                     });
 
-                    let _azle_boa_return_value = _azle_handle_boa_result(
+                    let _azle_boa_return_value = _azle_unwrap_boa_result(
                         func_js_object.call(
                             &boa_engine::JsValue::Null,
                             &[],

--- a/src/compiler/typescript_to_rust/azle_generate/src/generators/ic_object/functions/set_timer_interval.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/generators/ic_object/functions/set_timer_interval.rs
@@ -36,7 +36,7 @@ pub fn generate() -> proc_macro2::TokenStream {
                         *manual_mut = false;
                     });
 
-                    let _azle_boa_return_value = _azle_handle_boa_result(
+                    let _azle_boa_return_value = _azle_unwrap_boa_result(
                         func_js_object.call(
                             &boa_engine::JsValue::Null,
                             &[],

--- a/src/compiler/typescript_to_rust/azle_generate/src/generators/vm_value_conversion/try_from_vm_value_impls/basic.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/generators/vm_value_conversion/try_from_vm_value_impls/basic.rs
@@ -32,7 +32,7 @@ pub fn generate() -> proc_macro2::TokenStream {
 
         impl CdkActTryFromVmValue<ic_cdk::export::candid::Empty, &mut boa_engine::Context> for boa_engine::JsValue {
             fn try_from_vm_value(self, context: &mut boa_engine::Context) -> Result<ic_cdk::export::candid::Empty, CdkActTryFromVmValueError> {
-                panic!("JsValue cannot be converted into Empty");
+                Err(CdkActTryFromVmValueError("JsValue cannot be converted into type 'empty'".to_string()))
             }
         }
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/generators/vm_value_conversion/try_into_vm_value_impls/basic.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/generators/vm_value_conversion/try_into_vm_value_impls/basic.rs
@@ -41,7 +41,7 @@ pub fn generate() -> proc_macro2::TokenStream {
 
         impl CdkActTryIntoVmValue<&mut boa_engine::Context, boa_engine::JsValue> for ic_cdk::export::Principal {
             fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
-                let exports_js_value = _azle_handle_boa_result(context.eval("exports"), context);
+                let exports_js_value = _azle_unwrap_boa_result(context.eval("exports"), context);
                 let exports_js_object = exports_js_value.as_object().unwrap();
 
                 let principal_class_js_value = exports_js_object.get("Principal", context).unwrap();
@@ -50,7 +50,7 @@ pub fn generate() -> proc_macro2::TokenStream {
                 let from_text_js_value = principal_class_js_object.get("fromText", context).unwrap();
                 let from_text_js_object = from_text_js_value.as_object().unwrap();
 
-                let principal_js_value = _azle_handle_boa_result(from_text_js_object.call(&principal_class_js_value, &[self.to_text().into()], context), context);
+                let principal_js_value = _azle_unwrap_boa_result(from_text_js_object.call(&principal_class_js_value, &[self.to_text().into()], context), context);
 
                 Ok(principal_js_value)
             }

--- a/src/compiler/typescript_to_rust/azle_generate/src/generators/vm_value_conversion/try_into_vm_value_impls/basic.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/generators/vm_value_conversion/try_into_vm_value_impls/basic.rs
@@ -20,7 +20,7 @@ pub fn generate() -> proc_macro2::TokenStream {
 
         impl CdkActTryIntoVmValue<&mut boa_engine::Context, boa_engine::JsValue> for ic_cdk::export::candid::Empty {
             fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
-                panic!("Empty cannot be converted into JsValue");
+                Err(CdkActTryIntoVmValueError("Empty cannot be converted into JsValue".to_string()))
             }
         }
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_functions_and_methods/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_functions_and_methods/mod.rs
@@ -1,6 +1,6 @@
 mod ts_fn_param;
 
-use swc_ecma_ast::{TsEntityName, TsFnParam, TsType, TsTypeAnn};
+use swc_ecma_ast::{TsFnParam, TsType, TsTypeAnn};
 
 use super::{GetName, GetTsType};
 
@@ -8,51 +8,11 @@ pub trait FunctionAndMethodTypeHelperMethods {
     fn get_ts_type_ann(&self) -> TsTypeAnn;
     fn get_ts_fn_params(&self) -> Vec<TsFnParam>;
     fn get_valid_return_types(&self) -> Vec<&str>;
+    fn get_return_type(&self) -> Option<TsType>;
 
     fn get_param_types(&self) -> Vec<TsType> {
         self.get_ts_fn_params().iter().fold(vec![], |acc, param| {
             vec![acc, vec![param.get_ts_type().clone()]].concat()
         })
-    }
-
-    fn get_return_type(&self) -> Option<TsType> {
-        let mode = self.get_func_mode();
-        if mode == "Oneway" {
-            None
-        } else {
-            let ts_type = self.get_ts_type_ann().get_ts_type();
-            let ts_type_ref = ts_type.as_ts_type_ref().unwrap();
-            match &ts_type_ref.type_params {
-                Some(type_param_inst) => {
-                    if type_param_inst.params.len() != 1 {
-                        panic!("Func must specify exactly one return type")
-                    }
-                    match type_param_inst.params.get(0) {
-                        Some(param) => {
-                            let ts_type = &**param;
-                            Some(ts_type.clone())
-                        }
-                        None => panic!("Func must specify exactly one return type"),
-                    }
-                }
-                None => panic!("Func must specify a return type"),
-            }
-        }
-    }
-
-    fn get_func_mode(&self) -> String {
-        match self.get_ts_type_ann().get_ts_type() {
-            TsType::TsTypeRef(type_reference) => match &type_reference.type_name {
-                TsEntityName::TsQualifiedName(_) => panic!("Unsupported qualified name. Func return type must directly be Query, Update, or Oneway"),
-                TsEntityName::Ident(identifier) => {
-                let mode = identifier.get_name();
-                if !self.get_valid_return_types().contains(&mode) {
-                    panic!("Return type must be one of {:?}", self.get_valid_return_types())
-                }
-                mode.to_string()
-            }
-            },
-            _ => panic!("Return type must be one of {:?}", self.get_valid_return_types()),
-        }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_fn_or_constructor_type/azle_fn_type/function_and_method_type_helper_methods.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_fn_or_constructor_type/azle_fn_type/function_and_method_type_helper_methods.rs
@@ -1,7 +1,7 @@
-use swc_ecma_ast::{TsFnParam, TsTypeAnn};
+use swc_ecma_ast::{TsFnParam, TsType, TsTypeAnn};
 
 use super::AzleFnType;
-use crate::ts_ast::FunctionAndMethodTypeHelperMethods;
+use crate::ts_ast::{ast_traits::GetTsType, FunctionAndMethodTypeHelperMethods};
 
 impl FunctionAndMethodTypeHelperMethods for AzleFnType<'_> {
     fn get_ts_fn_params(&self) -> Vec<TsFnParam> {
@@ -14,5 +14,9 @@ impl FunctionAndMethodTypeHelperMethods for AzleFnType<'_> {
 
     fn get_valid_return_types(&self) -> Vec<&str> {
         vec!["Oneway", "Update", "Query"]
+    }
+
+    fn get_return_type(&self) -> Option<TsType> {
+        Some(self.get_ts_type_ann().get_ts_type())
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_lit/azle_type_element/azle_method_signature/function_and_method_helpers.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_lit/azle_type_element/azle_method_signature/function_and_method_helpers.rs
@@ -1,8 +1,9 @@
-use swc_ecma_ast::{TsFnParam, TsTypeAnn};
-
-use crate::ts_ast::azle_functions_and_methods::FunctionAndMethodTypeHelperMethods;
+use swc_ecma_ast::{TsEntityName, TsFnParam, TsType, TsTypeAnn};
 
 use super::AzleMethodSignature;
+use crate::ts_ast::{
+    ast_traits::GetTsType, azle_functions_and_methods::FunctionAndMethodTypeHelperMethods, GetName,
+};
 
 impl FunctionAndMethodTypeHelperMethods for AzleMethodSignature<'_> {
     fn get_ts_fn_params(&self) -> Vec<TsFnParam> {
@@ -18,5 +19,43 @@ impl FunctionAndMethodTypeHelperMethods for AzleMethodSignature<'_> {
 
     fn get_valid_return_types(&self) -> Vec<&str> {
         vec!["Oneway", "Update", "Query", "CanisterResult"]
+    }
+
+    fn get_return_type(&self) -> Option<TsType> {
+        let mode = match self.get_ts_type_ann().get_ts_type() {
+            TsType::TsTypeRef(type_reference) => match &type_reference.type_name {
+                TsEntityName::TsQualifiedName(_) => panic!("Unsupported qualified name. Func return type must directly be Query, Update, or Oneway"),
+                TsEntityName::Ident(identifier) => {
+                let mode = identifier.get_name();
+                if !self.get_valid_return_types().contains(&mode) {
+                    panic!("Return type must be one of {:?}", self.get_valid_return_types())
+                }
+                mode.to_string()
+            }
+            },
+            _ => panic!("Return type must be one of {:?}", self.get_valid_return_types()),
+        };
+
+        if mode == "Oneway" {
+            None
+        } else {
+            let ts_type = self.get_ts_type_ann().get_ts_type();
+            let ts_type_ref = ts_type.as_ts_type_ref().unwrap();
+            match &ts_type_ref.type_params {
+                Some(type_param_inst) => {
+                    if type_param_inst.params.len() != 1 {
+                        panic!("Func must specify exactly one return type")
+                    }
+                    match type_param_inst.params.get(0) {
+                        Some(param) => {
+                            let ts_type = &**param;
+                            Some(ts_type.clone())
+                        }
+                        None => panic!("Func must specify exactly one return type"),
+                    }
+                }
+                None => panic!("Func must specify a return type"),
+            }
+        }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_ref/get_name.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_ref/get_name.rs
@@ -7,6 +7,9 @@ impl GetName for AzleTypeRef<'_> {
     fn get_name(&self) -> &str {
         match &self.ts_type_ref.type_name {
             TsEntityName::TsQualifiedName(ts_qualified_name) => {
+                // TODO: This could be improved for Qualified TypeRefs with type params.
+                // Currently we just drop the type params. It would be better if we
+                // included them.
                 panic!(
                     "{}",
                     self.qualified_name_error(ts_qualified_name.right.get_name().to_string())

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/mod.rs
@@ -39,6 +39,13 @@ impl<'a> AzleType<'a> {
         }
     }
 
+    pub fn as_azle_type_ref(self) -> Option<AzleTypeRef<'a>> {
+        match self {
+            AzleType::AzleTypeRef(azle_type_ref) => Some(azle_type_ref),
+            _ => None,
+        }
+    }
+
     // It seems like these would be useful, but we aren't using them right now,
     // but they can hang out here until we are done that way if we need them
     // they are here. though its not like they are that hard to write up from
@@ -47,13 +54,6 @@ impl<'a> AzleType<'a> {
     //     match self {
     //         AzleType::AzleTypeLit(_) => true,
     //         _ => false,
-    //     }
-    // }
-    //
-    // pub fn as_azle_type_ref(self) -> Option<AzleTypeRef<'a>> {
-    //     match self {
-    //         AzleType::AzleTypeRef(azle_type_ref) => Some(azle_type_ref),
-    //         _ => None,
     //     }
     // }
     //

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type_alias_decls/azle_type_alias_decl.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type_alias_decls/azle_type_alias_decl.rs
@@ -91,8 +91,8 @@ impl AzleTypeAliasListHelperMethods for Vec<AzleTypeAliasDecl<'_>> {
     fn generate_type_alias_lookup(&self) -> HashMap<String, AzleTypeAliasDecl> {
         self.iter()
             .fold(HashMap::new(), |mut acc, azle_type_alias| {
-                let type_alias_names = azle_type_alias.ts_type_alias_decl.id.get_name().to_string();
-                acc.insert(type_alias_names, azle_type_alias.clone());
+                let type_alias_name = azle_type_alias.ts_type_alias_decl.id.get_name().to_string();
+                acc.insert(type_alias_name, azle_type_alias.clone());
                 acc
             })
     }
@@ -130,7 +130,7 @@ impl AzleTypeAliasListHelperMethods for Vec<AzleTypeAliasDecl<'_>> {
 
         type_names.iter().fold(vec![], |acc, dependant_type_name| {
             let type_alias_decl = type_alias_lookup.get(dependant_type_name);
-            let token_stream = match type_alias_decl {
+            let act_data_type = match type_alias_decl {
                 Some(azle_type_alias) => azle_type_alias.to_act_node(),
                 None => {
                     panic!(
@@ -139,7 +139,7 @@ impl AzleTypeAliasListHelperMethods for Vec<AzleTypeAliasDecl<'_>> {
                     )
                 }
             };
-            vec![acc, vec![token_stream]].concat()
+            vec![acc, vec![act_data_type]].concat()
         })
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/ts_type/ts_fn_type.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/ts_type/ts_fn_type.rs
@@ -1,6 +1,8 @@
-use swc_ecma_ast::{TsFnParam, TsFnType, TsTypeAnn};
+use swc_ecma_ast::{TsFnParam, TsFnType, TsType, TsTypeAnn};
 
-use crate::ts_ast::{FunctionAndMethodTypeHelperMethods, GenerateInlineName};
+use crate::ts_ast::{
+    ast_traits::GetTsType, FunctionAndMethodTypeHelperMethods, GenerateInlineName,
+};
 
 impl FunctionAndMethodTypeHelperMethods for TsFnType {
     fn get_ts_fn_params(&self) -> Vec<TsFnParam> {
@@ -13,6 +15,10 @@ impl FunctionAndMethodTypeHelperMethods for TsFnType {
 
     fn get_valid_return_types(&self) -> Vec<&str> {
         vec!["Oneway", "Update", "Query"]
+    }
+
+    fn get_return_type(&self) -> Option<TsType> {
+        Some(self.get_ts_type_ann().get_ts_type())
     }
 }
 


### PR DESCRIPTION
Previously when a function was declared as `null` we would just drop the returned value rather than trapping if the value wasn't `null`. Same for `void` functions that didn't return undefined. Now those will be errors.

Additionally, this changes the wording of uncaught exceptions from `Azle runtime error: {x}` to `Uncaught {x}`. This more closely aligns with Node and browsers.

Other minor changes include:
- switching to using a guard clause in src/compiler/typescript_to_rust/azle_generate/src/generators/async_await_result_handler.rs
- renaming `_azle_handle_boa_result` to `_azle_unwrap_boa_result`
- renaming `_azle_handle_boa_error` to `_azle_js_value_to_string`