### PR TITLE
Fixed name collisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 [[package]]
 name = "cdk_framework"
 version = "0.0.0"
-source = "git+https://github.com/demergent-labs/cdk_framework?rev=c669090c4bdce8e01a564dd2b0302ecfb44f84c2#c669090c4bdce8e01a564dd2b0302ecfb44f84c2"
+source = "git+https://github.com/demergent-labs/cdk_framework?rev=d73870ef2fd12e7ce3762840a426ccb295c47c51#d73870ef2fd12e7ce3762840a426ccb295c47c51"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 [[package]]
 name = "cdk_framework"
 version = "0.0.0"
-source = "git+https://github.com/demergent-labs/cdk_framework?rev=b6add5d6f3950a51671c840326191acb7eaf446f#b6add5d6f3950a51671c840326191acb7eaf446f"
+source = "git+https://github.com/demergent-labs/cdk_framework?rev=c669090c4bdce8e01a564dd2b0302ecfb44f84c2#c669090c4bdce8e01a564dd2b0302ecfb44f84c2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/compiler/typescript_to_rust/azle_generate/Cargo.toml
+++ b/src/compiler/typescript_to_rust/azle_generate/Cargo.toml
@@ -12,5 +12,5 @@ swc_ecma_parser = "0.117.4"
 derive-syn-parse = "0.1.5"
 swc_ecma_ast = "0.90.10"
 annotate-snippets = "0.9.1"
-cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "c669090c4bdce8e01a564dd2b0302ecfb44f84c2" }
+cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "d73870ef2fd12e7ce3762840a426ccb295c47c51" }
 # cdk_framework = { path = "/home/cdk_framework" }

--- a/src/compiler/typescript_to_rust/azle_generate/Cargo.toml
+++ b/src/compiler/typescript_to_rust/azle_generate/Cargo.toml
@@ -12,5 +12,5 @@ swc_ecma_parser = "0.117.4"
 derive-syn-parse = "0.1.5"
 swc_ecma_ast = "0.90.10"
 annotate-snippets = "0.9.1"
-cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "b6add5d6f3950a51671c840326191acb7eaf446f" }
+cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "c669090c4bdce8e01a564dd2b0302ecfb44f84c2" }
 # cdk_framework = { path = "/home/cdk_framework" }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/boa_error_handlers.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/boa_error_handlers.rs
@@ -8,9 +8,9 @@ pub fn generate() -> TokenStream {
             context: &mut boa_engine::Context
         ) -> boa_engine::JsValue {
             match boa_result {
-                Ok(_azle_boa_return_value) => _azle_boa_return_value,
-                Err(_azle_boa_error) => {
-                    let error_message = _azle_js_value_to_string(_azle_boa_error.to_opaque(context), context);
+                Ok(boa_return_value) => boa_return_value,
+                Err(boa_error) => {
+                    let error_message = _azle_js_value_to_string(boa_error.to_opaque(context), context);
 
                     ic_cdk::api::trap(&format!("Uncaught {}", error_message));
                 },

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/accept_message.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/accept_message.rs
@@ -3,9 +3,9 @@ pub fn generate() -> proc_macro2::TokenStream {
         fn _azle_ic_accept_message(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            Ok(ic_cdk::api::call::accept_message().try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::call::accept_message().try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/arg_data_raw.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/arg_data_raw.rs
@@ -3,9 +3,9 @@ pub fn generate() -> proc_macro2::TokenStream {
         fn _azle_ic_arg_data_raw(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            Ok(ic_cdk::api::call::arg_data_raw().try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::call::arg_data_raw().try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/arg_data_raw_size.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/arg_data_raw_size.rs
@@ -3,9 +3,9 @@ pub fn generate() -> proc_macro2::TokenStream {
         fn _azle_ic_arg_data_raw_size(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            Ok(ic_cdk::api::call::arg_data_raw_size().try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::call::arg_data_raw_size().try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/async_call/promise_fulfillment.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/async_call/promise_fulfillment.rs
@@ -1,13 +1,13 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         BOA_CONTEXT_REF_CELL.with(|box_context_ref_cell| {
-            let mut _azle_boa_context = box_context_ref_cell.borrow_mut();
+            let mut boa_context = box_context_ref_cell.borrow_mut();
 
             let call_result_js_value = match call_result {
                 Ok(value) => {
-                    let js_value = value.try_into_vm_value(&mut *_azle_boa_context).unwrap();
+                    let js_value = value.try_into_vm_value(&mut *boa_context).unwrap();
 
-                    let canister_result_js_object = boa_engine::object::ObjectInitializer::new(&mut *_azle_boa_context)
+                    let canister_result_js_object = boa_engine::object::ObjectInitializer::new(&mut *boa_context)
                         .property(
                             "Ok",
                             js_value,
@@ -20,9 +20,9 @@ pub fn generate() -> proc_macro2::TokenStream {
                     canister_result_js_value
                 },
                 Err(err) => {
-                    let js_value = format!("Rejection code {rejection_code}, {error_message}", rejection_code = (err.0 as i32).to_string(), error_message = err.1).try_into_vm_value(&mut *_azle_boa_context).unwrap();
+                    let js_value = format!("Rejection code {rejection_code}, {error_message}", rejection_code = (err.0 as i32).to_string(), error_message = err.1).try_into_vm_value(&mut *boa_context).unwrap();
 
-                    let canister_result_js_object = boa_engine::object::ObjectInitializer::new(&mut *_azle_boa_context)
+                    let canister_result_js_object = boa_engine::object::ObjectInitializer::new(&mut *boa_context)
                         .property(
                             "Err",
                             js_value,
@@ -40,7 +40,7 @@ pub fn generate() -> proc_macro2::TokenStream {
             let mut promise_object = promise_js_object.borrow_mut();
             let mut promise = promise_object.as_promise_mut().unwrap();
 
-            promise.fulfill_promise(&call_result_js_value, &mut *_azle_boa_context);
+            promise.fulfill_promise(&call_result_js_value, &mut *boa_context);
 
             let main_promise = PROMISE_MAP_REF_CELL.with(|promise_map_ref_cell| {
                 let promise_map = promise_map_ref_cell.borrow().clone();
@@ -50,7 +50,7 @@ pub fn generate() -> proc_macro2::TokenStream {
                 main_promise.clone()
             });
 
-            _azle_async_await_result_handler(&mut *_azle_boa_context, &main_promise, &uuid, &method_name, manual);
+            _azle_async_await_result_handler(&mut *boa_context, &main_promise, &uuid, &method_name, manual);
         });
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/call_raw.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/call_raw.rs
@@ -10,16 +10,16 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_call_raw(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
             // TODO make this promise in a better way once Boa allows it or you can figure it out
-            let promise_js_value = _context.eval("new Promise(() => {})").unwrap();
+            let promise_js_value = context.eval("new Promise(() => {})").unwrap();
 
-            let canister_id: ic_cdk::export::Principal = _aargs.get(0).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
-            let method: String = _aargs.get(1).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
-            let args_raw: Vec<u8> = _aargs.get(2).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
-            let payment: u64 = _aargs.get(3).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
+            let canister_id: ic_cdk::export::Principal = aargs.get(0).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
+            let method: String = aargs.get(1).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
+            let args_raw: Vec<u8> = aargs.get(2).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
+            let payment: u64 = aargs.get(3).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
 
             _azle_ic_call_raw_spawn(
                 &promise_js_value,

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/call_raw128.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/call_raw128.rs
@@ -10,16 +10,16 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_call_raw128(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
             // TODO make this promise in a better way once Boa allows it or you can figure it out
-            let promise_js_value = _context.eval("new Promise(() => {})").unwrap();
+            let promise_js_value = context.eval("new Promise(() => {})").unwrap();
 
-            let canister_id: ic_cdk::export::Principal = _aargs.get(0).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
-            let method: String = _aargs.get(1).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
-            let args_raw: Vec<u8> = _aargs.get(2).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
-            let payment: u128 = _aargs.get(3).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
+            let canister_id: ic_cdk::export::Principal = aargs.get(0).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
+            let method: String = aargs.get(1).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
+            let args_raw: Vec<u8> = aargs.get(2).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
+            let payment: u128 = aargs.get(3).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
 
             _azle_ic_call_raw128_spawn(
                 &promise_js_value,

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/caller.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/caller.rs
@@ -3,9 +3,9 @@ pub fn generate() -> proc_macro2::TokenStream {
         fn _azle_ic_caller(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            Ok(ic_cdk::api::caller().try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::caller().try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/candid_decode.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/candid_decode.rs
@@ -2,14 +2,14 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_candid_decode(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let candid_encoded: Vec<u8> = _aargs.get(0).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
+            let candid_encoded: Vec<u8> = aargs.get(0).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
             let candid_args: candid::IDLArgs = candid::IDLArgs::from_bytes(&candid_encoded).unwrap();
             let candid_string = candid_args.to_string();
 
-            Ok(candid_string.try_into_vm_value(_context).unwrap())
+            Ok(candid_string.try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/candid_encode.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/candid_encode.rs
@@ -2,14 +2,14 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_candid_encode(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let candid_string: String = _aargs.get(0).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
+            let candid_string: String = aargs.get(0).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
             let candid_args: candid::IDLArgs = candid_string.parse().unwrap();
             let candid_encoded: Vec<u8> = candid_args.to_bytes().unwrap();
 
-            Ok(candid_encoded.try_into_vm_value(&mut *_context).unwrap())
+            Ok(candid_encoded.try_into_vm_value(&mut *context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/canister_balance.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/canister_balance.rs
@@ -3,9 +3,9 @@ pub fn generate() -> proc_macro2::TokenStream {
         fn _azle_ic_canister_balance(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            Ok(ic_cdk::api::canister_balance().try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::canister_balance().try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/canister_balance128.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/canister_balance128.rs
@@ -3,9 +3,9 @@ pub fn generate() -> proc_macro2::TokenStream {
         fn _azle_ic_canister_balance128(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            Ok(ic_cdk::api::canister_balance128().try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::canister_balance128().try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/clear_timer.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/clear_timer.rs
@@ -2,11 +2,11 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_clear_timer(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let timer_id_js_value = _aargs.get(0).unwrap().clone();
-            let timer_id: ic_cdk_timers::TimerId = timer_id_js_value.try_from_vm_value(&mut *_context).unwrap();
+            let timer_id_js_value = aargs.get(0).unwrap().clone();
+            let timer_id: ic_cdk_timers::TimerId = timer_id_js_value.try_from_vm_value(&mut *context).unwrap();
 
             ic_cdk_timers::clear_timer(timer_id);
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/data_certificate.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/data_certificate.rs
@@ -3,9 +3,9 @@ pub fn generate() -> proc_macro2::TokenStream {
         fn _azle_ic_data_certificate(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            Ok(ic_cdk::api::data_certificate().try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::data_certificate().try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/id.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/id.rs
@@ -3,9 +3,9 @@ pub fn generate() -> proc_macro2::TokenStream {
         fn _azle_ic_id(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            Ok(ic_cdk::api::id().try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::id().try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_accept.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_accept.rs
@@ -2,10 +2,10 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_msg_cycles_accept(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let max_amount: u64 = _aargs[0].clone().try_from_vm_value(_context).unwrap();
+            let max_amount: u64 = aargs[0].clone().try_from_vm_value(context).unwrap();
             let return_value: boa_engine::bigint::JsBigInt = ic_cdk::api::call::msg_cycles_accept(max_amount).into();
             Ok(return_value.into())
         }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_accept128.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_accept128.rs
@@ -2,10 +2,10 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_msg_cycles_accept128(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let max_amount: u128 = _aargs[0].clone().try_from_vm_value(_context).unwrap();
+            let max_amount: u128 = aargs[0].clone().try_from_vm_value(context).unwrap();
             // TODO: This extra conversion may not be necessary once
             // https://github.com/boa-dev/boa/issues/1970 is implemented.
             let return_value: boa_engine::bigint::JsBigInt = ic_cdk::api::call::msg_cycles_accept128(max_amount).into();

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/notify_raw.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/notify_raw.rs
@@ -2,20 +2,20 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_notify_raw(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let canister_id_js_value = _aargs.get(0).unwrap().clone();
-            let canister_id_principal: ic_cdk::export::Principal = canister_id_js_value.try_from_vm_value(&mut *_context).unwrap();
+            let canister_id_js_value = aargs.get(0).unwrap().clone();
+            let canister_id_principal: ic_cdk::export::Principal = canister_id_js_value.try_from_vm_value(&mut *context).unwrap();
 
-            let method_js_value = _aargs.get(1).unwrap().clone();
-            let method_string: String = method_js_value.try_from_vm_value(&mut *_context).unwrap();
+            let method_js_value = aargs.get(1).unwrap().clone();
+            let method_string: String = method_js_value.try_from_vm_value(&mut *context).unwrap();
 
-            let args_raw_js_value = _aargs.get(2).unwrap().clone();
-            let args_raw_vec: Vec<u8> = args_raw_js_value.try_from_vm_value(&mut *_context).unwrap();
+            let args_raw_js_value = aargs.get(2).unwrap().clone();
+            let args_raw_vec: Vec<u8> = args_raw_js_value.try_from_vm_value(&mut *context).unwrap();
 
-            let payment_js_value = _aargs.get(3).unwrap().clone();
-            let payment: u128 = payment_js_value.try_from_vm_value(&mut *_context).unwrap();
+            let payment_js_value = aargs.get(3).unwrap().clone();
+            let payment: u128 = payment_js_value.try_from_vm_value(&mut *context).unwrap();
 
             let notify_result = ic_cdk::api::call::notify_raw(
                 canister_id_principal,
@@ -24,7 +24,7 @@ pub fn generate() -> proc_macro2::TokenStream {
                 payment
             );
 
-            Ok(notify_result.try_into_vm_value(_context).unwrap())
+            Ok(notify_result.try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/performance_counter.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/performance_counter.rs
@@ -2,10 +2,10 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_performance_counter(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let counter_type: u32 = _aargs[0].clone().try_from_vm_value(_context).unwrap();
+            let counter_type: u32 = aargs[0].clone().try_from_vm_value(context).unwrap();
             let return_value: boa_engine::bigint::JsBigInt = ic_cdk::api::call::performance_counter(counter_type).into();
             Ok(return_value.into())
         }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/print.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/print.rs
@@ -2,10 +2,10 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_print(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
+            aargs: &[boa_engine::JsValue],
             _context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            ic_cdk::println!("{:#?}", _aargs);
+            ic_cdk::println!("{:#?}", aargs);
 
             return Ok(boa_engine::JsValue::Undefined);
         }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reject.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reject.rs
@@ -2,14 +2,14 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_reject(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context,
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context,
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let message: String = _aargs.get(0).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
+            let message: String = aargs.get(0).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
 
             Ok(
                 ic_cdk::api::call::reject(&message)
-                    .try_into_vm_value(&mut *_context).unwrap()
+                    .try_into_vm_value(&mut *context).unwrap()
             )
         }
     }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reject_code.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reject_code.rs
@@ -3,9 +3,9 @@ pub fn generate() -> proc_macro2::TokenStream {
         fn _azle_ic_reject_code(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context,
+            context: &mut boa_engine::Context,
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            Ok(ic_cdk::api::call::reject_code().try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::call::reject_code().try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reject_message.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reject_message.rs
@@ -3,9 +3,9 @@ pub fn generate() -> proc_macro2::TokenStream {
         fn _azle_ic_reject_message(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context,
+            context: &mut boa_engine::Context,
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            Ok(ic_cdk::api::call::reject_message().try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::call::reject_message().try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reply.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reply.rs
@@ -13,8 +13,8 @@ pub fn generate(methods: &Vec<QueryOrUpdateMethod>) -> TokenStream {
     quote! {
         fn _azle_ic_reply(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
             let method_name = METHOD_NAME_REF_CELL.with(|method_name_ref_cell| method_name_ref_cell.borrow().clone());
 
@@ -46,8 +46,8 @@ fn generate_match_arm(method: &QueryOrUpdateMethod) -> TokenStream {
 
     quote!(
         #name => {
-            let reply_value: #return_type = _aargs.get(0).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
-            Ok(ic_cdk::api::call::reply((reply_value,)).try_into_vm_value(_context).unwrap())
+            let reply_value: #return_type = aargs.get(0).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
+            Ok(ic_cdk::api::call::reply((reply_value,)).try_into_vm_value(context).unwrap())
         }
     )
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reply_raw.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reply_raw.rs
@@ -5,12 +5,12 @@ pub fn generate() -> TokenStream {
     quote! {
         fn _azle_ic_reply_raw(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context,
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context,
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let buf_js_value: boa_engine::JsValue = _aargs.get(0).unwrap().clone();
-            let buf_vec: Vec<u8> = buf_js_value.try_from_vm_value(&mut *_context).unwrap();
-            Ok(ic_cdk::api::call::reply_raw(&buf_vec).try_into_vm_value(_context).unwrap())
+            let buf_js_value: boa_engine::JsValue = aargs.get(0).unwrap().clone();
+            let buf_vec: Vec<u8> = buf_js_value.try_from_vm_value(&mut *context).unwrap();
+            Ok(ic_cdk::api::call::reply_raw(&buf_vec).try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/call.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/call.rs
@@ -18,19 +18,19 @@ pub fn generate(
     quote! {
         fn #call_wrapper_fn_name(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let canister_id_js_value = _aargs.get(0).unwrap().clone();
-            let canister_id_principal: ic_cdk::export::Principal = canister_id_js_value.try_from_vm_value(&mut *_context).unwrap();
+            let canister_id_js_value = aargs.get(0).unwrap().clone();
+            let canister_id_principal: ic_cdk::export::Principal = canister_id_js_value.try_from_vm_value(&mut *context).unwrap();
 
-            let args_js_value = _aargs.get(1).unwrap().clone();
+            let args_js_value = aargs.get(1).unwrap().clone();
             let args_js_object = args_js_value.as_object().unwrap();
 
             #(#param_variables)*
 
             // TODO make this promise in a better way once Boa allows it or you can figure it out
-            let promise_js_value = _context.eval("new Promise(() => {})").unwrap();
+            let promise_js_value = context.eval("new Promise(() => {})").unwrap();
             let promise_js_value_cloned = promise_js_value.clone();
 
             ic_cdk::spawn(async move {

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/call_with_payment.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/call_with_payment.rs
@@ -23,22 +23,22 @@ pub fn generate(
     quote! {
         fn #call_with_payment_wrapper_fn_name(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let canister_id_js_value = _aargs.get(0).unwrap().clone();
-            let canister_id_principal: ic_cdk::export::Principal = canister_id_js_value.try_from_vm_value(&mut *_context).unwrap();
+            let canister_id_js_value = aargs.get(0).unwrap().clone();
+            let canister_id_principal: ic_cdk::export::Principal = canister_id_js_value.try_from_vm_value(&mut *context).unwrap();
 
-            let args_js_value = _aargs.get(1).unwrap().clone();
+            let args_js_value = aargs.get(1).unwrap().clone();
             let args_js_object = args_js_value.as_object().unwrap();
 
             #(#param_variables)*
 
-            let cycles_js_value = args_js_object.get(#index_string, _context).unwrap();
-            let cycles: u64 = cycles_js_value.try_from_vm_value(&mut *_context).unwrap();
+            let cycles_js_value = args_js_object.get(#index_string, context).unwrap();
+            let cycles: u64 = cycles_js_value.try_from_vm_value(&mut *context).unwrap();
 
             // TODO make this promise in a better way once Boa allows it or you can figure it out
-            let promise_js_value = _context.eval("new Promise(() => {})").unwrap();
+            let promise_js_value = context.eval("new Promise(() => {})").unwrap();
             let promise_js_value_cloned = promise_js_value.clone();
 
             ic_cdk::spawn(async move {

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/call_with_payment128.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/call_with_payment128.rs
@@ -25,22 +25,22 @@ pub fn generate(
     quote! {
         fn #call_with_payment128_wrapper_fn_name(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let canister_id_js_value = _aargs.get(0).unwrap().clone();
-            let canister_id_principal: ic_cdk::export::Principal = canister_id_js_value.try_from_vm_value(&mut *_context).unwrap();
+            let canister_id_js_value = aargs.get(0).unwrap().clone();
+            let canister_id_principal: ic_cdk::export::Principal = canister_id_js_value.try_from_vm_value(&mut *context).unwrap();
 
-            let args_js_value = _aargs.get(1).unwrap().clone();
+            let args_js_value = aargs.get(1).unwrap().clone();
             let args_js_object = args_js_value.as_object().unwrap();
 
             #(#param_variables)*
 
-            let cycles_js_value = args_js_object.get(#index_string, _context).unwrap();
-            let cycles: u128 = cycles_js_value.try_from_vm_value(&mut *_context).unwrap();
+            let cycles_js_value = args_js_object.get(#index_string, context).unwrap();
+            let cycles: u128 = cycles_js_value.try_from_vm_value(&mut *context).unwrap();
 
             // TODO make this promise in a better way once Boa allows it or you can figure it out
-            let promise_js_value = _context.eval("new Promise(() => {})").unwrap();
+            let promise_js_value = context.eval("new Promise(() => {})").unwrap();
             let promise_js_value_cloned = promise_js_value.clone();
 
             ic_cdk::spawn(async move {

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/mod.rs
@@ -81,8 +81,8 @@ pub fn generate_param_variables(method: &Method, canister_name: &String) -> Vec<
             }, method.create_qualified_name(canister_name));
 
             quote! {
-                let #param_name_js_value = args_js_object.get(#index, _context).unwrap();
-                let #param_name: #param_type = #param_name_js_value.try_from_vm_value(&mut *_context).unwrap();
+                let #param_name_js_value = args_js_object.get(#index, context).unwrap();
+                let #param_name: #param_type = #param_name_js_value.try_from_vm_value(&mut *context).unwrap();
             }
         })
     .collect()

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/notify.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/notify.rs
@@ -12,13 +12,13 @@ pub fn generate(service: &Service, method: &Method) -> TokenStream {
     quote! {
         fn #wrapper_fn_name(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let canister_id_js_value = _aargs.get(0).unwrap().clone();
-            let canister_id_principal: ic_cdk::export::Principal = canister_id_js_value.try_from_vm_value(&mut *_context).unwrap();
+            let canister_id_js_value = aargs.get(0).unwrap().clone();
+            let canister_id_principal: ic_cdk::export::Principal = canister_id_js_value.try_from_vm_value(&mut *context).unwrap();
 
-            let args_js_value = _aargs.get(1).unwrap().clone();
+            let args_js_value = aargs.get(1).unwrap().clone();
             let args_js_object = args_js_value.as_object().unwrap();
 
             #(#param_variables)*
@@ -28,7 +28,7 @@ pub fn generate(service: &Service, method: &Method) -> TokenStream {
                 #args
             );
 
-            Ok(notify_result.try_into_vm_value(_context).unwrap())
+            Ok(notify_result.try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/notify_with_payment128.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/notify_with_payment128.rs
@@ -15,19 +15,19 @@ pub fn generate(service: &Service, method: &Method) -> TokenStream {
     quote! {
         fn #wrapper_fn_name(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let canister_id_js_value = _aargs.get(0).unwrap().clone();
-            let canister_id_principal: ic_cdk::export::Principal = canister_id_js_value.try_from_vm_value(&mut *_context).unwrap();
+            let canister_id_js_value = aargs.get(0).unwrap().clone();
+            let canister_id_principal: ic_cdk::export::Principal = canister_id_js_value.try_from_vm_value(&mut *context).unwrap();
 
-            let args_js_value = _aargs.get(1).unwrap().clone();
+            let args_js_value = aargs.get(1).unwrap().clone();
             let args_js_object = args_js_value.as_object().unwrap();
 
             #(#param_variables)*
 
-            let cycles_js_value = _aargs.get(2).unwrap().clone();
-            let cycles: u128 = cycles_js_value.try_from_vm_value(&mut *_context).unwrap();
+            let cycles_js_value = aargs.get(2).unwrap().clone();
+            let cycles: u128 = cycles_js_value.try_from_vm_value(&mut *context).unwrap();
 
             let notify_result = #real_function_name(
                 canister_id_principal,
@@ -35,7 +35,7 @@ pub fn generate(service: &Service, method: &Method) -> TokenStream {
                 cycles,
             );
 
-            Ok(notify_result.try_into_vm_value(_context).unwrap())
+            Ok(notify_result.try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_certified_data.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_certified_data.rs
@@ -2,12 +2,12 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_set_certified_data(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let data_js_value: boa_engine::JsValue = _aargs.get(0).unwrap().clone();
-            let data_vec: Vec<u8> = data_js_value.try_from_vm_value(&mut *_context).unwrap();
-            Ok(ic_cdk::api::set_certified_data(&data_vec).try_into_vm_value(_context).unwrap())
+            let data_js_value: boa_engine::JsValue = aargs.get(0).unwrap().clone();
+            let data_vec: Vec<u8> = data_js_value.try_from_vm_value(&mut *context).unwrap();
+            Ok(ic_cdk::api::set_certified_data(&data_vec).try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_timer.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_timer.rs
@@ -14,7 +14,7 @@ pub fn generate() -> proc_macro2::TokenStream {
 
             let closure = move || {
                 BOA_CONTEXT_REF_CELL.with(|boa_context_ref_cell| {
-                    let mut _azle_boa_context = boa_context_ref_cell.borrow_mut();
+                    let mut boa_context = boa_context_ref_cell.borrow_mut();
 
                     let uuid = uuid::Uuid::new_v4().to_string();
 
@@ -36,18 +36,18 @@ pub fn generate() -> proc_macro2::TokenStream {
                         *manual_mut = false;
                     });
 
-                    let _azle_boa_return_value = _azle_unwrap_boa_result(
+                    let boa_return_value = _azle_unwrap_boa_result(
                         func_js_object.call(
                             &boa_engine::JsValue::Null,
                             &[],
-                            &mut *_azle_boa_context
+                            &mut *boa_context
                         ),
-                        &mut *_azle_boa_context
+                        &mut *boa_context
                     );
 
                     _azle_async_await_result_handler(
-                        &mut _azle_boa_context,
-                        &_azle_boa_return_value,
+                        &mut boa_context,
+                        &boa_return_value,
                         &uuid,
                         "_AZLE_TIMER",
                         false

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_timer.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_timer.rs
@@ -2,14 +2,14 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_set_timer(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let delay_js_value = _aargs.get(0).unwrap().clone();
-            let delay_as_u64: u64 = delay_js_value.try_from_vm_value(&mut *_context).unwrap();
+            let delay_js_value = aargs.get(0).unwrap().clone();
+            let delay_as_u64: u64 = delay_js_value.try_from_vm_value(&mut *context).unwrap();
             let delay = core::time::Duration::new(delay_as_u64, 0);
 
-            let func_js_value = _aargs.get(1).unwrap();
+            let func_js_value = aargs.get(1).unwrap();
             let func_js_object = func_js_value.as_object().unwrap().clone();
 
             let closure = move || {
@@ -57,7 +57,7 @@ pub fn generate() -> proc_macro2::TokenStream {
 
             let timer_id = ic_cdk_timers::set_timer(delay, closure);
 
-            Ok(timer_id.try_into_vm_value(_context).unwrap())
+            Ok(timer_id.try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_timer_interval.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_timer_interval.rs
@@ -2,14 +2,14 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_set_timer_interval(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let interval_js_value = _aargs.get(0).unwrap().clone();
-            let interval_as_u64: u64 = interval_js_value.try_from_vm_value(&mut *_context).unwrap();
+            let interval_js_value = aargs.get(0).unwrap().clone();
+            let interval_as_u64: u64 = interval_js_value.try_from_vm_value(&mut *context).unwrap();
             let interval = core::time::Duration::new(interval_as_u64, 0);
 
-            let func_js_value = _aargs.get(1).unwrap();
+            let func_js_value = aargs.get(1).unwrap();
             let func_js_object = func_js_value.as_object().unwrap().clone();
 
             let closure = move || {
@@ -57,7 +57,7 @@ pub fn generate() -> proc_macro2::TokenStream {
 
             let timer_id = ic_cdk_timers::set_timer_interval(interval, closure);
 
-            Ok(timer_id.try_into_vm_value(_context).unwrap())
+            Ok(timer_id.try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_timer_interval.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_timer_interval.rs
@@ -14,7 +14,7 @@ pub fn generate() -> proc_macro2::TokenStream {
 
             let closure = move || {
                 BOA_CONTEXT_REF_CELL.with(|boa_context_ref_cell| {
-                    let mut _azle_boa_context = boa_context_ref_cell.borrow_mut();
+                    let mut boa_context = boa_context_ref_cell.borrow_mut();
 
                     let uuid = uuid::Uuid::new_v4().to_string();
 
@@ -36,18 +36,18 @@ pub fn generate() -> proc_macro2::TokenStream {
                         *manual_mut = false;
                     });
 
-                    let _azle_boa_return_value = _azle_unwrap_boa_result(
+                    let boa_return_value = _azle_unwrap_boa_result(
                         func_js_object.call(
                             &boa_engine::JsValue::Null,
                             &[],
-                            &mut *_azle_boa_context
+                            &mut *boa_context
                         ),
-                        &mut *_azle_boa_context
+                        &mut *boa_context
                     );
 
                     _azle_async_await_result_handler(
-                        &mut _azle_boa_context,
-                        &_azle_boa_return_value,
+                        &mut boa_context,
+                        &boa_return_value,
                         &uuid,
                         "_AZLE_TIMER",
                         false

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_grow.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_grow.rs
@@ -2,16 +2,16 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_stable64_grow(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context,
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context,
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let new_pages: u64 = _aargs
+            let new_pages: u64 = aargs
                 .get(0)
                 .unwrap()
                 .clone()
-                .try_from_vm_value(&mut *_context)
+                .try_from_vm_value(&mut *context)
                 .unwrap();
-            Ok(ic_cdk::api::stable::stable64_grow(new_pages).try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::stable::stable64_grow(new_pages).try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_read.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_read.rs
@@ -2,25 +2,25 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_stable64_read(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context,
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context,
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let offset: u64 = _aargs
+            let offset: u64 = aargs
                 .get(0)
                 .unwrap()
                 .clone()
-                .try_from_vm_value(&mut *_context)
+                .try_from_vm_value(&mut *context)
                 .unwrap();
-            let length: u64 = _aargs
+            let length: u64 = aargs
                 .get(1)
                 .unwrap()
                 .clone()
-                .try_from_vm_value(&mut *_context)
+                .try_from_vm_value(&mut *context)
                 .unwrap();
 
             let mut buf: Vec<u8> = vec![0; length as usize];
             ic_cdk::api::stable::stable64_read(offset, &mut buf);
-            Ok(buf.to_vec().try_into_vm_value(_context).unwrap())
+            Ok(buf.to_vec().try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_size.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_size.rs
@@ -3,9 +3,9 @@ pub fn generate() -> proc_macro2::TokenStream {
         fn _azle_ic_stable64_size(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            Ok(ic_cdk::api::stable::stable64_size().try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::stable::stable64_size().try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_write.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_write.rs
@@ -2,20 +2,20 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_stable64_write(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context,
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context,
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let offset: u64 = _aargs
+            let offset: u64 = aargs
                 .get(0)
                 .unwrap()
                 .clone()
-                .try_from_vm_value(&mut *_context)
+                .try_from_vm_value(&mut *context)
                 .unwrap();
-            let buf_vector: Vec<u8> = _aargs
+            let buf_vector: Vec<u8> = aargs
                 .get(1)
                 .unwrap()
                 .clone()
-                .try_from_vm_value(&mut *_context)
+                .try_from_vm_value(&mut *context)
                 .unwrap();
             let buf: &[u8] = &buf_vector[..];
             ic_cdk::api::stable::stable64_write(offset, buf);

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/contains_key.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/contains_key.rs
@@ -8,11 +8,11 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     quote! {
         fn _azle_ic_stable_b_tree_map_contains_key(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let memory_id: u8 = _aargs.get(0).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
-            let key_js_value = _aargs.get(1).unwrap().clone();
+            let memory_id: u8 = aargs.get(0).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
+            let key_js_value = aargs.get(1).unwrap().clone();
 
             match memory_id {
                 #(#match_arms)*
@@ -40,13 +40,13 @@ fn generate_match_arms(
 
             quote! {
                 #memory_id => {
-                    Ok(#map_name_ident.with(|p| {
-                        p.borrow().contains_key(
+                    Ok(#map_name_ident.with(|stable_b_tree_map_ref_cell| {
+                        stable_b_tree_map_ref_cell.borrow().contains_key(
                             &#key_wrapper_type_name(
-                                key_js_value.try_from_vm_value(&mut *_context).unwrap()
+                                key_js_value.try_from_vm_value(&mut *context).unwrap()
                             )
                         )
-                    }).try_into_vm_value(&mut *_context).unwrap())
+                    }).try_into_vm_value(&mut *context).unwrap())
                 }
             }
         })

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/get.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/get.rs
@@ -8,11 +8,11 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     quote::quote! {
         fn _azle_ic_stable_b_tree_map_get(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let memory_id: u8 = _aargs.get(0).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
-            let key_js_value = _aargs.get(1).unwrap().clone();
+            let memory_id: u8 = aargs.get(0).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
+            let key_js_value = aargs.get(1).unwrap().clone();
 
             match memory_id {
                 #(#match_arms)*
@@ -40,15 +40,15 @@ fn generate_match_arms(
 
             quote! {
                 #memory_id => {
-                    match #map_name_ident.with(|p| {
-                        p.borrow().get(
+                    match #map_name_ident.with(|stable_b_tree_map_ref_cell| {
+                        stable_b_tree_map_ref_cell.borrow().get(
                             &#key_wrapper_type_name(
-                                key_js_value.try_from_vm_value(&mut *_context).unwrap()
+                                key_js_value.try_from_vm_value(&mut *context).unwrap()
                             )
                         )
                     }) {
-                        Some(value) => Ok(value.0.try_into_vm_value(&mut *_context).unwrap()),
-                        None => Ok(().try_into_vm_value(&mut *_context).unwrap())
+                        Some(value) => Ok(value.0.try_into_vm_value(&mut *context).unwrap()),
+                        None => Ok(().try_into_vm_value(&mut *context).unwrap())
                     }
                 }
             }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/insert.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/insert.rs
@@ -8,12 +8,12 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     quote::quote! {
         fn _azle_ic_stable_b_tree_map_insert(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let memory_id: u8 = _aargs.get(0).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
-            let key_js_value = _aargs.get(1).unwrap().clone();
-            let value_js_value = _aargs.get(2).unwrap().clone();
+            let memory_id: u8 = aargs.get(0).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
+            let key_js_value = aargs.get(1).unwrap().clone();
+            let value_js_value = aargs.get(2).unwrap().clone();
 
             match memory_id {
                 #(#match_arms)*
@@ -48,17 +48,17 @@ fn generate_match_arms(
             quote! {
                 #memory_id => {
                     let key = #key_wrapper_type_name(
-                        key_js_value.try_from_vm_value(&mut *_context).unwrap()
+                        key_js_value.try_from_vm_value(&mut *context).unwrap()
                     );
                     let value = #value_wrapper_type_name(
-                        value_js_value.try_from_vm_value(&mut *_context).unwrap()
+                        value_js_value.try_from_vm_value(&mut *context).unwrap()
                     );
 
-                    let insert_result = #map_name_ident.with(|p| {
-                        p.borrow_mut().insert(key, value)
+                    let insert_result = #map_name_ident.with(|stable_b_tree_map_ref_cell| {
+                        stable_b_tree_map_ref_cell.borrow_mut().insert(key, value)
                     });
 
-                    Ok(insert_result.try_into_vm_value(&mut *_context).unwrap())
+                    Ok(insert_result.try_into_vm_value(&mut *context).unwrap())
                 }
             }
         })

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/is_empty.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/is_empty.rs
@@ -8,10 +8,10 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     quote! {
         fn _azle_ic_stable_b_tree_map_is_empty(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let memory_id: u8 = _aargs.get(0).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
+            let memory_id: u8 = aargs.get(0).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
 
             match memory_id {
                 #(#match_arms)*
@@ -33,9 +33,9 @@ fn generate_match_arms(
 
             quote! {
                 #memory_id => {
-                    Ok(#map_name_ident.with(|p| {
-                        p.borrow().is_empty()
-                    }).try_into_vm_value(&mut *_context).unwrap())
+                    Ok(#map_name_ident.with(|stable_b_tree_map_ref_cell| {
+                        stable_b_tree_map_ref_cell.borrow().is_empty()
+                    }).try_into_vm_value(&mut *context).unwrap())
                 }
             }
         })

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/items.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/items.rs
@@ -8,10 +8,10 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     quote! {
         fn _azle_ic_stable_b_tree_map_items(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let memory_id: u8 = _aargs.get(0).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
+            let memory_id: u8 = aargs.get(0).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
 
             match memory_id {
                 #(#match_arms)*
@@ -38,16 +38,16 @@ fn generate_match_arms(
                             .borrow()
                             .iter()
                             .map(|(key_wrapper_type, value_wrapper_type)| {
-                                let key = key_wrapper_type.0.try_into_vm_value(&mut *_context).unwrap();
-                                let value = value_wrapper_type.0.try_into_vm_value(&mut *_context).unwrap();
+                                let key = key_wrapper_type.0.try_into_vm_value(&mut *context).unwrap();
+                                let value = value_wrapper_type.0.try_into_vm_value(&mut *context).unwrap();
                                 let tuple = vec![key, value];
 
-                                boa_engine::object::builtins::JsArray::from_iter(tuple, &mut *_context).into()
+                                boa_engine::object::builtins::JsArray::from_iter(tuple, &mut *context).into()
                             })
                             .collect::<Vec<boa_engine::JsValue>>()
                     });
 
-                    Ok(boa_engine::object::builtins::JsArray::from_iter(items, &mut *_context).into())
+                    Ok(boa_engine::object::builtins::JsArray::from_iter(items, &mut *context).into())
                 }
             }
         })

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/keys.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/keys.rs
@@ -9,10 +9,10 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     quote! {
         fn _azle_ic_stable_b_tree_map_keys(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let memory_id: u8 = _aargs.get(0).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
+            let memory_id: u8 = aargs.get(0).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
 
             match memory_id {
                 #(#match_arms)*
@@ -51,7 +51,7 @@ fn generate_match_arms(
                                 .iter()
                                 .map(|(key_wrapper_type, _)| key_wrapper_type.0)
                                 .collect::<Vec<#key_type>>()
-                        }).try_into_vm_value(&mut *_context).unwrap()
+                        }).try_into_vm_value(&mut *context).unwrap()
                     )
                 }
             }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/len.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/len.rs
@@ -8,10 +8,10 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     quote! {
         fn _azle_ic_stable_b_tree_map_len(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let memory_id: u8 = _aargs.get(0).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
+            let memory_id: u8 = aargs.get(0).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
 
             match memory_id {
                 #(#match_arms)*
@@ -33,9 +33,9 @@ fn generate_match_arms(
 
             quote! {
                 #memory_id => {
-                    Ok(#map_name_ident.with(|p| {
-                        p.borrow().len()
-                    }).try_into_vm_value(&mut *_context).unwrap())
+                    Ok(#map_name_ident.with(|stable_b_tree_map_ref_cell| {
+                        stable_b_tree_map_ref_cell.borrow().len()
+                    }).try_into_vm_value(&mut *context).unwrap())
                 }
             }
         })

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/remove.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/remove.rs
@@ -8,11 +8,11 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     quote! {
         fn _azle_ic_stable_b_tree_map_remove(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let memory_id: u8 = _aargs.get(0).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
-            let key_js_value = _aargs.get(1).unwrap().clone();
+            let memory_id: u8 = aargs.get(0).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
+            let key_js_value = aargs.get(1).unwrap().clone();
 
             match memory_id {
                 #(#match_arms)*
@@ -40,11 +40,11 @@ fn generate_match_arms(
 
             quote! {
                 #memory_id => {
-                    let key = #key_wrapper_type_name(key_js_value.try_from_vm_value(&mut *_context).unwrap());
+                    let key = #key_wrapper_type_name(key_js_value.try_from_vm_value(&mut *context).unwrap());
 
-                    match #map_name_ident.with(|p| p.borrow_mut().remove(&key)) {
-                        Some(value) => Ok(value.0.try_into_vm_value(&mut *_context).unwrap()),
-                        None => Ok(().try_into_vm_value(&mut *_context).unwrap())
+                    match #map_name_ident.with(|stable_b_tree_map_ref_cell| stable_b_tree_map_ref_cell.borrow_mut().remove(&key)) {
+                        Some(value) => Ok(value.0.try_into_vm_value(&mut *context).unwrap()),
+                        None => Ok(().try_into_vm_value(&mut *context).unwrap())
                     }
                 }
             }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/values.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/values.rs
@@ -9,10 +9,10 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     quote! {
         fn _azle_ic_stable_b_tree_map_values(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let memory_id: u8 = _aargs.get(0).unwrap().clone().try_from_vm_value(&mut *_context).unwrap();
+            let memory_id: u8 = aargs.get(0).unwrap().clone().try_from_vm_value(&mut *context).unwrap();
 
             match memory_id {
                 #(#match_arms)*
@@ -52,7 +52,7 @@ fn generate_match_arms(
                                 .iter()
                                 .map(|(_, value_wrapper_type)| value_wrapper_type.0)
                                 .collect::<Vec<#value_type>>()
-                        }).try_into_vm_value(&mut *_context).unwrap()
+                        }).try_into_vm_value(&mut *context).unwrap()
                     )
                 }
             }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_bytes.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_bytes.rs
@@ -3,9 +3,9 @@ pub fn generate() -> proc_macro2::TokenStream {
         fn _azle_ic_stable_bytes(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context,
+            context: &mut boa_engine::Context,
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            Ok(ic_cdk::api::stable::stable_bytes().try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::stable::stable_bytes().try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_grow.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_grow.rs
@@ -2,16 +2,16 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_stable_grow(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context,
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context,
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let new_pages: u32 = _aargs
+            let new_pages: u32 = aargs
                 .get(0)
                 .unwrap()
                 .clone()
-                .try_from_vm_value(&mut *_context)
+                .try_from_vm_value(&mut *context)
                 .unwrap();
-            Ok(ic_cdk::api::stable::stable_grow(new_pages).try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::stable::stable_grow(new_pages).try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_read.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_read.rs
@@ -2,25 +2,25 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_stable_read(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context,
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context,
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let offset: u32 = _aargs
+            let offset: u32 = aargs
                 .get(0)
                 .unwrap()
                 .clone()
-                .try_from_vm_value(&mut *_context)
+                .try_from_vm_value(&mut *context)
                 .unwrap();
-            let length: u32 = _aargs
+            let length: u32 = aargs
                 .get(1)
                 .unwrap()
                 .clone()
-                .try_from_vm_value(&mut *_context)
+                .try_from_vm_value(&mut *context)
                 .unwrap();
 
             let mut buf: Vec<u8> = vec![0; length as usize];
             ic_cdk::api::stable::stable_read(offset, &mut buf);
-            Ok(buf.try_into_vm_value(_context).unwrap())
+            Ok(buf.try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_size.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_size.rs
@@ -3,9 +3,9 @@ pub fn generate() -> proc_macro2::TokenStream {
         fn _azle_ic_stable_size(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            Ok(ic_cdk::api::stable::stable_size().try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::stable::stable_size().try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_write.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_write.rs
@@ -2,20 +2,20 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_stable_write(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context,
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context,
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let offset: u32 = _aargs
+            let offset: u32 = aargs
                 .get(0)
                 .unwrap()
                 .clone()
-                .try_from_vm_value(&mut *_context)
+                .try_from_vm_value(&mut *context)
                 .unwrap();
-            let buf_vector: Vec<u8> = _aargs
+            let buf_vector: Vec<u8> = aargs
                 .get(1)
                 .unwrap()
                 .clone()
-                .try_from_vm_value(&mut *_context)
+                .try_from_vm_value(&mut *context)
                 .unwrap();
             let buf: &[u8] = &buf_vector[..];
             ic_cdk::api::stable::stable_write(offset, buf);

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/time.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/time.rs
@@ -3,9 +3,9 @@ pub fn generate() -> proc_macro2::TokenStream {
         fn _azle_ic_time(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            Ok(ic_cdk::api::time().try_into_vm_value(_context).unwrap())
+            Ok(ic_cdk::api::time().try_into_vm_value(context).unwrap())
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/trap.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/trap.rs
@@ -2,10 +2,10 @@ pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         fn _azle_ic_trap(
             _this: &boa_engine::JsValue,
-            _aargs: &[boa_engine::JsValue],
-            _context: &mut boa_engine::Context
+            aargs: &[boa_engine::JsValue],
+            context: &mut boa_engine::Context
         ) -> boa_engine::JsResult<boa_engine::JsValue> {
-            let message: String = _aargs.get(0).unwrap().clone().try_from_vm_value(_context).unwrap();
+            let message: String = aargs.get(0).unwrap().clone().try_from_vm_value(context).unwrap();
             ic_cdk::api::trap(&message);
         }
     }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/stable_b_tree_map/rust/bounded_storable_impl.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/stable_b_tree_map/rust/bounded_storable_impl.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Ident, TokenStream};
 
 pub fn generate(wrapper_type_name: &Ident, max_size: u32) -> TokenStream {
     quote::quote! {
-        impl BoundedStorable for #wrapper_type_name {
+        impl ic_stable_structures::BoundedStorable for #wrapper_type_name {
             fn max_size() -> u32 {
                 #max_size
             }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/stable_b_tree_map/rust/storable_impl.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/stable_b_tree_map/rust/storable_impl.rs
@@ -2,9 +2,9 @@ use proc_macro2::{Ident, TokenStream};
 
 pub fn generate(wrapper_type_name: &Ident) -> TokenStream {
     quote::quote! {
-        impl Storable for #wrapper_type_name {
+        impl ic_stable_structures::Storable for #wrapper_type_name {
             fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-                Cow::Owned(candid::Encode!(self).unwrap())
+                std::borrow::Cow::Owned(candid::Encode!(self).unwrap())
             }
 
             fn from_bytes(bytes: Vec<u8>) -> Self {

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/stable_b_tree_map/rust/wrapper_type.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/stable_b_tree_map/rust/wrapper_type.rs
@@ -36,7 +36,7 @@ pub fn generate(
     (
         wrapper_struct_name_ident.clone(),
         quote! {
-            #[derive(CandidType, Deserialize, CdkActTryFromVmValue)]
+            #[derive(candid::CandidType, candid::Deserialize, CdkActTryFromVmValue)]
             struct #wrapper_struct_name_ident(#inner_type);
             #(#dependent_types)*
         },

--- a/src/compiler/typescript_to_rust/azle_generate/src/candid_type/func/rust.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/candid_type/func/rust.rs
@@ -18,7 +18,7 @@ pub fn generate_list_into_vm_value_impl(function_name: String) -> TokenStream {
     quote! {
         impl CdkActTryIntoVmValue<&mut boa_engine::Context, boa_engine::JsValue> for Vec<#function_name> {
             fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
-                try_into_vm_value_generic_array(self, context)
+                _azle_try_into_vm_value_generic_array(self, context)
             }
         }
     }
@@ -41,7 +41,7 @@ pub fn generate_list_from_vm_value_impl(function_name: String) -> TokenStream {
     quote! {
         impl CdkActTryFromVmValue<Vec<#function_name>, &mut boa_engine::Context> for boa_engine::JsValue {
             fn try_from_vm_value(self, context: &mut boa_engine::Context) -> Result<Vec<#function_name>, CdkActTryFromVmValueError> {
-                try_from_vm_value_generic_array(self, context)
+                _azle_try_from_vm_value_generic_array(self, context)
             }
         }
     }

--- a/src/compiler/typescript_to_rust/azle_generate/src/candid_type/service/vm_value_conversions.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/candid_type/service/vm_value_conversions.rs
@@ -26,7 +26,7 @@ pub fn list_to_vm_value(name: String) -> TokenStream {
     quote! {
         impl CdkActTryIntoVmValue<&mut boa_engine::Context, boa_engine::JsValue> for Vec<#service_name> {
             fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
-                try_into_vm_value_generic_array(self, context)
+                _azle_try_into_vm_value_generic_array(self, context)
             }
         }
     }
@@ -63,7 +63,7 @@ pub fn list_from_vm_value(name: String) -> TokenStream {
     quote! {
         impl CdkActTryFromVmValue<Vec<#service_name>, &mut boa_engine::Context> for boa_engine::JsValue {
             fn try_from_vm_value(self, context: &mut boa_engine::Context) -> Result<Vec<#service_name>, CdkActTryFromVmValueError> {
-                try_from_vm_value_generic_array(self, context)
+                _azle_try_from_vm_value_generic_array(self, context)
             }
         }
     }

--- a/src/compiler/typescript_to_rust/azle_generate/src/candid_type/tuple/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/candid_type/tuple/mod.rs
@@ -1,7 +1,4 @@
-use cdk_framework::act::node::{
-    candid::{tuple::Elem, Tuple},
-    CandidType,
-};
+use cdk_framework::act::node::candid::{tuple::Elem, Tuple};
 use swc_common::SourceMap;
 use swc_ecma_ast::{TsTupleType, TsTypeAliasDecl};
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/heartbeat/rust.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/heartbeat/rust.rs
@@ -7,7 +7,7 @@ pub fn generate(heartbeat_fn_decl: &AnnotatedFnDecl) -> proc_macro2::TokenStream
 
     quote::quote! {
         BOA_CONTEXT_REF_CELL.with(|box_context_ref_cell| {
-            let mut _azle_boa_context = box_context_ref_cell.borrow_mut();
+            let mut boa_context = box_context_ref_cell.borrow_mut();
 
             let uuid = uuid::Uuid::new_v4().to_string();
 
@@ -32,8 +32,8 @@ pub fn generate(heartbeat_fn_decl: &AnnotatedFnDecl) -> proc_macro2::TokenStream
             #call_to_heartbeat_js_function
 
             _azle_async_await_result_handler(
-                &mut _azle_boa_context,
-                &_azle_boa_return_value,
+                &mut boa_context,
+                &boa_return_value,
                 &uuid,
                 #function_name,
                 true

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/init/rust.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/init/rust.rs
@@ -10,7 +10,7 @@ pub fn generate(init_fn_decl_option: Option<&AnnotatedFnDecl>) -> proc_macro2::T
 
     quote::quote! {
         BOA_CONTEXT_REF_CELL.with(|box_context_ref_cell| {
-            let mut _azle_boa_context = box_context_ref_cell.borrow_mut();
+            let mut boa_context = box_context_ref_cell.borrow_mut();
 
             METHOD_NAME_REF_CELL.with(|method_name_ref_cell| {
                 let mut method_name_mut = method_name_ref_cell.borrow_mut();
@@ -18,12 +18,12 @@ pub fn generate(init_fn_decl_option: Option<&AnnotatedFnDecl>) -> proc_macro2::T
                 *method_name_mut = #function_name.to_string()
             });
 
-            _azle_register_ic_object(&mut _azle_boa_context);
+            _azle_register_ic_object(&mut boa_context);
 
-            _azle_unwrap_boa_result(_azle_boa_context.eval(format!(
+            _azle_unwrap_boa_result(boa_context.eval(format!(
                 "let exports = {{}}; {compiled_js}",
                 compiled_js = MAIN_JS
-            )), &mut _azle_boa_context);
+            )), &mut boa_context);
 
             #call_to_init_js_function
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/inspect_message/rust.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/inspect_message/rust.rs
@@ -8,7 +8,7 @@ pub fn generate(inspect_message_fn_decl: &AnnotatedFnDecl) -> proc_macro2::Token
 
     quote::quote! {
         BOA_CONTEXT_REF_CELL.with(|box_context_ref_cell| {
-            let mut _azle_boa_context = box_context_ref_cell.borrow_mut();
+            let mut boa_context = box_context_ref_cell.borrow_mut();
 
             METHOD_NAME_REF_CELL.with(|method_name_ref_cell| {
                 let mut method_name_mut = method_name_ref_cell.borrow_mut();

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/post_upgrade/rust.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/post_upgrade/rust.rs
@@ -13,7 +13,7 @@ pub fn generate(post_upgrade_fn_decl_option: Option<&AnnotatedFnDecl>) -> TokenS
 
     quote::quote! {
         BOA_CONTEXT_REF_CELL.with(|box_context_ref_cell| {
-            let mut _azle_boa_context = box_context_ref_cell.borrow_mut();
+            let mut boa_context = box_context_ref_cell.borrow_mut();
 
             METHOD_NAME_REF_CELL.with(|method_name_ref_cell| {
                 let mut method_name_mut = method_name_ref_cell.borrow_mut();
@@ -21,12 +21,12 @@ pub fn generate(post_upgrade_fn_decl_option: Option<&AnnotatedFnDecl>) -> TokenS
                 *method_name_mut = #function_name.to_string()
             });
 
-            _azle_register_ic_object(&mut _azle_boa_context);
+            _azle_register_ic_object(&mut boa_context);
 
-            _azle_unwrap_boa_result(_azle_boa_context.eval(format!(
+            _azle_unwrap_boa_result(boa_context.eval(format!(
                 "let exports = {{}}; {compiled_js}",
                 compiled_js = MAIN_JS
-            )), &mut _azle_boa_context);
+            )), &mut boa_context);
 
             #call_to_post_upgrade_js_function
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/pre_upgrade/rust.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/pre_upgrade/rust.rs
@@ -7,7 +7,7 @@ pub fn generate(pre_upgrade_fn_decl: &AnnotatedFnDecl) -> proc_macro2::TokenStre
 
     quote::quote! {
         BOA_CONTEXT_REF_CELL.with(|box_context_ref_cell| {
-            let mut _azle_boa_context = box_context_ref_cell.borrow_mut();
+            let mut boa_context = box_context_ref_cell.borrow_mut();
 
             METHOD_NAME_REF_CELL.with(|method_name_ref_cell| {
                 let mut method_name_mut = method_name_ref_cell.borrow_mut();

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/query_and_update/shared/body.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/query_and_update/shared/body.rs
@@ -16,7 +16,7 @@ pub fn generate(fn_decl: &AnnotatedFnDecl) -> proc_macro2::TokenStream {
 
     quote! {
         BOA_CONTEXT_REF_CELL.with(|box_context_ref_cell| {
-            let mut _azle_boa_context = box_context_ref_cell.borrow_mut();
+            let mut boa_context = box_context_ref_cell.borrow_mut();
 
             let uuid = uuid::Uuid::new_v4().to_string();
 
@@ -40,9 +40,9 @@ pub fn generate(fn_decl: &AnnotatedFnDecl) -> proc_macro2::TokenStream {
 
             #call_to_js_function
 
-            let _azle_final_return_value = _azle_async_await_result_handler(
-                &mut _azle_boa_context,
-                &_azle_boa_return_value,
+            let final_return_value = _azle_async_await_result_handler(
+                &mut boa_context,
+                &boa_return_value,
                 &uuid,
                 #function_name,
                 #manual
@@ -57,9 +57,9 @@ pub fn generate(fn_decl: &AnnotatedFnDecl) -> proc_macro2::TokenStream {
 ///
 /// # Context
 ///
-/// * `_azle_final_return_value: boa_engine::JsValue` - The value to be returned
+/// * `final_return_value: boa_engine::JsValue` - The value to be returned
 ///    unless this is a ManualReply method.
-/// * `_azle_boa_context: &mut boa_engine::Context` - The current boa context
+/// * `boa_context: &mut boa_engine::Context` - The current boa context
 fn generate_return_expression(annotated_fn_decl: &AnnotatedFnDecl) -> proc_macro2::TokenStream {
     if annotated_fn_decl.is_manual() || annotated_fn_decl.is_promise() {
         return quote! {
@@ -72,12 +72,12 @@ fn generate_return_expression(annotated_fn_decl: &AnnotatedFnDecl) -> proc_macro
     let null_and_void_handler = match return_type {
         TsType::TsKeywordType(keyword) => match keyword.kind {
             TsNullKeyword => quote! {
-                if !_azle_final_return_value.is_null() {
+                if !final_return_value.is_null() {
                     ic_cdk::api::trap("TypeError: value is not of type 'null'");
                 }
             },
             TsVoidKeyword => quote! {
-                if !_azle_final_return_value.is_undefined() {
+                if !final_return_value.is_undefined() {
                     ic_cdk::api::trap("TypeError: value is not of type 'void'");
                 }
             },
@@ -88,7 +88,7 @@ fn generate_return_expression(annotated_fn_decl: &AnnotatedFnDecl) -> proc_macro
 
     quote! {
         #null_and_void_handler
-        match _azle_final_return_value.try_from_vm_value(&mut *_azle_boa_context) {
+        match final_return_value.try_from_vm_value(&mut *boa_context) {
             Ok(return_value) => return_value,
             Err(e) => ic_cdk::api::trap(&format!("TypeError: {}",&e.0))
         }

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/rust.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/rust.rs
@@ -22,21 +22,21 @@ pub fn generate_call_to_js_function(annotated_fn_decl: &AnnotatedFnDecl) -> Toke
         .collect();
 
     quote! {
-        let _azle_exports_js_value = _azle_unwrap_boa_result(_azle_boa_context.eval("exports"), &mut _azle_boa_context);
-        let _azle_exports_js_object = _azle_exports_js_value.as_object().unwrap();
+        let exports_js_value = _azle_unwrap_boa_result(boa_context.eval("exports"), &mut boa_context);
+        let exports_js_object = exports_js_value.as_object().unwrap();
 
-        let _azle_function_js_value = _azle_exports_js_object.get(#function_name, &mut _azle_boa_context).unwrap();
-        let _azle_function_js_object = _azle_function_js_value.as_object().unwrap();
+        let function_js_value = exports_js_object.get(#function_name, &mut boa_context).unwrap();
+        let function_js_object = function_js_value.as_object().unwrap();
 
-        let _azle_boa_return_value = _azle_unwrap_boa_result(
-            _azle_function_js_object.call(
+        let boa_return_value = _azle_unwrap_boa_result(
+            function_js_object.call(
                 &boa_engine::JsValue::Null,
                 &[
-                    #(#param_name_idents.try_into_vm_value(&mut _azle_boa_context).unwrap()),*
+                    #(#param_name_idents.try_into_vm_value(&mut boa_context).unwrap()),*
                 ],
-                &mut _azle_boa_context
+                &mut boa_context
             ),
-            &mut _azle_boa_context
+            &mut boa_context
         );
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/header/use_statements.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/header/use_statements.rs
@@ -1,6 +1,7 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         use azle_vm_value_derive::{CdkActTryIntoVmValue, CdkActTryFromVmValue};
+        use candid::{Decode, Encode};
         use rand::Rng as _AzleTraitRng;
         use slotmap::Key as _AzleTraitSlotMapKey;
         use std::convert::TryInto as _AzleTraitTryInto;

--- a/src/compiler/typescript_to_rust/azle_generate/src/header/use_statements.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/header/use_statements.rs
@@ -1,15 +1,9 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
         use azle_vm_value_derive::{CdkActTryIntoVmValue, CdkActTryFromVmValue};
-        use ic_cdk::api::call::CallResult;
-        use std::borrow::BorrowMut;
-        use rand::{
-            Rng,
-            SeedableRng,
-            rngs::StdRng
-        };
-        use slotmap::Key as AzleSlotMapKey; // Renamed to avoid clashes with user-defined types
-        use std::str::FromStr;
-        use std::convert::TryInto;
+        use rand::Rng as _AzleTraitRng;
+        use slotmap::Key as _AzleTraitSlotMapKey;
+        use std::convert::TryInto as _AzleTraitTryInto;
+        use std::str::FromStr as _AzleTraitFromStr;
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_from_vm_value_impls/vec.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_from_vm_value_impls/vec.rs
@@ -32,7 +32,7 @@ pub fn generate() -> proc_macro2::TokenStream {
             boa_engine::JsValue: for<'a> CdkActTryFromVmValue<T, &'a mut boa_engine::Context>
         {
             fn try_from_vm_value(self, context: &mut boa_engine::Context) -> Result<Vec<T>, CdkActTryFromVmValueError> {
-                try_from_vm_value_generic_array::<T>(self, context)
+                _azle_try_from_vm_value_generic_array::<T>(self, context)
             }
         }
 
@@ -58,7 +58,7 @@ pub fn generate() -> proc_macro2::TokenStream {
         }
 
         // TODO this seems like such a messy and inefficient way to do it
-        fn try_from_vm_value_generic_array<T>(js_value: boa_engine::JsValue, context: &mut boa_engine::Context) -> Result<Vec<T>, CdkActTryFromVmValueError>
+        fn _azle_try_from_vm_value_generic_array<T>(js_value: boa_engine::JsValue, context: &mut boa_engine::Context) -> Result<Vec<T>, CdkActTryFromVmValueError>
         where
             boa_engine::JsValue: for<'a> CdkActTryFromVmValue<T, &'a mut boa_engine::Context>
         {

--- a/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_into_vm_value_impls/vec.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_into_vm_value_impls/vec.rs
@@ -62,7 +62,7 @@ pub fn generate() -> proc_macro2::TokenStream {
             T: for<'a> CdkActTryIntoVmValue<&'a mut boa_engine::Context, boa_engine::JsValue>
         {
             fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
-                try_into_vm_value_generic_array(self, context)
+                _azle_try_into_vm_value_generic_array(self, context)
             }
         }
 
@@ -73,7 +73,7 @@ pub fn generate() -> proc_macro2::TokenStream {
             }
         }
 
-        fn try_into_vm_value_generic_array<T>(generic_array: Vec<T>, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError>
+        fn _azle_try_into_vm_value_generic_array<T>(generic_array: Vec<T>, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError>
         where
             T:  for<'a> CdkActTryIntoVmValue<&'a mut boa_engine::Context, boa_engine::JsValue>
         {


### PR DESCRIPTION
In order to reduce conlicts with user-defined code, this PR:

- Removes global `use` statements in favor of fully qualified names
- Removes `_azle_` prefixes from variables in favor of prefixing user-defined variables with `cdk_user_defined_`
- Adds `_azle_` prefixes to global functions so they don't conflict with user-defined functions
- Removes leading underscores on function params where the param is used in the function body

> **Note**
> We still have a `use candid::{Encode, Decode}` statement, but it doesn't clash with structs/enums/types so users can still have their own struct/enum/type with that name.

Depends on https://github.com/demergent-labs/cdk_framework/pull/65