### PR TITLE
Changed Func Parsing

### DIFF
--- a/canisters/ledger/index.ts
+++ b/canisters/ledger/index.ts
@@ -8,6 +8,7 @@ import {
     Opt,
     Principal,
     query,
+    Query,
     update,
     Variant
 } from '../../index';
@@ -182,7 +183,7 @@ export type QueryArchiveResult = Variant<{
 
 // A function that is used for fetching archived ledger blocks.
 type QueryArchiveFn = Func<
-    (get_blocks_args: GetBlocksArgs) => Query<QueryArchiveResult>
+    Query<(get_blocks_args: GetBlocksArgs) => QueryArchiveResult>
 >;
 
 // The result of a "query_blocks" call.

--- a/canisters/management/index.ts
+++ b/canisters/management/index.ts
@@ -21,10 +21,10 @@ import {
     CanisterResult,
     ExternalCanister,
     Func,
-    ic,
     nat,
     nat64,
     Opt,
+    Query,
     $query,
     Principal,
     update,
@@ -170,7 +170,7 @@ export type HttpTransform = {
 };
 
 export type HttpTransformFunc = Func<
-    (args: HttpTransformArgs) => Query<HttpResponse>
+    Query<(args: HttpTransformArgs) => HttpResponse>
 >;
 
 export type HttpTransformArgs = {

--- a/examples/func_types/canisters/func_types/func_types.ts
+++ b/examples/func_types/canisters/func_types/func_types.ts
@@ -1,7 +1,7 @@
 import {
     Func,
-    FuncQuery,
-    FuncUpdate,
+    Query,
+    Update,
     $init,
     nat64,
     ok,
@@ -29,11 +29,11 @@ type Reaction = Variant<{
     ComplexFunc: ComplexFunc;
 }>;
 
-type BasicFunc = Func<FuncQuery<(param1: string) => string>>;
-type ComplexFunc = Func<FuncUpdate<(user: User, reaction: Reaction) => nat64>>;
-type StableFunc = Func<FuncQuery<(param1: nat64, param2: string) => void>>;
+type BasicFunc = Func<Query<(param1: string) => string>>;
+type ComplexFunc = Func<Update<(user: User, reaction: Reaction) => nat64>>;
+type StableFunc = Func<Query<(param1: nat64, param2: string) => void>>;
 type NullFunc = Func<
-    FuncQuery<
+    Query<
         (
             param1: Opt<null>,
             param2: null[],

--- a/examples/func_types/canisters/func_types/func_types.ts
+++ b/examples/func_types/canisters/func_types/func_types.ts
@@ -1,5 +1,7 @@
 import {
     Func,
+    FuncQuery,
+    FuncUpdate,
     $init,
     nat64,
     ok,
@@ -8,9 +10,7 @@ import {
     $query,
     StableBTreeMap,
     $update,
-    Variant,
-    Query,
-    Update
+    Variant
 } from 'azle';
 import { Notifier, NotifierFunc } from '../notifiers/types';
 
@@ -29,17 +29,19 @@ type Reaction = Variant<{
     ComplexFunc: ComplexFunc;
 }>;
 
-type BasicFunc = Func<(param1: string) => Query<string>>;
-type ComplexFunc = Func<(user: User, reaction: Reaction) => Update<nat64>>;
-type StableFunc = Func<(param1: nat64, param2: string) => Query<void>>;
+type BasicFunc = Func<FuncQuery<(param1: string) => string>>;
+type ComplexFunc = Func<FuncUpdate<(user: User, reaction: Reaction) => nat64>>;
+type StableFunc = Func<FuncQuery<(param1: nat64, param2: string) => void>>;
 type NullFunc = Func<
-    (
-        param1: Opt<null>,
-        param2: null[],
-        param3: null,
-        param4: null[][],
-        param5: Opt<null>[]
-    ) => Query<null>
+    FuncQuery<
+        (
+            param1: Opt<null>,
+            param2: null[],
+            param3: null,
+            param4: null[][],
+            param5: Opt<null>[]
+        ) => null
+    >
 >;
 
 $init;

--- a/examples/func_types/canisters/notifiers/types.ts
+++ b/examples/func_types/canisters/notifiers/types.ts
@@ -1,14 +1,13 @@
 import {
     blob,
-    Canister,
     CanisterResult,
     ExternalCanister,
     Func,
-    Oneway,
+    FuncOneway,
     query
 } from 'azle';
 
-export type NotifierFunc = Func<(message: blob) => Oneway>;
+export type NotifierFunc = Func<FuncOneway<(message: blob) => void>>;
 
 export type NotifierOld = Canister<{
     get_notifier(): CanisterResult<NotifierFunc>;

--- a/examples/func_types/canisters/notifiers/types.ts
+++ b/examples/func_types/canisters/notifiers/types.ts
@@ -1,13 +1,14 @@
 import {
     blob,
+    Canister,
     CanisterResult,
     ExternalCanister,
     Func,
-    FuncOneway,
+    Oneway,
     query
 } from 'azle';
 
-export type NotifierFunc = Func<FuncOneway<(message: blob) => void>>;
+export type NotifierFunc = Func<Oneway<(message: blob) => void>>;
 
 export type NotifierOld = Canister<{
     get_notifier(): CanisterResult<NotifierFunc>;

--- a/examples/inline_types/src/inline_types.did
+++ b/examples/inline_types/src/inline_types.did
@@ -1,145 +1,159 @@
-type AzleInline10134563958881694720 = record { testVariant : TestVariant };
-type AzleInline10664464874059054195 = record {
-  "variant" : AzleInline7490137446430438151;
+type AzleInline10606854607571099350 = record { prop1 : text; prop2 : text };
+type AzleInline11103238129438584416 = record { id : text; title : text };
+type AzleInline12201226198168570047 = record {
+  "variant" : AzleInline40647362636145945;
 };
-type AzleInline11176947628425875238 = variant { prop1 : Test };
-type AzleInline1136376404574922452 = variant {
-  ok : opt AzleInline4422132652328047813;
-  err : InsertError;
-};
-type AzleInline15709029710433407382 = record { id : text; title : text };
-type AzleInline16310876903028532563 = record {
-  prop1 : opt text;
-  prop2 : AzleInline16788612102005432527;
-  prop3 : opt AzleInline488414271151064074;
-};
-type AzleInline16598272309081177769 = record {
-  "opt" : opt AzleInline2461023088926241501;
-  "vec" : vec AzleInline2461023088926241501;
-  primitive : text;
-  "func" : func () -> (
-      record { prop1 : text; "variant" : AzleInline17765423431258201622 },
-    ) query;
-  "variant" : AzleInline8273904979405424738;
-  "record" : AzleInline2236061876033704896;
-};
-type AzleInline16788612102005432527 = variant { var1; var2 : TestVariant };
-type AzleInline17765423431258201622 = variant {
-  v1;
-  v2 : AzleInline4334856068537875025;
-};
-type AzleInline18069512391554055116 = variant { var1; var2 };
-type AzleInline2236061876033704896 = record {
-  optional : opt nat64;
-  prop1 : text;
-  "variant" : AzleInline7888633673241165148;
-};
-type AzleInline2461023088926241501 = record {
+type AzleInline12567140505456452269 = record {
   "opt" : opt text;
   "vec" : vec text;
   primitive : nat;
   "func" : func () -> (text);
-  "variant" : AzleInline7888633673241165148;
-  "record" : AzleInline4334856068537875025;
+  "variant" : AzleInline8892292986830439123;
+  "record" : AzleInline2796879789686904113;
 };
-type AzleInline2544036346751232949 = record {
-  prop1 : opt text;
-  prop2 : AzleInline16788612102005432527;
-  prop3 : opt AzleInline488414271151064074;
+type AzleInline12761259732196363186 = record {
+  optional : opt nat64;
+  prop1 : text;
+  "variant" : AzleInline8892292986830439123;
 };
-type AzleInline2914978839541039010 = record { prop1 : text; prop2 : Thing };
-type AzleInline3497772238701600867 = variant { prop1 : UserVariant };
-type AzleInline4334856068537875025 = record { prop1 : text };
-type AzleInline4422132652328047813 = record {
-  "variant" : AzleInline7490137446430438151;
-};
-type AzleInline4512439892601748518 = variant { var1; var2; var3 };
-type AzleInline4698629609756288940 = variant { var1; var2 };
-type AzleInline488414271151064074 = record { prop1 : nat };
-type AzleInline7490137446430438151 = variant { var1; var2 : TestVariant };
-type AzleInline7888633673241165148 = variant { v1; v2 };
-type AzleInline8205775227596209522 = record { prop1 : text; prop2 : text };
-type AzleInline8273904979405424738 = variant {
+type AzleInline13053209677524063143 = variant { var1; var2; var3 };
+type AzleInline13321669397179536235 = record { prop1 : nat };
+type AzleInline13533271542184586027 = record { prop1 : text; prop2 : Thing };
+type AzleInline14349533676526529706 = record { prop1 : text };
+type AzleInline15632156002574315610 = variant {
   v1;
   v2;
-  v3 : AzleInline4334856068537875025;
+  v3 : AzleInline75056091434791924;
 };
-type AzleInline8281352489336244159 = record { test : Test };
+type AzleInline156501469918979835 = variant { prop1 : Test };
+type AzleInline16085823266644008377 = variant {
+  ok : opt AzleInline4082601158333989258;
+  err : InsertError;
+};
+type AzleInline16654887267279174714 = variant { prop1 : UserVariant };
+type AzleInline17634699056210974936 = record {
+  "opt" : opt AzleInline12567140505456452269;
+  "vec" : vec AzleInline12567140505456452269;
+  primitive : text;
+  "func" : func () -> (
+      record { prop1 : text; "variant" : AzleInline6442926183131535686 },
+    ) query;
+  "variant" : AzleInline15632156002574315610;
+  "record" : AzleInline12761259732196363186;
+};
+type AzleInline18254169622384439227 = record { testVariant : TestVariant };
+type AzleInline18385892998895713480 = variant { var1; var2 : TestVariant };
+type AzleInline2796879789686904113 = record { prop1 : text };
+type AzleInline3433198680103236386 = record { test : Test };
+type AzleInline3528821404366509568 = record { prop1 : text; prop2 : text };
+type AzleInline40647362636145945 = variant { var1; var2 : TestVariant };
+type AzleInline4082601158333989258 = record {
+  "variant" : AzleInline40647362636145945;
+};
+type AzleInline5634826154517590805 = variant { var1; var2 : TestVariant };
+type AzleInline595875284796351013 = record {
+  "opt" : opt text;
+  "vec" : vec text;
+  primitive : nat;
+  "func" : func () -> (text);
+  "variant" : AzleInline8892292986830439123;
+  "record" : AzleInline75056091434791924;
+};
+type AzleInline5987613880488740375 = record {
+  prop1 : opt text;
+  prop2 : AzleInline40647362636145945;
+  prop3 : opt AzleInline13321669397179536235;
+};
+type AzleInline637595233572856709 = variant { var1; var2 };
+type AzleInline6442926183131535686 = variant {
+  v1;
+  v2 : AzleInline75056091434791924;
+};
+type AzleInline7425494474395383332 = record {
+  "opt" : opt text;
+  "vec" : vec text;
+  primitive : nat;
+  "func" : func () -> (text);
+  "variant" : AzleInline8892292986830439123;
+  "record" : AzleInline75056091434791924;
+};
+type AzleInline75056091434791924 = record { prop1 : text };
+type AzleInline8892292986830439123 = variant { v1; v2 };
 type InsertError = variant {
   ValueTooLarge : KeyTooLarge;
   KeyTooLarge : KeyTooLarge;
 };
 type KeyTooLarge = record { max : nat32; given : nat32 };
-type ManualReply = variant { ok : AzleInline8205775227596209522; err : text };
+type ManualReply = variant { ok : AzleInline3528821404366509568; err : text };
 type Reaction = variant { one; two; three : Test };
 type Test = record { id : text };
 type TestVariant = variant { prop1 : text; prop2 : Test };
 type Thing = record { id : text };
-type User1 = record { id : text; job : AzleInline15709029710433407382 };
+type User1 = record { id : text; job : AzleInline11103238129438584416 };
 type UserVariant = variant { prop1 };
 service : () -> {
-  complex : (AzleInline16598272309081177769) -> (
-      AzleInline16598272309081177769,
+  complex : (AzleInline17634699056210974936) -> (
+      AzleInline17634699056210974936,
     ) query;
   inline_func : (
       func (
           text,
-          opt AzleInline2461023088926241501,
-          vec AzleInline2461023088926241501,
-          AzleInline2236061876033704896,
-          AzleInline8273904979405424738,
+          opt AzleInline7425494474395383332,
+          vec AzleInline7425494474395383332,
+          AzleInline12761259732196363186,
+          AzleInline15632156002574315610,
           func () -> (
               record {
                 prop1 : text;
-                "variant" : AzleInline17765423431258201622;
+                "variant" : AzleInline6442926183131535686;
               },
             ) query,
         ) -> () query,
     ) -> (
       func (
           text,
-          opt AzleInline2461023088926241501,
-          vec AzleInline2461023088926241501,
-          AzleInline2236061876033704896,
-          AzleInline8273904979405424738,
+          opt AzleInline595875284796351013,
+          vec AzleInline595875284796351013,
+          AzleInline12761259732196363186,
+          AzleInline15632156002574315610,
           func () -> (
               record {
                 prop1 : text;
-                "variant" : AzleInline17765423431258201622;
+                "variant" : AzleInline6442926183131535686;
               },
             ) query,
         ) -> () query,
     ) query;
-  inline_record_param : (AzleInline4334856068537875025) -> (text) query;
-  inline_record_return_type : () -> (AzleInline8205775227596209522) query;
+  inline_record_param : (AzleInline75056091434791924) -> (text) query;
+  inline_record_return_type : () -> (AzleInline10606854607571099350) query;
   inline_record_return_type_as_external_canister_call : () -> (ManualReply);
-  inline_variant_param : (AzleInline18069512391554055116) -> (
-      AzleInline4698629609756288940,
+  inline_variant_param : (AzleInline637595233572856709) -> (
+      AzleInline637595233572856709,
     ) query;
-  inline_variant_return_type : () -> (AzleInline4512439892601748518) query;
+  inline_variant_return_type : () -> (AzleInline13053209677524063143) query;
   record_referencing_other_types_from_return_type : () -> (
-      AzleInline2914978839541039010,
+      AzleInline13533271542184586027,
     ) query;
-  record_referencing_record_from_param : (AzleInline8281352489336244159) -> (
+  record_referencing_record_from_param : (AzleInline3433198680103236386) -> (
       text,
     ) query;
-  record_referencing_variant_from_param : (AzleInline10134563958881694720) -> (
+  record_referencing_variant_from_param : (AzleInline18254169622384439227) -> (
       opt text,
     ) query;
   record_with_inline_fields : () -> (User1) query;
-  stable_map_get : (AzleInline16310876903028532563) -> (
-      opt AzleInline10664464874059054195,
+  stable_map_get : (AzleInline5987613880488740375) -> (
+      opt AzleInline12201226198168570047,
     ) query;
   stable_map_insert : (
-      AzleInline2544036346751232949,
-      AzleInline10664464874059054195,
-    ) -> (AzleInline1136376404574922452);
+      AzleInline5987613880488740375,
+      AzleInline12201226198168570047,
+    ) -> (AzleInline16085823266644008377);
   variant_referencing_other_types_from_return_type : () -> (TestVariant) query;
   variant_referencing_record_from_param : (
-      AzleInline11176947628425875238,
+      AzleInline156501469918979835,
     ) -> () query;
   variant_referencing_variant_from_param : (
-      AzleInline3497772238701600867,
+      AzleInline16654887267279174714,
     ) -> () query;
   variant_with_inline_fields : () -> (Reaction) query;
 }

--- a/examples/inline_types/src/inline_types.did
+++ b/examples/inline_types/src/inline_types.did
@@ -1,74 +1,76 @@
-type AzleInline10157776775476251355 = variant {
-  v1;
-  v2;
-  v3 : AzleInline511802176825669836;
+type AzleInline10134563958881694720 = record { testVariant : TestVariant };
+type AzleInline10664464874059054195 = record {
+  "variant" : AzleInline7490137446430438151;
 };
-type AzleInline10500607399545802115 = variant { v1; v2 };
-type AzleInline10606854607571099350 = record { prop1 : text; prop2 : text };
-type AzleInline12201226198168570047 = record {
-  "variant" : AzleInline40647362636145945;
-};
-type AzleInline13053209677524063143 = variant { var1; var2; var3 };
-type AzleInline13321669397179536235 = record { prop1 : nat };
-type AzleInline13533271542184586027 = record { prop1 : text; prop2 : Thing };
-type AzleInline156501469918979835 = variant { prop1 : Test };
-type AzleInline15709029710433407382 = record { id : text; title : text };
-type AzleInline16085823266644008377 = variant {
-  ok : opt AzleInline4082601158333989258;
+type AzleInline11176947628425875238 = variant { prop1 : Test };
+type AzleInline1136376404574922452 = variant {
+  ok : opt AzleInline4422132652328047813;
   err : InsertError;
 };
-type AzleInline16654887267279174714 = variant { prop1 : UserVariant };
-type AzleInline18254169622384439227 = record { testVariant : TestVariant };
-type AzleInline18385892998895713480 = variant { var1; var2 : TestVariant };
-type AzleInline3116605806354637774 = record {
+type AzleInline15709029710433407382 = record { id : text; title : text };
+type AzleInline16310876903028532563 = record {
+  prop1 : opt text;
+  prop2 : AzleInline16788612102005432527;
+  prop3 : opt AzleInline488414271151064074;
+};
+type AzleInline16598272309081177769 = record {
+  "opt" : opt AzleInline2461023088926241501;
+  "vec" : vec AzleInline2461023088926241501;
+  primitive : text;
+  "func" : func () -> (
+      record { prop1 : text; "variant" : AzleInline17765423431258201622 },
+    ) query;
+  "variant" : AzleInline8273904979405424738;
+  "record" : AzleInline2236061876033704896;
+};
+type AzleInline16788612102005432527 = variant { var1; var2 : TestVariant };
+type AzleInline17765423431258201622 = variant {
+  v1;
+  v2 : AzleInline4334856068537875025;
+};
+type AzleInline18069512391554055116 = variant { var1; var2 };
+type AzleInline2236061876033704896 = record {
   optional : opt nat64;
   prop1 : text;
-  "variant" : AzleInline3741885802289446236;
+  "variant" : AzleInline7888633673241165148;
 };
-type AzleInline3433198680103236386 = record { test : Test };
-type AzleInline3528821404366509568 = record { prop1 : text; prop2 : text };
-type AzleInline3741885802289446236 = variant { v1; v2 };
-type AzleInline40647362636145945 = variant { var1; var2 : TestVariant };
-type AzleInline4082601158333989258 = record {
-  "variant" : AzleInline40647362636145945;
-};
-type AzleInline4802940308926078777 = record { prop1 : text };
-type AzleInline511802176825669836 = record { prop1 : text };
-type AzleInline5165610369897643930 = record {
+type AzleInline2461023088926241501 = record {
   "opt" : opt text;
   "vec" : vec text;
   primitive : nat;
   "func" : func () -> (text);
-  "variant" : AzleInline3741885802289446236;
-  "record" : AzleInline511802176825669836;
+  "variant" : AzleInline7888633673241165148;
+  "record" : AzleInline4334856068537875025;
 };
-type AzleInline5634826154517590805 = variant { var1; var2 : TestVariant };
-type AzleInline5987613880488740375 = record {
+type AzleInline2544036346751232949 = record {
   prop1 : opt text;
-  prop2 : AzleInline40647362636145945;
-  prop3 : opt AzleInline13321669397179536235;
+  prop2 : AzleInline16788612102005432527;
+  prop3 : opt AzleInline488414271151064074;
 };
-type AzleInline637595233572856709 = variant { var1; var2 };
-type AzleInline666297162520119653 = variant {
+type AzleInline2914978839541039010 = record { prop1 : text; prop2 : Thing };
+type AzleInline3497772238701600867 = variant { prop1 : UserVariant };
+type AzleInline4334856068537875025 = record { prop1 : text };
+type AzleInline4422132652328047813 = record {
+  "variant" : AzleInline7490137446430438151;
+};
+type AzleInline4512439892601748518 = variant { var1; var2; var3 };
+type AzleInline4698629609756288940 = variant { var1; var2 };
+type AzleInline488414271151064074 = record { prop1 : nat };
+type AzleInline7490137446430438151 = variant { var1; var2 : TestVariant };
+type AzleInline7888633673241165148 = variant { v1; v2 };
+type AzleInline8205775227596209522 = record { prop1 : text; prop2 : text };
+type AzleInline8273904979405424738 = variant {
   v1;
-  v2 : AzleInline511802176825669836;
+  v2;
+  v3 : AzleInline4334856068537875025;
 };
-type AzleInline9139287954320819026 = record {
-  "opt" : opt AzleInline5165610369897643930;
-  "vec" : vec AzleInline5165610369897643930;
-  primitive : text;
-  "func" : func () -> (
-      record { prop1 : text; "variant" : AzleInline666297162520119653 },
-    ) query;
-  "variant" : AzleInline10157776775476251355;
-  "record" : AzleInline3116605806354637774;
-};
+type AzleInline8281352489336244159 = record { test : Test };
 type InsertError = variant {
   ValueTooLarge : KeyTooLarge;
   KeyTooLarge : KeyTooLarge;
 };
 type KeyTooLarge = record { max : nat32; given : nat32 };
-type ManualReply = variant { ok : AzleInline3528821404366509568; err : text };
+type ManualReply = variant { ok : AzleInline8205775227596209522; err : text };
 type Reaction = variant { one; two; three : Test };
 type Test = record { id : text };
 type TestVariant = variant { prop1 : text; prop2 : Test };
@@ -76,62 +78,68 @@ type Thing = record { id : text };
 type User1 = record { id : text; job : AzleInline15709029710433407382 };
 type UserVariant = variant { prop1 };
 service : () -> {
-  complex : (AzleInline9139287954320819026) -> (
-      AzleInline9139287954320819026,
+  complex : (AzleInline16598272309081177769) -> (
+      AzleInline16598272309081177769,
     ) query;
   inline_func : (
       func (
           text,
-          opt AzleInline5165610369897643930,
-          vec AzleInline5165610369897643930,
-          AzleInline3116605806354637774,
-          AzleInline10157776775476251355,
+          opt AzleInline2461023088926241501,
+          vec AzleInline2461023088926241501,
+          AzleInline2236061876033704896,
+          AzleInline8273904979405424738,
           func () -> (
-              record { prop1 : text; "variant" : AzleInline666297162520119653 },
+              record {
+                prop1 : text;
+                "variant" : AzleInline17765423431258201622;
+              },
             ) query,
         ) -> () query,
     ) -> (
       func (
           text,
-          opt AzleInline5165610369897643930,
-          vec AzleInline5165610369897643930,
-          AzleInline3116605806354637774,
-          AzleInline10157776775476251355,
+          opt AzleInline2461023088926241501,
+          vec AzleInline2461023088926241501,
+          AzleInline2236061876033704896,
+          AzleInline8273904979405424738,
           func () -> (
-              record { prop1 : text; "variant" : AzleInline666297162520119653 },
+              record {
+                prop1 : text;
+                "variant" : AzleInline17765423431258201622;
+              },
             ) query,
         ) -> () query,
     ) query;
-  inline_record_param : (AzleInline511802176825669836) -> (text) query;
-  inline_record_return_type : () -> (AzleInline10606854607571099350) query;
+  inline_record_param : (AzleInline4334856068537875025) -> (text) query;
+  inline_record_return_type : () -> (AzleInline8205775227596209522) query;
   inline_record_return_type_as_external_canister_call : () -> (ManualReply);
-  inline_variant_param : (AzleInline637595233572856709) -> (
-      AzleInline637595233572856709,
+  inline_variant_param : (AzleInline18069512391554055116) -> (
+      AzleInline4698629609756288940,
     ) query;
-  inline_variant_return_type : () -> (AzleInline13053209677524063143) query;
+  inline_variant_return_type : () -> (AzleInline4512439892601748518) query;
   record_referencing_other_types_from_return_type : () -> (
-      AzleInline13533271542184586027,
+      AzleInline2914978839541039010,
     ) query;
-  record_referencing_record_from_param : (AzleInline3433198680103236386) -> (
+  record_referencing_record_from_param : (AzleInline8281352489336244159) -> (
       text,
     ) query;
-  record_referencing_variant_from_param : (AzleInline18254169622384439227) -> (
+  record_referencing_variant_from_param : (AzleInline10134563958881694720) -> (
       opt text,
     ) query;
   record_with_inline_fields : () -> (User1) query;
-  stable_map_get : (AzleInline5987613880488740375) -> (
-      opt AzleInline12201226198168570047,
+  stable_map_get : (AzleInline16310876903028532563) -> (
+      opt AzleInline10664464874059054195,
     ) query;
   stable_map_insert : (
-      AzleInline5987613880488740375,
-      AzleInline12201226198168570047,
-    ) -> (AzleInline16085823266644008377);
+      AzleInline2544036346751232949,
+      AzleInline10664464874059054195,
+    ) -> (AzleInline1136376404574922452);
   variant_referencing_other_types_from_return_type : () -> (TestVariant) query;
   variant_referencing_record_from_param : (
-      AzleInline156501469918979835,
+      AzleInline11176947628425875238,
     ) -> () query;
   variant_referencing_variant_from_param : (
-      AzleInline16654887267279174714,
+      AzleInline3497772238701600867,
     ) -> () query;
   variant_with_inline_fields : () -> (Reaction) query;
 }

--- a/examples/inline_types/src/inline_types.ts
+++ b/examples/inline_types/src/inline_types.ts
@@ -1,7 +1,7 @@
 import {
     Func,
-    FuncQuery,
-    FuncUpdate,
+    Query,
+    Update,
     InsertError,
     nat,
     nat64,
@@ -195,7 +195,7 @@ export async function inline_record_return_type_as_external_canister_call(): Pro
 $query;
 export function inline_func(
     callback: Func<
-        FuncQuery<
+        Query<
             (
                 primitive: string,
                 opt: Opt<{
@@ -204,7 +204,7 @@ export function inline_func(
                     vec: string[];
                     record: { prop1: string };
                     variant: Variant<{ v1: null; v2: null }>;
-                    func: Func<FuncUpdate<() => string>>;
+                    func: Func<Update<() => string>>;
                 }>,
                 vec: {
                     primitive: nat;
@@ -212,7 +212,7 @@ export function inline_func(
                     vec: string[];
                     record: { prop1: string };
                     variant: Variant<{ v1: null; v2: null }>;
-                    func: Func<FuncUpdate<() => string>>;
+                    func: Func<Update<() => string>>;
                 }[],
                 record: {
                     prop1: string;
@@ -221,7 +221,7 @@ export function inline_func(
                 },
                 variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>,
                 func: Func<
-                    FuncQuery<
+                    Query<
                         () => {
                             prop1: string;
                             variant: Variant<{
@@ -235,7 +235,7 @@ export function inline_func(
         >
     >
 ): Func<
-    FuncQuery<
+    Query<
         (
             primitive: string,
             opt: Opt<{
@@ -244,7 +244,7 @@ export function inline_func(
                 vec: string[];
                 record: { prop1: string };
                 variant: Variant<{ v1: null; v2: null }>;
-                func: Func<FuncUpdate<() => string>>;
+                func: Func<Update<() => string>>;
             }>,
             vec: {
                 primitive: nat;
@@ -252,7 +252,7 @@ export function inline_func(
                 vec: string[];
                 record: { prop1: string };
                 variant: Variant<{ v1: null; v2: null }>;
-                func: Func<FuncUpdate<() => string>>;
+                func: Func<Update<() => string>>;
             }[],
             record: {
                 prop1: string;
@@ -261,7 +261,7 @@ export function inline_func(
             },
             variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>,
             func: Func<
-                FuncQuery<
+                Query<
                     () => {
                         prop1: string;
                         variant: Variant<{
@@ -286,7 +286,7 @@ export function complex(record: {
         vec: string[];
         record: { prop1: string };
         variant: Variant<{ v1: null; v2: null }>;
-        func: Func<FuncUpdate<() => string>>;
+        func: Func<Update<() => string>>;
     }>;
     vec: {
         primitive: nat;
@@ -294,7 +294,7 @@ export function complex(record: {
         vec: string[];
         record: { prop1: string };
         variant: Variant<{ v1: null; v2: null }>;
-        func: Func<FuncUpdate<() => string>>;
+        func: Func<Update<() => string>>;
     }[];
     record: {
         prop1: string;
@@ -303,7 +303,7 @@ export function complex(record: {
     };
     variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>;
     func: Func<
-        FuncQuery<
+        Query<
             () => {
                 prop1: string;
                 variant: Variant<{ v1: null; v2: { prop1: string } }>;
@@ -318,7 +318,7 @@ export function complex(record: {
         vec: string[];
         record: { prop1: string };
         variant: Variant<{ v1: null; v2: null }>;
-        func: Func<FuncUpdate<() => string>>;
+        func: Func<Update<() => string>>;
     }>;
     vec: {
         primitive: nat;
@@ -326,7 +326,7 @@ export function complex(record: {
         vec: string[];
         record: { prop1: string };
         variant: Variant<{ v1: null; v2: null }>;
-        func: Func<FuncUpdate<() => string>>;
+        func: Func<Update<() => string>>;
     }[];
     record: {
         prop1: string;
@@ -335,7 +335,7 @@ export function complex(record: {
     };
     variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>;
     func: Func<
-        FuncQuery<
+        Query<
             () => {
                 prop1: string;
                 variant: Variant<{ v1: null; v2: { prop1: string } }>;

--- a/examples/inline_types/src/inline_types.ts
+++ b/examples/inline_types/src/inline_types.ts
@@ -1,14 +1,14 @@
 import {
     Func,
+    FuncQuery,
+    FuncUpdate,
     InsertError,
     nat,
     nat64,
     Opt,
     $query,
-    Query,
     StableBTreeMap,
     $update,
-    Update,
     Variant
 } from 'azle';
 import {
@@ -195,6 +195,47 @@ export async function inline_record_return_type_as_external_canister_call(): Pro
 $query;
 export function inline_func(
     callback: Func<
+        FuncQuery<
+            (
+                primitive: string,
+                opt: Opt<{
+                    primitive: nat;
+                    opt: Opt<string>;
+                    vec: string[];
+                    record: { prop1: string };
+                    variant: Variant<{ v1: null; v2: null }>;
+                    func: Func<FuncUpdate<() => string>>;
+                }>,
+                vec: {
+                    primitive: nat;
+                    opt: Opt<string>;
+                    vec: string[];
+                    record: { prop1: string };
+                    variant: Variant<{ v1: null; v2: null }>;
+                    func: Func<FuncUpdate<() => string>>;
+                }[],
+                record: {
+                    prop1: string;
+                    optional: Opt<nat64>;
+                    variant: Variant<{ v1: null; v2: null }>;
+                },
+                variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>,
+                func: Func<
+                    FuncQuery<
+                        () => {
+                            prop1: string;
+                            variant: Variant<{
+                                v1: null;
+                                v2: { prop1: string };
+                            }>;
+                        }
+                    >
+                >
+            ) => void
+        >
+    >
+): Func<
+    FuncQuery<
         (
             primitive: string,
             opt: Opt<{
@@ -203,7 +244,7 @@ export function inline_func(
                 vec: string[];
                 record: { prop1: string };
                 variant: Variant<{ v1: null; v2: null }>;
-                func: Func<() => Update<string>>;
+                func: Func<FuncUpdate<() => string>>;
             }>,
             vec: {
                 primitive: nat;
@@ -211,7 +252,7 @@ export function inline_func(
                 vec: string[];
                 record: { prop1: string };
                 variant: Variant<{ v1: null; v2: null }>;
-                func: Func<() => Update<string>>;
+                func: Func<FuncUpdate<() => string>>;
             }[],
             record: {
                 prop1: string;
@@ -220,51 +261,18 @@ export function inline_func(
             },
             variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>,
             func: Func<
-                () => Query<{
-                    prop1: string;
-                    variant: Variant<{
-                        v1: null;
-                        v2: { prop1: string };
-                    }>;
-                }>
+                FuncQuery<
+                    () => {
+                        prop1: string;
+                        variant: Variant<{
+                            v1: null;
+                            v2: { prop1: string };
+                        }>;
+                    }
+                >
             >
-        ) => Query<void>
+        ) => void
     >
-): Func<
-    (
-        primitive: string,
-        opt: Opt<{
-            primitive: nat;
-            opt: Opt<string>;
-            vec: string[];
-            record: { prop1: string };
-            variant: Variant<{ v1: null; v2: null }>;
-            func: Func<() => Update<string>>;
-        }>,
-        vec: {
-            primitive: nat;
-            opt: Opt<string>;
-            vec: string[];
-            record: { prop1: string };
-            variant: Variant<{ v1: null; v2: null }>;
-            func: Func<() => Update<string>>;
-        }[],
-        record: {
-            prop1: string;
-            optional: Opt<nat64>;
-            variant: Variant<{ v1: null; v2: null }>;
-        },
-        variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>,
-        func: Func<
-            () => Query<{
-                prop1: string;
-                variant: Variant<{
-                    v1: null;
-                    v2: { prop1: string };
-                }>;
-            }>
-        >
-    ) => Query<void>
 > {
     return callback;
 }
@@ -278,7 +286,7 @@ export function complex(record: {
         vec: string[];
         record: { prop1: string };
         variant: Variant<{ v1: null; v2: null }>;
-        func: Func<() => Update<string>>;
+        func: Func<FuncUpdate<() => string>>;
     }>;
     vec: {
         primitive: nat;
@@ -286,7 +294,7 @@ export function complex(record: {
         vec: string[];
         record: { prop1: string };
         variant: Variant<{ v1: null; v2: null }>;
-        func: Func<() => Update<string>>;
+        func: Func<FuncUpdate<() => string>>;
     }[];
     record: {
         prop1: string;
@@ -295,10 +303,12 @@ export function complex(record: {
     };
     variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>;
     func: Func<
-        () => Query<{
-            prop1: string;
-            variant: Variant<{ v1: null; v2: { prop1: string } }>;
-        }>
+        FuncQuery<
+            () => {
+                prop1: string;
+                variant: Variant<{ v1: null; v2: { prop1: string } }>;
+            }
+        >
     >;
 }): {
     primitive: string;
@@ -308,7 +318,7 @@ export function complex(record: {
         vec: string[];
         record: { prop1: string };
         variant: Variant<{ v1: null; v2: null }>;
-        func: Func<() => Update<string>>;
+        func: Func<FuncUpdate<() => string>>;
     }>;
     vec: {
         primitive: nat;
@@ -316,7 +326,7 @@ export function complex(record: {
         vec: string[];
         record: { prop1: string };
         variant: Variant<{ v1: null; v2: null }>;
-        func: Func<() => Update<string>>;
+        func: Func<FuncUpdate<() => string>>;
     }[];
     record: {
         prop1: string;
@@ -325,10 +335,12 @@ export function complex(record: {
     };
     variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>;
     func: Func<
-        () => Query<{
-            prop1: string;
-            variant: Variant<{ v1: null; v2: { prop1: string } }>;
-        }>
+        FuncQuery<
+            () => {
+                prop1: string;
+                variant: Variant<{ v1: null; v2: { prop1: string } }>;
+            }
+        >
     >;
 } {
     return record;

--- a/examples/inline_types/src/types.ts
+++ b/examples/inline_types/src/types.ts
@@ -3,8 +3,8 @@ import {
     ExternalCanister,
     InsertError,
     Func,
-    FuncQuery,
-    FuncUpdate,
+    Query,
+    Update,
     Opt,
     Principal,
     nat,
@@ -127,71 +127,93 @@ export type InlineTypesOld = Canister<{
     >;
     inline_func(
         callback: Func<
-            (
-                primitive: string,
-                opt: Opt<{
-                    primitive: nat;
-                    opt: Opt<string>;
-                    vec: string[];
-                    record: { prop1: string };
-                    variant: Variant<{ v1: null; v2: null }>;
-                    func: Func<() => Update<string>>;
-                }>,
-                vec: {
-                    primitive: nat;
-                    opt: Opt<string>;
-                    vec: string[];
-                    record: { prop1: string };
-                    variant: Variant<{ v1: null; v2: null }>;
-                    func: Func<() => Update<string>>;
-                }[],
-                record: {
-                    prop1: string;
-                    optional: Opt<nat64>;
-                    variant: Variant<{ v1: null; v2: null }>;
-                },
-                variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>,
-                func: Func<
-                    () => Query<{
+            Query<
+                (
+                    primitive: string,
+                    opt: Opt<{
+                        primitive: nat;
+                        opt: Opt<string>;
+                        vec: string[];
+                        record: { prop1: string };
+                        variant: Variant<{ v1: null; v2: null }>;
+                        func: Func<Update<() => string>>;
+                    }>,
+                    vec: {
+                        primitive: nat;
+                        opt: Opt<string>;
+                        vec: string[];
+                        record: { prop1: string };
+                        variant: Variant<{ v1: null; v2: null }>;
+                        func: Func<Update<() => string>>;
+                    }[],
+                    record: {
                         prop1: string;
-                        variant: Variant<{ v1: null; v2: { prop1: string } }>;
-                    }>
-                >
-            ) => Query<void>
+                        optional: Opt<nat64>;
+                        variant: Variant<{ v1: null; v2: null }>;
+                    },
+                    variant: Variant<{
+                        v1: null;
+                        v2: null;
+                        v3: { prop1: string };
+                    }>,
+                    func: Func<
+                        Query<
+                            () => {
+                                prop1: string;
+                                variant: Variant<{
+                                    v1: null;
+                                    v2: { prop1: string };
+                                }>;
+                            }
+                        >
+                    >
+                ) => void
+            >
         >
     ): CanisterResult<
         Func<
-            (
-                primitive: string,
-                opt: Opt<{
-                    primitive: nat;
-                    opt: Opt<string>;
-                    vec: string[];
-                    record: { prop1: string };
-                    variant: Variant<{ v1: null; v2: null }>;
-                    func: Func<() => Update<string>>;
-                }>,
-                vec: {
-                    primitive: nat;
-                    opt: Opt<string>;
-                    vec: string[];
-                    record: { prop1: string };
-                    variant: Variant<{ v1: null; v2: null }>;
-                    func: Func<() => Update<string>>;
-                }[],
-                record: {
-                    prop1: string;
-                    optional: Opt<nat64>;
-                    variant: Variant<{ v1: null; v2: null }>;
-                },
-                variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>,
-                func: Func<
-                    () => Query<{
+            Query<
+                (
+                    primitive: string,
+                    opt: Opt<{
+                        primitive: nat;
+                        opt: Opt<string>;
+                        vec: string[];
+                        record: { prop1: string };
+                        variant: Variant<{ v1: null; v2: null }>;
+                        func: Func<Update<() => string>>;
+                    }>,
+                    vec: {
+                        primitive: nat;
+                        opt: Opt<string>;
+                        vec: string[];
+                        record: { prop1: string };
+                        variant: Variant<{ v1: null; v2: null }>;
+                        func: Func<Update<() => string>>;
+                    }[],
+                    record: {
                         prop1: string;
-                        variant: Variant<{ v1: null; v2: { prop1: string } }>;
-                    }>
-                >
-            ) => Query<void>
+                        optional: Opt<nat64>;
+                        variant: Variant<{ v1: null; v2: null }>;
+                    },
+                    variant: Variant<{
+                        v1: null;
+                        v2: null;
+                        v3: { prop1: string };
+                    }>,
+                    func: Func<
+                        Query<
+                            () => {
+                                prop1: string;
+                                variant: Variant<{
+                                    v1: null;
+                                    v2: { prop1: string };
+                                }>;
+                            }
+                        >
+                    >
+                ) => void
+            >
         >
     >;
     inline_record_return_type_as_external_canister_call(): CanisterResult<
@@ -211,7 +233,7 @@ export type InlineTypesOld = Canister<{
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<() => Update<string>>;
+            func: Func<Update<() => string>>;
         }>;
         vec: {
             primitive: nat;
@@ -219,7 +241,7 @@ export type InlineTypesOld = Canister<{
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<() => Update<string>>;
+            func: Func<Update<() => string>>;
         }[];
         record: {
             prop1: string;
@@ -228,10 +250,12 @@ export type InlineTypesOld = Canister<{
         };
         variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>;
         func: Func<
-            () => Query<{
-                prop1: string;
-                variant: Variant<{ v1: null; v2: { prop1: string } }>;
-            }>
+            Query<
+                () => {
+                    prop1: string;
+                    variant: Variant<{ v1: null; v2: { prop1: string } }>;
+                }
+            >
         >;
     }): CanisterResult<{
         primitive: string;
@@ -241,7 +265,7 @@ export type InlineTypesOld = Canister<{
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<() => Update<string>>;
+            func: Func<Update<() => string>>;
         }>;
         vec: {
             primitive: nat;
@@ -249,7 +273,7 @@ export type InlineTypesOld = Canister<{
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<() => Update<string>>;
+            func: Func<Update<() => string>>;
         }[];
         record: {
             prop1: string;
@@ -258,10 +282,12 @@ export type InlineTypesOld = Canister<{
         };
         variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>;
         func: Func<
-            () => Query<{
-                prop1: string;
-                variant: Variant<{ v1: null; v2: { prop1: string } }>;
-            }>
+            Query<
+                () => {
+                    prop1: string;
+                    variant: Variant<{ v1: null; v2: { prop1: string } }>;
+                }
+            >
         >;
     }>;
 }>;
@@ -363,7 +389,7 @@ export class InlineTypes extends ExternalCanister {
     @query
     inline_func: (
         callback: Func<
-            FuncQuery<
+            Query<
                 (
                     primitive: string,
                     opt: Opt<{
@@ -372,7 +398,7 @@ export class InlineTypes extends ExternalCanister {
                         vec: string[];
                         record: { prop1: string };
                         variant: Variant<{ v1: null; v2: null }>;
-                        func: Func<FuncUpdate<() => string>>;
+                        func: Func<Update<() => string>>;
                     }>,
                     vec: {
                         primitive: nat;
@@ -380,7 +406,7 @@ export class InlineTypes extends ExternalCanister {
                         vec: string[];
                         record: { prop1: string };
                         variant: Variant<{ v1: null; v2: null }>;
-                        func: Func<FuncUpdate<() => string>>;
+                        func: Func<Update<() => string>>;
                     }[],
                     record: {
                         prop1: string;
@@ -393,7 +419,7 @@ export class InlineTypes extends ExternalCanister {
                         v3: { prop1: string };
                     }>,
                     func: Func<
-                        FuncQuery<
+                        Query<
                             () => {
                                 prop1: string;
                                 variant: Variant<{
@@ -408,7 +434,7 @@ export class InlineTypes extends ExternalCanister {
         >
     ) => CanisterResult<
         Func<
-            FuncQuery<
+            Query<
                 (
                     primitive: string,
                     opt: Opt<{
@@ -417,7 +443,7 @@ export class InlineTypes extends ExternalCanister {
                         vec: string[];
                         record: { prop1: string };
                         variant: Variant<{ v1: null; v2: null }>;
-                        func: Func<FuncUpdate<() => string>>;
+                        func: Func<Update<() => string>>;
                     }>,
                     vec: {
                         primitive: nat;
@@ -425,7 +451,7 @@ export class InlineTypes extends ExternalCanister {
                         vec: string[];
                         record: { prop1: string };
                         variant: Variant<{ v1: null; v2: null }>;
-                        func: Func<FuncUpdate<() => string>>;
+                        func: Func<Update<() => string>>;
                     }[],
                     record: {
                         prop1: string;
@@ -438,7 +464,7 @@ export class InlineTypes extends ExternalCanister {
                         v3: { prop1: string };
                     }>,
                     func: Func<
-                        FuncQuery<
+                        Query<
                             () => {
                                 prop1: string;
                                 variant: Variant<{
@@ -473,7 +499,7 @@ export class InlineTypes extends ExternalCanister {
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<FuncUpdate<() => string>>;
+            func: Func<Update<() => string>>;
         }>;
         vec: {
             primitive: nat;
@@ -481,7 +507,7 @@ export class InlineTypes extends ExternalCanister {
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<FuncUpdate<() => string>>;
+            func: Func<Update<() => string>>;
         }[];
         record: {
             prop1: string;
@@ -490,7 +516,7 @@ export class InlineTypes extends ExternalCanister {
         };
         variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>;
         func: Func<
-            FuncQuery<
+            Query<
                 () => {
                     prop1: string;
                     variant: Variant<{ v1: null; v2: { prop1: string } }>;
@@ -505,7 +531,7 @@ export class InlineTypes extends ExternalCanister {
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<FuncUpdate<() => string>>;
+            func: Func<Update<() => string>>;
         }>;
         vec: {
             primitive: nat;
@@ -513,7 +539,7 @@ export class InlineTypes extends ExternalCanister {
             vec: string[];
             record: { prop1: string };
             variant: Variant<{ v1: null; v2: null }>;
-            func: Func<FuncUpdate<() => string>>;
+            func: Func<Update<() => string>>;
         }[];
         record: {
             prop1: string;
@@ -522,7 +548,7 @@ export class InlineTypes extends ExternalCanister {
         };
         variant: Variant<{ v1: null; v2: null; v3: { prop1: string } }>;
         func: Func<
-            FuncQuery<
+            Query<
                 () => {
                     prop1: string;
                     variant: Variant<{ v1: null; v2: { prop1: string } }>;

--- a/examples/list_of_lists/src/index.ts
+++ b/examples/list_of_lists/src/index.ts
@@ -5,6 +5,7 @@ import {
     float32,
     float64,
     Func,
+    FuncQuery,
     int,
     int16,
     int32,
@@ -16,7 +17,6 @@ import {
     nat64,
     nat8,
     Opt,
-    Query,
     $query,
     reserved,
     Variant
@@ -33,7 +33,7 @@ type State = Variant<{
     gas: null;
 }>;
 
-type BasicFunc = Func<(param1: string) => Query<string>>;
+type BasicFunc = Func<FuncQuery<(param1: string) => string>>;
 
 $query;
 export function list_of_string_one(param: string[]): string[] {

--- a/examples/list_of_lists/src/index.ts
+++ b/examples/list_of_lists/src/index.ts
@@ -5,7 +5,7 @@ import {
     float32,
     float64,
     Func,
-    FuncQuery,
+    Query,
     int,
     int16,
     int32,
@@ -33,7 +33,7 @@ type State = Variant<{
     gas: null;
 }>;
 
-type BasicFunc = Func<FuncQuery<(param1: string) => string>>;
+type BasicFunc = Func<Query<(param1: string) => string>>;
 
 $query;
 export function list_of_string_one(param: string[]): string[] {

--- a/examples/motoko_examples/http_counter/src/main.ts
+++ b/examples/motoko_examples/http_counter/src/main.ts
@@ -1,7 +1,7 @@
 import {
     blob,
     Func,
-    FuncQuery,
+    Query,
     ic,
     nat,
     nat16,
@@ -28,7 +28,7 @@ type CallbackStrategy = {
     token: Token;
 };
 
-type Callback = Func<FuncQuery<(t: Token) => StreamingCallbackHttpResponse>>;
+type Callback = Func<Query<(t: Token) => StreamingCallbackHttpResponse>>;
 
 type StreamingStrategy = Variant<{
     Callback: CallbackStrategy;

--- a/examples/motoko_examples/http_counter/src/main.ts
+++ b/examples/motoko_examples/http_counter/src/main.ts
@@ -1,12 +1,12 @@
 import {
     blob,
     Func,
+    FuncQuery,
     ic,
     nat,
     nat16,
     Opt,
     $query,
-    Query,
     StableBTreeMap,
     $update,
     Variant
@@ -28,7 +28,7 @@ type CallbackStrategy = {
     token: Token;
 };
 
-type Callback = Func<(t: Token) => Query<StreamingCallbackHttpResponse>>;
+type Callback = Func<FuncQuery<(t: Token) => StreamingCallbackHttpResponse>>;
 
 type StreamingStrategy = Variant<{
     Callback: CallbackStrategy;

--- a/index.ts
+++ b/index.ts
@@ -117,6 +117,10 @@ type ic = {
     trap: (message: string) => never;
 };
 
+// TODO see if we can get the T here to have some more information, like the func type
+// TODO we especially want to add the possibility of an optional cycle parameter and the notify method
+export type Canister<T> = T;
+
 export type Variant<T> = Partial<T>;
 export type Opt<T> = T | null;
 
@@ -192,10 +196,9 @@ export function attempt<T, E>(
     }
 }
 
-// TODO rename these to Query, Update, and Oneway after the custom decorators refactor
-export type FuncQuery<T> = T;
-export type FuncUpdate<T> = T;
-export type FuncOneway<T> = T;
+export type Query<T> = T;
+export type Update<T> = T;
+export type Oneway<T> = T;
 
 // TODO type this more strictly
 export type Func<T extends (...args: any[]) => any> = [Principal, string];

--- a/index.ts
+++ b/index.ts
@@ -117,20 +117,6 @@ type ic = {
     trap: (message: string) => never;
 };
 
-export type PreUpgrade = void;
-export type PostUpgrade = void;
-export type Heartbeat = void;
-export type Init = void;
-export type InspectMessage = void;
-export type Query<T> = T;
-export type Manual<T> = void;
-export type Update<T> = T;
-export type Oneway = void;
-
-// TODO see if we can get the T here to have some more information, like the func type
-// TODO we especially want to add the possibility of an optional cycle parameter and the notify method
-export type Canister<T> = T;
-
 export type Variant<T> = Partial<T>;
 export type Opt<T> = T | null;
 
@@ -206,10 +192,13 @@ export function attempt<T, E>(
     }
 }
 
+// TODO rename these to Query, Update, and Oneway after the custom decorators refactor
+export type FuncQuery<T> = T;
+export type FuncUpdate<T> = T;
+export type FuncOneway<T> = T;
+
 // TODO type this more strictly
-export type Func<
-    T extends (...args: any[]) => Query<any> | Update<any> | Oneway
-> = [Principal, string];
+export type Func<T extends (...args: any[]) => any> = [Principal, string];
 
 export { Principal } from '@dfinity/principal';
 
@@ -312,3 +301,5 @@ export const $post_upgrade = (options: { guard: string }) => {};
 export const $pre_upgrade = (options: { guard: string }) => {};
 export const $query = (options: { guard: string }) => {};
 export const $update = (options: { guard: string }) => {};
+
+export type Manual<T> = void;

--- a/index.ts
+++ b/index.ts
@@ -196,12 +196,12 @@ export function attempt<T, E>(
     }
 }
 
-export type Query<T> = T;
-export type Update<T> = T;
-export type Oneway<T> = T;
+// TODO type these more strictly
+export type Query<T extends (...args: any[]) => any> = [Principal, string];
+export type Update<T extends (...args: any[]) => any> = [Principal, string];
+export type Oneway<T extends (...args: any[]) => any> = [Principal, string];
 
-// TODO type this more strictly
-export type Func<T extends (...args: any[]) => any> = [Principal, string];
+export type Func<T> = T;
 
 export { Principal } from '@dfinity/principal';
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_functions_and_methods/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_functions_and_methods/mod.rs
@@ -1,6 +1,6 @@
 mod ts_fn_param;
 
-use swc_ecma_ast::{TsEntityName, TsFnParam, TsType, TsTypeAnn};
+use swc_ecma_ast::{TsFnParam, TsType, TsTypeAnn};
 
 use super::{GetName, GetTsType};
 
@@ -16,43 +16,6 @@ pub trait FunctionAndMethodTypeHelperMethods {
     }
 
     fn get_return_type(&self) -> Option<TsType> {
-        let mode = self.get_func_mode();
-        if mode == "Oneway" {
-            None
-        } else {
-            let ts_type = self.get_ts_type_ann().get_ts_type();
-            let ts_type_ref = ts_type.as_ts_type_ref().unwrap();
-            match &ts_type_ref.type_params {
-                Some(type_param_inst) => {
-                    if type_param_inst.params.len() != 1 {
-                        panic!("Func must specify exactly one return type")
-                    }
-                    match type_param_inst.params.get(0) {
-                        Some(param) => {
-                            let ts_type = &**param;
-                            Some(ts_type.clone())
-                        }
-                        None => panic!("Func must specify exactly one return type"),
-                    }
-                }
-                None => panic!("Func must specify a return type"),
-            }
-        }
-    }
-
-    fn get_func_mode(&self) -> String {
-        match self.get_ts_type_ann().get_ts_type() {
-            TsType::TsTypeRef(type_reference) => match &type_reference.type_name {
-                TsEntityName::TsQualifiedName(_) => panic!("Unsupported qualified name. Func return type must directly be Query, Update, or Oneway"),
-                TsEntityName::Ident(identifier) => {
-                let mode = identifier.get_name();
-                if !self.get_valid_return_types().contains(&mode) {
-                    panic!("Return type must be one of {:?}", self.get_valid_return_types())
-                }
-                mode.to_string()
-            }
-            },
-            _ => panic!("Return type must be one of {:?}", self.get_valid_return_types()),
-        }
+        Some(self.get_ts_type_ann().get_ts_type())
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_functions_and_methods/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_functions_and_methods/mod.rs
@@ -8,14 +8,11 @@ pub trait FunctionAndMethodTypeHelperMethods {
     fn get_ts_type_ann(&self) -> TsTypeAnn;
     fn get_ts_fn_params(&self) -> Vec<TsFnParam>;
     fn get_valid_return_types(&self) -> Vec<&str>;
+    fn get_return_type(&self) -> Option<TsType>;
 
     fn get_param_types(&self) -> Vec<TsType> {
         self.get_ts_fn_params().iter().fold(vec![], |acc, param| {
             vec![acc, vec![param.get_ts_type().clone()]].concat()
         })
-    }
-
-    fn get_return_type(&self) -> Option<TsType> {
-        Some(self.get_ts_type_ann().get_ts_type())
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_fn_or_constructor_type/azle_fn_type/function_and_method_type_helper_methods.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_fn_or_constructor_type/azle_fn_type/function_and_method_type_helper_methods.rs
@@ -1,7 +1,7 @@
-use swc_ecma_ast::{TsFnParam, TsTypeAnn};
+use swc_ecma_ast::{TsFnParam, TsType, TsTypeAnn};
 
 use super::AzleFnType;
-use crate::ts_ast::FunctionAndMethodTypeHelperMethods;
+use crate::ts_ast::{ast_traits::GetTsType, FunctionAndMethodTypeHelperMethods};
 
 impl FunctionAndMethodTypeHelperMethods for AzleFnType<'_> {
     fn get_ts_fn_params(&self) -> Vec<TsFnParam> {
@@ -14,5 +14,9 @@ impl FunctionAndMethodTypeHelperMethods for AzleFnType<'_> {
 
     fn get_valid_return_types(&self) -> Vec<&str> {
         vec!["Oneway", "Update", "Query"]
+    }
+
+    fn get_return_type(&self) -> Option<TsType> {
+        Some(self.get_ts_type_ann().get_ts_type())
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_lit/azle_type_element/azle_method_signature/function_and_method_helpers.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_lit/azle_type_element/azle_method_signature/function_and_method_helpers.rs
@@ -1,8 +1,9 @@
-use swc_ecma_ast::{TsFnParam, TsTypeAnn};
-
-use crate::ts_ast::azle_functions_and_methods::FunctionAndMethodTypeHelperMethods;
+use swc_ecma_ast::{TsEntityName, TsFnParam, TsType, TsTypeAnn};
 
 use super::AzleMethodSignature;
+use crate::ts_ast::{
+    ast_traits::GetTsType, azle_functions_and_methods::FunctionAndMethodTypeHelperMethods, GetName,
+};
 
 impl FunctionAndMethodTypeHelperMethods for AzleMethodSignature<'_> {
     fn get_ts_fn_params(&self) -> Vec<TsFnParam> {
@@ -18,5 +19,43 @@ impl FunctionAndMethodTypeHelperMethods for AzleMethodSignature<'_> {
 
     fn get_valid_return_types(&self) -> Vec<&str> {
         vec!["Oneway", "Update", "Query", "CanisterResult"]
+    }
+
+    fn get_return_type(&self) -> Option<TsType> {
+        let mode = match self.get_ts_type_ann().get_ts_type() {
+            TsType::TsTypeRef(type_reference) => match &type_reference.type_name {
+                TsEntityName::TsQualifiedName(_) => panic!("Unsupported qualified name. Func return type must directly be Query, Update, or Oneway"),
+                TsEntityName::Ident(identifier) => {
+                let mode = identifier.get_name();
+                if !self.get_valid_return_types().contains(&mode) {
+                    panic!("Return type must be one of {:?}", self.get_valid_return_types())
+                }
+                mode.to_string()
+            }
+            },
+            _ => panic!("Return type must be one of {:?}", self.get_valid_return_types()),
+        };
+
+        if mode == "Oneway" {
+            None
+        } else {
+            let ts_type = self.get_ts_type_ann().get_ts_type();
+            let ts_type_ref = ts_type.as_ts_type_ref().unwrap();
+            match &ts_type_ref.type_params {
+                Some(type_param_inst) => {
+                    if type_param_inst.params.len() != 1 {
+                        panic!("Func must specify exactly one return type")
+                    }
+                    match type_param_inst.params.get(0) {
+                        Some(param) => {
+                            let ts_type = &**param;
+                            Some(ts_type.clone())
+                        }
+                        None => panic!("Func must specify exactly one return type"),
+                    }
+                }
+                None => panic!("Func must specify a return type"),
+            }
+        }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_ref/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_ref/errors.rs
@@ -220,7 +220,7 @@ impl AzleTypeRef<'_> {
     // the wrong name, we should only modify the name in the example, (rather
     // than nuking their function signature).
     fn func_wrong_enclosed_type_error(&self) -> ErrorMessage {
-        let example_func = "Update<() => void".to_string();
+        let example_func = "Update<() => void>".to_string();
 
         let type_params_absolute_range = (self.get_enclosed_span().lo, self.get_enclosed_span().hi);
         let source = self
@@ -236,7 +236,7 @@ impl AzleTypeRef<'_> {
             "{}{}{}",
             source[..start_pos + 1].to_string(),
             example_func,
-            source[end_pos..].to_string()
+            source[end_pos - 1..].to_string()
         );
 
         ErrorMessage {

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_ref/errors.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_ref/errors.rs
@@ -210,16 +210,33 @@ impl AzleTypeRef<'_> {
         }
     }
 
+    // TODO: 2 ways to improve this:
+    //
+    // 1. If the enclosed type is a TsFunc type, suggest that they wrap it in
+    // `Oneway`, `Query`, or `Update` and show them what that would look like in
+    // the example.
+    //
+    // 2. If the enclosed type is a TypeRef that contains a TsFunc, just with
+    // the wrong name, we should only modify the name in the example, (rather
+    // than nuking their function signature).
     fn func_wrong_enclosed_type_error(&self) -> ErrorMessage {
-        let example_func = "<Update<() => void>".to_string();
+        let example_func = "Update<() => void".to_string();
 
-        let absolute_range = (self.ts_type_ref.span.lo, self.ts_type_ref.span.hi);
-        let source = self.source_map.get_source_from_range(absolute_range);
+        let type_params_absolute_range = (self.get_enclosed_span().lo, self.get_enclosed_span().hi);
+        let source = self
+            .source_map
+            .get_source_from_range(type_params_absolute_range);
 
-        let offset = self.ts_type_ref.span.lo.to_usize() - self.get_range().0;
-        let range = (
-            self.get_range().0,
-            self.ts_type_ref.span.hi.to_usize() - offset,
+        let start_pos = self.source_map.get_range(self.get_enclosed_span()).0;
+        let offset = type_params_absolute_range.0.to_usize() - start_pos;
+        let end_pos = self.get_enclosed_span().hi.to_usize() - offset;
+        let range = (start_pos, end_pos);
+
+        let modified_source = format!(
+            "{}{}{}",
+            source[..start_pos + 1].to_string(),
+            example_func,
+            source[end_pos..].to_string()
         );
 
         ErrorMessage {
@@ -228,18 +245,14 @@ impl AzleTypeRef<'_> {
             line_number: self.get_line_number(),
             source,
             range,
-            annotation: "invalid inner type here".to_string(),
+            annotation: "the type params here are invalid".to_string(),
             suggestion: Some(Suggestion {
                 title:
                     "Funcs must have either Query, Update, or Oneway as the enclosed type. E.g.:"
                         .to_string(),
-                range: self
-                    .source_map
-                    .generate_modified_range(self.get_enclosed_span(), &example_func),
-                source: self
-                    .source_map
-                    .generate_modified_source(self.ts_type_ref.span, &example_func),
-                annotation: Some("Did you mean to have that type as a parameter?".to_string()),
+                range: (start_pos + 1, start_pos + 1 + example_func.len()),
+                source: modified_source,
+                annotation: None,
                 import_suggestion: None,
             }),
         }
@@ -271,7 +284,7 @@ impl AzleTypeRef<'_> {
 
     fn generate_example_func(&self) -> String {
         if self.ts_type_ref.get_enclosed_ts_types().len() == 0 {
-            "Update<() => void".to_string()
+            "Func<Update<() => void>>".to_string()
         } else {
             let enclosed_types = self
                 .ts_type_ref

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_ref/get_dependencies.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_ref/get_dependencies.rs
@@ -32,9 +32,12 @@ impl GetDependencies for AzleTypeRef<'_> {
             "Opt" => self
                 .get_enclosed_azle_type()
                 .get_dependent_types(type_alias_lookup, found_type_names),
-            "Func" => self
-                .get_enclosed_azle_type()
-                .get_dependent_types(type_alias_lookup, found_type_names),
+            "Func" => {
+                let request_type_type_ref =
+                    self.get_enclosed_azle_type().as_azle_type_ref().unwrap();
+                let azle_fn_type = request_type_type_ref.get_enclosed_azle_type();
+                azle_fn_type.get_dependent_types(type_alias_lookup, found_type_names)
+            }
             "Variant" => self
                 .get_enclosed_azle_type()
                 .get_dependent_types(type_alias_lookup, found_type_names),

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_ref/get_dependencies.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_ref/get_dependencies.rs
@@ -4,7 +4,10 @@ use std::{
 };
 
 use super::AzleTypeRef;
-use crate::ts_ast::{AzleTypeAliasDecl, GetDependencies, GetName};
+use crate::ts_ast::{
+    azle_type::{AzleFnOrConstructorType, AzleType},
+    AzleTypeAliasDecl, GetDependencies, GetName,
+};
 
 impl GetDependencies for AzleTypeRef<'_> {
     fn get_dependent_types(
@@ -33,9 +36,21 @@ impl GetDependencies for AzleTypeRef<'_> {
                 .get_enclosed_azle_type()
                 .get_dependent_types(type_alias_lookup, found_type_names),
             "Func" => {
-                let request_type_type_ref =
-                    self.get_enclosed_azle_type().as_azle_type_ref().unwrap();
-                let azle_fn_type = request_type_type_ref.get_enclosed_azle_type();
+                let request_type_type_ref = match self.get_enclosed_azle_type() {
+                    AzleType::AzleTypeRef(azle_type_ref) => azle_type_ref,
+                    _ => panic!("{}", self.wrong_enclosed_type_error()),
+                };
+
+                let mode = request_type_type_ref.get_name();
+                if !(mode == "Query" || mode == "Update" || mode == "Oneway") {
+                    panic!("{}", self.wrong_enclosed_type_error())
+                };
+                let azle_fn_type = match request_type_type_ref.get_enclosed_azle_type() {
+                    AzleType::AzleFnOrConstructorType(fn_or_const) => match fn_or_const {
+                        AzleFnOrConstructorType::AzleFnType(ts_fn_type) => ts_fn_type,
+                    },
+                    _ => panic!("{}", self.wrong_enclosed_type_error()),
+                };
                 azle_fn_type.get_dependent_types(type_alias_lookup, found_type_names)
             }
             "Variant" => self

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_ref/get_name.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/azle_type_ref/get_name.rs
@@ -7,6 +7,9 @@ impl GetName for AzleTypeRef<'_> {
     fn get_name(&self) -> &str {
         match &self.ts_type_ref.type_name {
             TsEntityName::TsQualifiedName(ts_qualified_name) => {
+                // TODO: This could be improved for Qualified TypeRefs with type params.
+                // Currently we just drop the type params. It would be better if we
+                // included them.
                 panic!(
                     "{}",
                     self.qualified_name_error(ts_qualified_name.right.get_name().to_string())

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type/mod.rs
@@ -39,6 +39,13 @@ impl<'a> AzleType<'a> {
         }
     }
 
+    pub fn as_azle_type_ref(self) -> Option<AzleTypeRef<'a>> {
+        match self {
+            AzleType::AzleTypeRef(azle_type_ref) => Some(azle_type_ref),
+            _ => None,
+        }
+    }
+
     // It seems like these would be useful, but we aren't using them right now,
     // but they can hang out here until we are done that way if we need them
     // they are here. though its not like they are that hard to write up from
@@ -47,13 +54,6 @@ impl<'a> AzleType<'a> {
     //     match self {
     //         AzleType::AzleTypeLit(_) => true,
     //         _ => false,
-    //     }
-    // }
-    //
-    // pub fn as_azle_type_ref(self) -> Option<AzleTypeRef<'a>> {
-    //     match self {
-    //         AzleType::AzleTypeRef(azle_type_ref) => Some(azle_type_ref),
-    //         _ => None,
     //     }
     // }
     //

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type_alias_decls/azle_type_alias_decl.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/azle_type_alias_decls/azle_type_alias_decl.rs
@@ -91,8 +91,8 @@ impl AzleTypeAliasListHelperMethods for Vec<AzleTypeAliasDecl<'_>> {
     fn generate_type_alias_lookup(&self) -> HashMap<String, AzleTypeAliasDecl> {
         self.iter()
             .fold(HashMap::new(), |mut acc, azle_type_alias| {
-                let type_alias_names = azle_type_alias.ts_type_alias_decl.id.get_name().to_string();
-                acc.insert(type_alias_names, azle_type_alias.clone());
+                let type_alias_name = azle_type_alias.ts_type_alias_decl.id.get_name().to_string();
+                acc.insert(type_alias_name, azle_type_alias.clone());
                 acc
             })
     }
@@ -130,7 +130,7 @@ impl AzleTypeAliasListHelperMethods for Vec<AzleTypeAliasDecl<'_>> {
 
         type_names.iter().fold(vec![], |acc, dependant_type_name| {
             let type_alias_decl = type_alias_lookup.get(dependant_type_name);
-            let token_stream = match type_alias_decl {
+            let act_data_type = match type_alias_decl {
                 Some(azle_type_alias) => azle_type_alias.to_act_node(),
                 None => {
                     panic!(
@@ -139,7 +139,7 @@ impl AzleTypeAliasListHelperMethods for Vec<AzleTypeAliasDecl<'_>> {
                     )
                 }
             };
-            vec![acc, vec![token_stream]].concat()
+            vec![acc, vec![act_data_type]].concat()
         })
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/ts_type/ts_fn_type.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/ts_ast/ts_type/ts_fn_type.rs
@@ -1,6 +1,8 @@
-use swc_ecma_ast::{TsFnParam, TsFnType, TsTypeAnn};
+use swc_ecma_ast::{TsFnParam, TsFnType, TsType, TsTypeAnn};
 
-use crate::ts_ast::{FunctionAndMethodTypeHelperMethods, GenerateInlineName};
+use crate::ts_ast::{
+    ast_traits::GetTsType, FunctionAndMethodTypeHelperMethods, GenerateInlineName,
+};
 
 impl FunctionAndMethodTypeHelperMethods for TsFnType {
     fn get_ts_fn_params(&self) -> Vec<TsFnParam> {
@@ -13,6 +15,10 @@ impl FunctionAndMethodTypeHelperMethods for TsFnType {
 
     fn get_valid_return_types(&self) -> Vec<&str> {
         vec!["Oneway", "Update", "Query"]
+    }
+
+    fn get_return_type(&self) -> Option<TsType> {
+        Some(self.get_ts_type_ann().get_ts_type())
     }
 }
 


### PR DESCRIPTION
Switches from parsing funcs like this: `Func<() => Query<MyReturnType>>`,
to parsing funcs like this: `Func<Query<() => MyReturnType>>`.