### PR TITLE
Fixed flakiness in function guards test

### DIFF
--- a/examples/guard_functions/src/guards.ts
+++ b/examples/guard_functions/src/guards.ts
@@ -23,7 +23,7 @@ export function allowAll(): GuardResult {
 
 export function acceptAllThenRejectAll(): GuardResult {
     console.log('acceptAllThenRejectAll called');
-    if (++state.heartbeatTick > 15) {
+    if (++state.heartbeatTick > 20) {
         console.log(`Heartbeat suppressed`);
         return { Err: 'This error message will never be seen' };
     }

--- a/examples/guard_functions/test/tests.ts
+++ b/examples/guard_functions/test/tests.ts
@@ -12,7 +12,7 @@ export function getTests(
             name: 'heartbeat guard',
             test: async () => {
                 const initialState = await guardFunctionsCanister.getState();
-                await sleep(8000);
+                await sleep(10_000);
                 const stateAfterRest = await guardFunctionsCanister.getState();
 
                 return {

--- a/examples/guard_functions/test/tests.ts
+++ b/examples/guard_functions/test/tests.ts
@@ -12,13 +12,19 @@ export function getTests(
             name: 'heartbeat guard',
             test: async () => {
                 const initialState = await guardFunctionsCanister.getState();
-                await sleep(10_000);
+                console.log(
+                    `Value at initial check was: ${initialState.heartbeatTick}`
+                );
+                await sleep(15_000);
                 const stateAfterRest = await guardFunctionsCanister.getState();
+                console.log(
+                    `Value after 15s delay was: ${stateAfterRest.heartbeatTick}`
+                );
 
                 return {
                     Ok:
-                        initialState.heartbeatTick < 15 &&
-                        stateAfterRest.heartbeatTick === 15
+                        initialState.heartbeatTick < 20 &&
+                        stateAfterRest.heartbeatTick === 20
                 };
             }
         },


### PR DESCRIPTION
The tests were failing because the heartbeat starts ticking before the tests start running. This resulted in either
- The suppression being triggered before the initial value check, or
- The suppression not being hit before the second check

I increased the suppression cutoff so that it for sure wouldn't be hit before our first check. Then, to counter the second bullet point I've increased the delay before our second check to ensure the suppression would have been triggered by then.

Additionally I logged the times of each check so that if it does fail in CI/CD we can see which side it erred on.