### PR TITLE
Changed Opt to be an algebraic data type

### DIFF
--- a/examples/bitcoin/src/index.ts
+++ b/examples/bitcoin/src/index.ts
@@ -1,4 +1,4 @@
-import { blob, match, Result, $update, Vec } from 'azle';
+import { blob, match, Opt, Result, $update, Vec } from 'azle';
 import {
     BitcoinNetwork,
     GetUtxosResult,
@@ -18,7 +18,7 @@ export async function getBalance(
     return await managementCanister
         .bitcoin_get_balance({
             address,
-            min_confirmations: null,
+            min_confirmations: Opt.None,
             network: BitcoinNetwork.Regtest
         })
         .cycles(BITCOIN_API_CYCLE_COST)
@@ -44,7 +44,7 @@ export async function getUtxos(
     return await managementCanister
         .bitcoin_get_utxos({
             address,
-            filter: null,
+            filter: Opt.None,
             network: BitcoinNetwork.Regtest
         })
         .cycles(BITCOIN_API_CYCLE_COST)

--- a/examples/cross_canister_calls/canisters/canister2/canister2.ts
+++ b/examples/cross_canister_calls/canisters/canister2/canister2.ts
@@ -50,7 +50,8 @@ export function balance(id: string): nat64 {
 
 $query;
 export function account(accountArgs: AccountArgs): Opt<Account> {
-    return state.accounts[accountArgs.id] ?? null;
+    let account = state.accounts[accountArgs.id];
+    return account ? Opt.Some(account) : Opt.None;
 }
 
 $query;

--- a/examples/cross_canister_calls/canisters/canister2/canister2.ts
+++ b/examples/cross_canister_calls/canisters/canister2/canister2.ts
@@ -50,7 +50,7 @@ export function balance(id: string): nat64 {
 
 $query;
 export function account(accountArgs: AccountArgs): Opt<Account> {
-    let account = state.accounts[accountArgs.id];
+    const account = state.accounts[accountArgs.id];
     return account ? Opt.Some(account) : Opt.None;
 }
 

--- a/examples/ethereum_json_rpc/src/index.ts
+++ b/examples/ethereum_json_rpc/src/index.ts
@@ -6,7 +6,8 @@ import {
     nat32,
     $query,
     StableBTreeMap,
-    $update
+    $update,
+    Opt
 } from 'azle';
 import {
     HttpResponse,
@@ -29,26 +30,31 @@ $update;
 export async function ethGetBalance(ethereumAddress: string): Promise<JSON> {
     const httpResult = await managementCanister
         .http_request({
-            url: stableStorage.get('ethereumUrl') ?? '',
-            max_response_bytes: 2_000n,
+            url: match(stableStorage.get('ethereumUrl'), {
+                Some: (url) => url,
+                None: () => ''
+            }),
+            max_response_bytes: Opt.Some(2_000n),
             method: {
                 post: null
             },
             headers: [],
-            body: new Uint8Array(
-                encodeUtf8(
-                    JSON.stringify({
-                        jsonrpc: '2.0',
-                        method: 'eth_getBalance',
-                        params: [ethereumAddress, 'earliest'],
-                        id: 1
-                    })
+            body: Opt.Some(
+                new Uint8Array(
+                    encodeUtf8(
+                        JSON.stringify({
+                            jsonrpc: '2.0',
+                            method: 'eth_getBalance',
+                            params: [ethereumAddress, 'earliest'],
+                            id: 1
+                        })
+                    )
                 )
             ),
-            transform: {
+            transform: Opt.Some({
                 function: [ic.id(), 'ethTransform'],
                 context: Uint8Array.from([])
-            }
+            })
         })
         .cycles(50_000_000n)
         .call();
@@ -63,26 +69,31 @@ $update;
 export async function ethGetBlockByNumber(number: nat32): Promise<JSON> {
     const httpResult = await managementCanister
         .http_request({
-            url: stableStorage.get('ethereumUrl') ?? '',
-            max_response_bytes: 2_000n,
+            url: match(stableStorage.get('ethereumUrl'), {
+                Some: (url) => url,
+                None: () => ''
+            }),
+            max_response_bytes: Opt.Some(2_000n),
             method: {
                 post: null
             },
             headers: [],
-            body: new Uint8Array(
-                encodeUtf8(
-                    JSON.stringify({
-                        jsonrpc: '2.0',
-                        method: 'eth_getBlockByNumber',
-                        params: [`0x${number.toString(16)}`, false],
-                        id: 1
-                    })
+            body: Opt.Some(
+                new Uint8Array(
+                    encodeUtf8(
+                        JSON.stringify({
+                            jsonrpc: '2.0',
+                            method: 'eth_getBlockByNumber',
+                            params: [`0x${number.toString(16)}`, false],
+                            id: 1
+                        })
+                    )
                 )
             ),
-            transform: {
+            transform: Opt.Some({
                 function: [ic.id(), 'ethTransform'],
                 context: Uint8Array.from([])
-            }
+            })
         })
         .cycles(50_000_000n)
         .call();

--- a/examples/func_types/canisters/func_types/func_types.ts
+++ b/examples/func_types/canisters/func_types/func_types.ts
@@ -57,12 +57,10 @@ export function init(): void {
 
 $query;
 export function getStableFunc(): StableFunc {
-    return (
-        stableStorage.get('stableFunc') ?? [
-            Principal.from('aaaaa-aa'),
-            'raw_rand'
-        ]
-    );
+    return match(stableStorage.get('stableFunc'), {
+        Some: (func) => func,
+        None: () => [Principal.from('aaaaa-aa'), 'raw_rand'] as StableFunc
+    });
 }
 
 $query;

--- a/examples/init/src/init.ts
+++ b/examples/init/src/init.ts
@@ -9,9 +9,9 @@ type Reaction = Variant<{
     Wave: null;
 }>;
 
-let user: Opt<User> = null;
-let reaction: Opt<Reaction> = null;
-let owner: Opt<Principal> = null;
+let user: Opt<User> = Opt.None;
+let reaction: Opt<Reaction> = Opt.None;
+let owner: Opt<Principal> = Opt.None;
 
 $init;
 export function init(
@@ -19,9 +19,9 @@ export function init(
     initReaction: Reaction,
     initOwner: Principal
 ): void {
-    user = initUser;
-    reaction = initReaction;
-    owner = initOwner;
+    user = Opt.Some(initUser);
+    reaction = Opt.Some(initReaction);
+    owner = Opt.Some(initOwner);
 }
 
 $query;

--- a/examples/inline_types/src/inline_types.ts
+++ b/examples/inline_types/src/inline_types.ts
@@ -127,10 +127,10 @@ export function recordReferencingVariantFromParam(
     }>
 ): Opt<string> {
     if (param1.testVariant.prop1 !== undefined) {
-        return param1.testVariant.prop1;
+        return Opt.Some(param1.testVariant.prop1);
     }
 
-    return null;
+    return Opt.None;
 }
 
 $query;

--- a/examples/key_value_store/canisters/azle/index.ts
+++ b/examples/key_value_store/canisters/azle/index.ts
@@ -6,7 +6,7 @@ type PerfResult = Record<{
     wasmIncludingPrelude: nat64;
 }>;
 
-let perfResult: Opt<PerfResult> = null;
+let perfResult: Opt<PerfResult> = Opt.None;
 
 $query;
 export function getPerfResult(): Opt<PerfResult> {
@@ -14,10 +14,10 @@ export function getPerfResult(): Opt<PerfResult> {
 }
 
 function recordPerformance(start: nat64, end: nat64): void {
-    perfResult = {
+    perfResult = Opt.Some({
         wasmBodyOnly: end - start,
         wasmIncludingPrelude: ic.performanceCounter(0)
-    };
+    });
 }
 //#endregion
 
@@ -25,7 +25,9 @@ let store: Map<string, string> = new Map();
 
 $query;
 export function get(key: string): Opt<string> {
-    return store.get(key) ?? null;
+    const keyOrUndefined = store.get(key);
+
+    return keyOrUndefined ? Opt.Some(keyOrUndefined) : Opt.None;
 }
 
 $update;

--- a/examples/ledger_canister/canisters/ledger_canister/ledger_canister.ts
+++ b/examples/ledger_canister/canisters/ledger_canister/ledger_canister.ts
@@ -43,14 +43,12 @@ export async function executeTransfer(
             fee: {
                 e8s: fee
             },
-            from_subaccount: null,
+            from_subaccount: Opt.None,
             to: binaryAddressFromAddress(to),
-            created_at_time:
-                createdAtTime === null
-                    ? null
-                    : {
-                          timestamp_nanos: createdAtTime
-                      }
+            created_at_time: match(createdAtTime, {
+                Some: (time) => Opt.Some({ timestamp_nanos: time }),
+                None: () => Opt.None
+            })
         })
         .call();
 }

--- a/examples/management_canister/src/management_canister.ts
+++ b/examples/management_canister/src/management_canister.ts
@@ -1,6 +1,15 @@
 // TODO once the Bitcoin integration is live, add the methods and tests
 
-import { blob, match, nat, Principal, $query, Result, $update } from 'azle';
+import {
+    blob,
+    match,
+    nat,
+    Opt,
+    Principal,
+    $query,
+    Result,
+    $update
+} from 'azle';
 import {
     CanisterStatusArgs,
     CanisterStatusResult,
@@ -22,7 +31,7 @@ export async function executeCreateCanister(): Promise<
 > {
     const createCanisterResultCallResult = await managementCanister
         .create_canister({
-            settings: null
+            settings: Opt.None
         })
         .cycles(50_000_000_000_000n)
         .call();
@@ -47,10 +56,10 @@ export async function executeUpdateSettings(
         .update_settings({
             canister_id: canisterId,
             settings: {
-                controllers: null,
-                compute_allocation: 1n,
-                memory_allocation: 3_000_000n,
-                freezing_threshold: 2_000_000n
+                controllers: Opt.None,
+                compute_allocation: Opt.Some(1n),
+                memory_allocation: Opt.Some(3_000_000n),
+                freezing_threshold: Opt.Some(2_000_000n)
             }
         })
         .call();
@@ -198,8 +207,8 @@ export async function provisionalCreateCanisterWithCycles(): Promise<
 > {
     const callResult = await managementCanister
         .provisional_create_canister_with_cycles({
-            amount: null,
-            settings: null
+            amount: Opt.None,
+            settings: Opt.None
         })
         .call();
 

--- a/examples/motoko_examples/calc/canisters/azle/index.ts
+++ b/examples/motoko_examples/calc/canisters/azle/index.ts
@@ -6,7 +6,7 @@ type PerfResult = Record<{
     wasmIncludingPrelude: nat64;
 }>;
 
-let perfResult: Opt<PerfResult> = null;
+let perfResult: Opt<PerfResult> = Opt.None;
 
 $query;
 export function getPerfResult(): Opt<PerfResult> {
@@ -14,10 +14,10 @@ export function getPerfResult(): Opt<PerfResult> {
 }
 
 function recordPerformance(start: nat64, end: nat64): void {
-    perfResult = {
+    perfResult = Opt.Some({
         wasmBodyOnly: end - start,
         wasmIncludingPrelude: ic.performanceCounter(0)
-    };
+    });
 }
 //#endregion
 
@@ -68,10 +68,10 @@ export function div(n: int): Opt<int> {
 
     let result: Opt<int>;
     if (n === 0n) {
-        result = null;
+        result = Opt.None;
     } else {
         cell /= n;
-        result = cell;
+        result = Opt.Some(cell);
     }
 
     const perfEnd = ic.performanceCounter(0);

--- a/examples/motoko_examples/phone-book/canisters/azle/index.ts
+++ b/examples/motoko_examples/phone-book/canisters/azle/index.ts
@@ -6,7 +6,7 @@ type PerfResult = Record<{
     wasmIncludingPrelude: nat64;
 }>;
 
-let perfResult: Opt<PerfResult> = null;
+let perfResult: Opt<PerfResult> = Opt.None;
 
 $query;
 export function getPerfResult(): Opt<PerfResult> {
@@ -14,10 +14,10 @@ export function getPerfResult(): Opt<PerfResult> {
 }
 
 function recordPerformance(start: nat64, end: nat64): void {
-    perfResult = {
+    perfResult = Opt.Some({
         wasmBodyOnly: end - start,
         wasmIncludingPrelude: ic.performanceCounter(0)
-    };
+    });
 }
 //#endregion
 
@@ -41,5 +41,7 @@ export function insert(name: string, entry: Entry): void {
 
 $query;
 export function lookup(name: string): Opt<Entry> {
-    return phoneBook.get(name) ?? null;
+    const entryOrUndefined = phoneBook.get(name);
+
+    return entryOrUndefined ? Opt.Some(entryOrUndefined) : Opt.None;
 }

--- a/examples/motoko_examples/superheroes/canisters/azle/index.ts
+++ b/examples/motoko_examples/superheroes/canisters/azle/index.ts
@@ -16,7 +16,7 @@ type PerfResult = Record<{
     wasmIncludingPrelude: nat64;
 }>;
 
-let perfResult: Opt<PerfResult> = null;
+let perfResult: Opt<PerfResult> = Opt.None;
 
 $query;
 export function getPerfResult(): Opt<PerfResult> {
@@ -24,10 +24,10 @@ export function getPerfResult(): Opt<PerfResult> {
 }
 
 function recordPerformance(start: nat64, end: nat64): void {
-    perfResult = {
+    perfResult = Opt.Some({
         wasmBodyOnly: end - start,
         wasmIncludingPrelude: ic.performanceCounter(0)
-    };
+    });
 }
 //#endregion
 
@@ -74,9 +74,8 @@ export function create(superhero: Superhero): SuperheroId {
 // Read a superhero.
 $query;
 export function read(superheroId: SuperheroId): Opt<Superhero> {
-    let result = superheroes.get(superheroId) ?? null;
-
-    return result;
+    const superheroOrUndefined = superheroes.get(superheroId);
+    return superheroOrUndefined ? Opt.Some(superheroOrUndefined) : Opt.None;
 }
 
 // Update a superhero.

--- a/examples/motoko_examples/threshold_ecdsa/canisters/azle/index.ts
+++ b/examples/motoko_examples/threshold_ecdsa/canisters/azle/index.ts
@@ -1,4 +1,4 @@
-import { blob, ic, match, Record, Result, $update } from 'azle';
+import { blob, ic, match, Opt, Record, Result, $update } from 'azle';
 import { managementCanister } from 'azle/canisters/management';
 
 $update;
@@ -8,7 +8,7 @@ export async function publicKey(): Promise<
     const caller = ic.caller().toUint8Array();
     const publicKeyResult = await managementCanister
         .ecdsa_public_key({
-            canister_id: null,
+            canister_id: Opt.None,
             derivation_path: [caller],
             key_id: { curve: { secp256k1: null }, name: 'dfx_test_key' }
         })

--- a/examples/optional_types/src/optional_types.did
+++ b/examples/optional_types/src/optional_types.did
@@ -6,4 +6,7 @@ service : () -> {
   getHead : () -> (opt Head) query;
   getHeadWithElements : () -> (opt Head) query;
   getHtml : () -> (Html) query;
+  getNull : () -> (null) query;
+  getOptNull : () -> (opt text) query;
+  stringToBoolean : (opt text) -> (bool) query;
 }

--- a/examples/optional_types/src/optional_types.ts
+++ b/examples/optional_types/src/optional_types.ts
@@ -45,7 +45,12 @@ export function getElement(element: Opt<Opt<Element>>): Opt<Opt<Element>> {
 }
 
 $query;
-export function returnOptNull(): Opt<string> {
+export function getNull(): null {
+    return null;
+}
+
+$query;
+export function getOptNull(): Opt<string> {
     return Opt.None;
 }
 

--- a/examples/optional_types/src/optional_types.ts
+++ b/examples/optional_types/src/optional_types.ts
@@ -1,6 +1,6 @@
 // TODO let's add more examples here, really test it out
 
-import { Opt, $query, Record, Vec } from 'azle';
+import { match, Opt, $query, Record, Vec } from 'azle';
 
 type Html = Record<{
     head: Opt<Head>;
@@ -17,29 +17,42 @@ type Element = Record<{
 $query;
 export function getHtml(): Html {
     return {
-        head: null
+        head: Opt.None
     };
 }
 
 $query;
 export function getHead(): Opt<Head> {
-    return {
+    return Opt.Some({
         elements: []
-    };
+    });
 }
 
 $query;
 export function getHeadWithElements(): Opt<Head> {
-    return {
+    return Opt.Some({
         elements: [
             {
                 id: '0'
             }
         ]
-    };
+    });
 }
 
 $query;
 export function getElement(element: Opt<Opt<Element>>): Opt<Opt<Element>> {
     return element;
+}
+
+$query;
+export function returnOptNull(): Opt<string> {
+    return Opt.None;
+}
+
+$query;
+export function stringToBoolean(optString: Opt<string>): boolean {
+    return match(optString, {
+        Some: (_) => true,
+        None: () => false
+    });
 }

--- a/examples/optional_types/test/tests.ts
+++ b/examples/optional_types/test/tests.ts
@@ -41,7 +41,7 @@ export function getTests(
             }
         },
         {
-            name: 'getElement',
+            name: 'getElement(None)',
             test: async () => {
                 const result = await optionalTypesCanister.getElement([]);
 
@@ -51,17 +51,17 @@ export function getTests(
             }
         },
         {
-            name: 'getElement',
+            name: 'getElement(Some(None))',
             test: async () => {
                 const result = await optionalTypesCanister.getElement([[]]);
 
                 return {
-                    Ok: result.length === 0
+                    Ok: result.length === 1 && result[0].length === 0
                 };
             }
         },
         {
-            name: 'getElement',
+            name: 'getElement(Some(Some({ id: "0" })))',
             test: async () => {
                 const result = await optionalTypesCanister.getElement([
                     [{ id: '0' }]
@@ -72,6 +72,48 @@ export function getTests(
                         result.length === 1 &&
                         result[0].length === 1 &&
                         result[0][0].id === '0'
+                };
+            }
+        },
+        {
+            name: 'getNull',
+            test: async () => {
+                const result = await optionalTypesCanister.getNull();
+
+                return {
+                    Ok: result === null
+                };
+            }
+        },
+        {
+            name: 'getOptNull',
+            test: async () => {
+                const result = await optionalTypesCanister.getOptNull();
+
+                return {
+                    Ok: result.length === 0
+                };
+            }
+        },
+        {
+            name: 'stringToBoolean(Some("something"))',
+            test: async () => {
+                const result = await optionalTypesCanister.stringToBoolean([
+                    'something'
+                ]);
+
+                return {
+                    Ok: result
+                };
+            }
+        },
+        {
+            name: 'stringToBoolean(None)',
+            test: async () => {
+                const result = await optionalTypesCanister.stringToBoolean([]);
+
+                return {
+                    Ok: !result
                 };
             }
         }

--- a/examples/outgoing_http_requests/src/index.ts
+++ b/examples/outgoing_http_requests/src/index.ts
@@ -1,4 +1,4 @@
-import { ic, Manual, match, Principal, $query, $update } from 'azle';
+import { ic, Manual, match, Opt, Principal, $query, $update } from 'azle';
 import {
     HttpResponse,
     HttpTransformArgs,
@@ -10,16 +10,16 @@ export async function xkcd(): Promise<HttpResponse> {
     const httpResult = await managementCanister
         .http_request({
             url: `https://xkcd.com/642/info.0.json`,
-            max_response_bytes: 2_000n,
+            max_response_bytes: Opt.Some(2_000n),
             method: {
                 get: null
             },
             headers: [],
-            body: null,
-            transform: {
+            body: Opt.None,
+            transform: Opt.Some({
                 function: [ic.id(), 'xkcdTransform'],
                 context: Uint8Array.from([])
-            }
+            })
         })
         .cycles(50_000_000n)
         .call();

--- a/examples/pre_and_post_upgrade/src/pre_and_post_upgrade.ts
+++ b/examples/pre_and_post_upgrade/src/pre_and_post_upgrade.ts
@@ -1,5 +1,6 @@
 import {
     $init,
+    match,
     nat64,
     $postUpgrade,
     $preUpgrade,
@@ -47,7 +48,10 @@ $postUpgrade;
 export function postUpgrade(): void {
     console.log('postUpgrade');
 
-    entries = (stableStorage.get('entries') ?? []).reduce((result, entry) => {
+    entries = match(stableStorage.get('entries'), {
+        Some: (x) => x,
+        None: () => [] as Vec<Entry>
+    }).reduce((result, entry) => {
         return {
             ...result,
             [entry.key]: entry.value

--- a/examples/run_time_errors/src/index.did
+++ b/examples/run_time_errors/src/index.did
@@ -3,6 +3,11 @@ service : () -> {
   alsoInaccessible : () -> (bool);
   getInitialized : () -> (bool) query;
   inaccessible : () -> (bool);
+  returnBothSomeAndNone : () -> (opt text) query;
+  returnInvalidSomeValue : () -> (opt text) query;
+  returnNonNullNone : () -> (opt text) query;
+  returnNonObject : () -> (opt text) query;
+  returnObjectWithNeitherSomeNorNone : () -> (opt text) query;
   throwBigint : () -> () query;
   throwBoolean : () -> () query;
   throwClass : () -> () query;

--- a/examples/run_time_errors/src/index.ts
+++ b/examples/run_time_errors/src/index.ts
@@ -1,4 +1,4 @@
-import { $heartbeat, ic, $inspectMessage, $query, $update } from 'azle';
+import { $heartbeat, ic, $inspectMessage, $query, $update, Opt } from 'azle';
 
 // throw 'Uncomment this to test that errors are handled during the eval process.';
 
@@ -140,3 +140,35 @@ export function alsoInaccessible(): boolean {
 //     console.log('postUpgrade');
 //     throw 'We are throwing in the post-upgrade';
 // }
+
+//#region invalid Opt return values
+$query;
+export function returnNonObject(): Opt<string> {
+    // @ts-expect-error: We want to test how this errors out
+    return true;
+}
+
+$query;
+export function returnBothSomeAndNone(): Opt<string> {
+    // @ts-expect-error
+    return { Some: 'string', None: null };
+}
+
+$query;
+export function returnObjectWithNeitherSomeNorNone(): Opt<string> {
+    // @ts-expect-error
+    return { Non: null };
+}
+
+$query;
+export function returnNonNullNone(): Opt<string> {
+    // @ts-expect-error
+    return { None: 'not null value' };
+}
+
+$query;
+export function returnInvalidSomeValue(): Opt<string> {
+    // @ts-expect-error
+    return { Some: null };
+}
+//#endregion

--- a/examples/run_time_errors/test/tests.ts
+++ b/examples/run_time_errors/test/tests.ts
@@ -4,121 +4,50 @@ import { _SERVICE } from './dfx_generated/run_time_errors/run_time_errors.did';
 
 export function getTests(errorCanister: ActorSubclass<_SERVICE>): Test[] {
     return [
-        {
-            name: 'throw big int',
-            test: async () => {
-                return {
-                    Ok: await testThrow(errorCanister.throwBigint, '3')
-                };
-            }
-        },
-        {
-            name: 'throw boolean',
-            test: async () => {
-                return {
-                    Ok: await testThrow(errorCanister.throwBoolean, 'false')
-                };
-            }
-        },
-        {
-            name: 'throw class',
-            test: async () => {
-                return {
-                    Ok: await testThrow(
-                        errorCanister.throwClass,
-                        'CustomClass toString'
-                    )
-                };
-            }
-        },
-        {
-            name: 'throw custom error',
-            test: async () => {
-                return {
-                    Ok: await testThrow(
-                        errorCanister.throwCustomError,
-                        'Error: This is a custom error'
-                    )
-                };
-            }
-        },
-        {
-            name: 'throw int',
-            test: async () => {
-                return {
-                    Ok: await testThrow(errorCanister.throwInt, '3')
-                };
-            }
-        },
-        {
-            name: 'throw null',
-            test: async () => {
-                return {
-                    Ok: await testThrow(errorCanister.throwNull, 'null')
-                };
-            }
-        },
-        {
-            name: 'throw null reference',
-            test: async () => {
-                return {
-                    Ok: await testThrow(
-                        errorCanister.throwNullReference,
-                        "TypeError: cannot convert 'null' or 'undefined' to object"
-                    )
-                };
-            }
-        },
-        {
-            name: 'throw object',
-            test: async () => {
-                return {
-                    Ok: await testThrow(
-                        errorCanister.throwObject,
-                        '[object Object]'
-                    )
-                };
-            }
-        },
-        {
-            name: 'throw rational',
-            test: async () => {
-                return {
-                    Ok: await testThrow(errorCanister.throwRational, '3.14')
-                };
-            }
-        },
-        {
-            name: 'throw string',
-            test: async () => {
-                return {
-                    Ok: await testThrow(
-                        errorCanister.throwString,
-                        'Hello World'
-                    )
-                };
-            }
-        },
-        {
-            name: 'throw symbol',
-            test: async () => {
-                return {
-                    Ok: await testThrow(errorCanister.throwSymbol, 'Symbol()')
-                };
-            }
-        },
-        {
-            name: 'throw undefined',
-            test: async () => {
-                return {
-                    Ok: await testThrow(
-                        errorCanister.throwUndefined,
-                        'undefined'
-                    )
-                };
-            }
-        }
+        expectToThrow('big int', errorCanister.throwBigint, '3'),
+        expectToThrow('boolean', errorCanister.throwBoolean, 'false'),
+        expectToThrow(
+            'class',
+            errorCanister.throwClass,
+            'CustomClass toString'
+        ),
+        expectToThrow(
+            'custom error',
+            errorCanister.throwCustomError,
+            'Error: This is a custom error'
+        ),
+        expectToThrow('int', errorCanister.throwInt, '3'),
+        expectToThrow('null', errorCanister.throwNull, 'null'),
+        expectToThrow(
+            'null reference',
+            errorCanister.throwNullReference,
+            "TypeError: cannot convert 'null' or 'undefined' to object"
+        ),
+        expectToThrow('object', errorCanister.throwObject, '[object Object]'),
+        expectToThrow('rational', errorCanister.throwRational, '3.14'),
+        expectToThrow('string', errorCanister.throwString, 'Hello World'),
+        expectToThrow('symbol', errorCanister.throwSymbol, 'Symbol()'),
+        expectToThrow('undefined', errorCanister.throwUndefined, 'undefined')
     ];
+}
+
+/** Creates a test that asserts the provided method throws the provided value */
+function expectToThrow(
+    /** The name of the test */
+    name: string,
+    /** The method to call */
+    canisterMethod: () => Promise<void>,
+    /** The value we expect the method to throw */
+    expectedValue: any
+): Test {
+    return {
+        name: `throw ${name}`,
+        test: async () => {
+            return {
+                Ok: await testThrow(canisterMethod, expectedValue)
+            };
+        }
+    };
 }
 
 async function testThrow(

--- a/examples/run_time_errors/test/tests.ts
+++ b/examples/run_time_errors/test/tests.ts
@@ -4,39 +4,72 @@ import { _SERVICE } from './dfx_generated/run_time_errors/run_time_errors.did';
 
 export function getTests(errorCanister: ActorSubclass<_SERVICE>): Test[] {
     return [
-        expectToThrow('big int', errorCanister.throwBigint, '3'),
-        expectToThrow('boolean', errorCanister.throwBoolean, 'false'),
-        expectToThrow(
-            'class',
+        expectError('throw big int', errorCanister.throwBigint, '3'),
+        expectError('throw boolean', errorCanister.throwBoolean, 'false'),
+        expectError(
+            'throw class',
             errorCanister.throwClass,
             'CustomClass toString'
         ),
-        expectToThrow(
-            'custom error',
+        expectError(
+            'throw custom error',
             errorCanister.throwCustomError,
             'Error: This is a custom error'
         ),
-        expectToThrow('int', errorCanister.throwInt, '3'),
-        expectToThrow('null', errorCanister.throwNull, 'null'),
-        expectToThrow(
-            'null reference',
+        expectError('throw int', errorCanister.throwInt, '3'),
+        expectError('throw null', errorCanister.throwNull, 'null'),
+        expectError(
+            'throw null reference',
             errorCanister.throwNullReference,
             "TypeError: cannot convert 'null' or 'undefined' to object"
         ),
-        expectToThrow('object', errorCanister.throwObject, '[object Object]'),
-        expectToThrow('rational', errorCanister.throwRational, '3.14'),
-        expectToThrow('string', errorCanister.throwString, 'Hello World'),
-        expectToThrow('symbol', errorCanister.throwSymbol, 'Symbol()'),
-        expectToThrow('undefined', errorCanister.throwUndefined, 'undefined')
+        expectError(
+            'throw object',
+            errorCanister.throwObject,
+            '[object Object]'
+        ),
+        expectError('throw rational', errorCanister.throwRational, '3.14'),
+        expectError('throw string', errorCanister.throwString, 'Hello World'),
+        expectError('throw symbol', errorCanister.throwSymbol, 'Symbol()'),
+        expectError(
+            'throw undefined',
+            errorCanister.throwUndefined,
+            'undefined'
+        ),
+        expectError(
+            'return non object',
+            errorCanister.returnNonObject,
+            'TypeError: value is not an Opt'
+        ),
+        expectError(
+            'return object with both Some and None',
+            errorCanister.returnBothSomeAndNone,
+            'TypeError: value is not an Opt'
+        ),
+        expectError(
+            'return object with neither Some nor None',
+            errorCanister.returnObjectWithNeitherSomeNorNone,
+            'TypeError: value is not an Opt'
+        ),
+        expectError(
+            'return object with non null None value',
+            errorCanister.returnNonNullNone,
+            'TypeError: value is not null'
+        ),
+        expectError(
+            'return object with invalid Some value',
+            errorCanister.returnInvalidSomeValue,
+            'TypeError: JsValue is not a string'
+        )
     ];
 }
 
 /** Creates a test that asserts the provided method throws the provided value */
-function expectToThrow(
+function expectError(
     /** The name of the test */
     name: string,
     /** The method to call */
-    canisterMethod: () => Promise<void>,
+    canisterMethod: () => Promise<any>,
     /** The value we expect the method to throw */
     expectedValue: any
 ): Test {
@@ -57,7 +90,7 @@ async function testThrow(
     return checkErrorMessage(await getErrorMessage(errorFunc), expectedError);
 }
 
-async function getErrorMessage(errorFunc: () => Promise<void>): Promise<any> {
+async function getErrorMessage(errorFunc: () => Promise<any>): Promise<any> {
     try {
         await errorFunc();
     } catch (err) {

--- a/examples/simple_user_accounts/src/simple_user_accounts.ts
+++ b/examples/simple_user_accounts/src/simple_user_accounts.ts
@@ -17,9 +17,9 @@ let db: Db = {
 
 $query;
 export function getUserById(id: string): Opt<User> {
-    const user = db.users[id] ?? null;
+    const userOrUndefined = db.users[id];
 
-    return user;
+    return userOrUndefined ? Opt.Some(userOrUndefined) : Opt.None;
 }
 
 $query;

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/get.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/get.rs
@@ -40,16 +40,13 @@ fn generate_match_arms(
 
             quote! {
                 #memory_id => {
-                    match #map_name_ident.with(|stable_b_tree_map_ref_cell| {
+                    Ok(#map_name_ident.with(|stable_b_tree_map_ref_cell| {
                         stable_b_tree_map_ref_cell.borrow().get(
                             &#key_wrapper_type_name(
                                 key_js_value.try_from_vm_value(&mut *context).unwrap()
                             )
                         )
-                    }) {
-                        Some(value) => Ok(value.0.try_into_vm_value(&mut *context).unwrap()),
-                        None => Ok(().try_into_vm_value(&mut *context).unwrap())
-                    }
+                    }).try_into_vm_value(&mut *context).unwrap())
                 }
             }
         })

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/remove.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/remove.rs
@@ -42,10 +42,9 @@ fn generate_match_arms(
                 #memory_id => {
                     let key = #key_wrapper_type_name(key_js_value.try_from_vm_value(&mut *context).unwrap());
 
-                    match #map_name_ident.with(|stable_b_tree_map_ref_cell| stable_b_tree_map_ref_cell.borrow_mut().remove(&key)) {
-                        Some(value) => Ok(value.0.try_into_vm_value(&mut *context).unwrap()),
-                        None => Ok(().try_into_vm_value(&mut *context).unwrap())
-                    }
+                    Ok(#map_name_ident.with(|stable_b_tree_map_ref_cell| {
+                        stable_b_tree_map_ref_cell.borrow_mut().remove(&key)
+                    }).try_into_vm_value(&mut *context).unwrap())
                 }
             }
         })

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/query_and_update/shared/body.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/query_and_update/shared/body.rs
@@ -73,12 +73,12 @@ fn generate_return_expression(annotated_fn_decl: &AnnotatedFnDecl) -> proc_macro
         TsType::TsKeywordType(keyword) => match keyword.kind {
             TsNullKeyword => quote! {
                 if !final_return_value.is_null() {
-                    ic_cdk::api::trap("TypeError: value is not of type 'null'");
+                    ic_cdk::api::trap("Uncaught TypeError: value is not of type 'null'");
                 }
             },
             TsVoidKeyword => quote! {
                 if !final_return_value.is_undefined() {
-                    ic_cdk::api::trap("TypeError: value is not of type 'void'");
+                    ic_cdk::api::trap("Uncaught TypeError: value is not of type 'void'");
                 }
             },
             _ => quote! {},
@@ -90,7 +90,7 @@ fn generate_return_expression(annotated_fn_decl: &AnnotatedFnDecl) -> proc_macro
         #null_and_void_handler
         match final_return_value.try_from_vm_value(&mut *boa_context) {
             Ok(return_value) => return_value,
-            Err(e) => ic_cdk::api::trap(&format!("TypeError: {}",&e.0))
+            Err(e) => ic_cdk::api::trap(&format!("Uncaught TypeError: {}",&e.0))
         }
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/guard_function/rust.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/guard_function/rust.rs
@@ -12,7 +12,7 @@ pub fn generate(function_name: &String) -> TokenStream {
 
             match js_guard_fn_return_value.try_from_vm_value(&mut *boa_context) {
                 Ok(return_value) => return_value,
-                Err(e) => ic_cdk::api::trap(&format!("TypeError: {}",&e.0))
+                Err(e) => ic_cdk::api::trap(&format!("Uncaught TypeError: {}",&e.0))
             }
         })
     }

--- a/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_from_vm_value_impls/generic.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_from_vm_value_impls/generic.rs
@@ -23,17 +23,57 @@ pub fn generate() -> proc_macro2::TokenStream {
 
         impl<T> CdkActTryFromVmValue<Option<T>, &mut boa_engine::Context<'_>> for boa_engine::JsValue
         where
-            boa_engine::JsValue: for<'a, 'b> CdkActTryFromVmValue<T, &'a mut boa_engine::Context<'b>>
+            boa_engine::JsValue: for<'a, 'b> CdkActTryFromVmValue<T, &'a mut boa_engine::Context<'b>>,
         {
-            fn try_from_vm_value(self, context: &mut boa_engine::Context) -> Result<Option<T>, CdkActTryFromVmValueError> {
-                if self.is_null() {
-                    Ok(None)
-                }
-                else {
-                    match self.try_from_vm_value(context) {
-                        Ok(value) => Ok(Some(value)),
-                        Err(err) => Err(err)
+            fn try_from_vm_value(
+                self,
+                context: &mut boa_engine::Context,
+            ) -> Result<Option<T>, CdkActTryFromVmValueError> {
+                match self.as_object() {
+                    Some(js_object) => {
+                        let has_none_property = match js_object.has_own_property("None", context) {
+                            Ok(has_none_property) => has_none_property,
+                            Err(err) => return Err(CdkActTryFromVmValueError(err.to_string())),
+                        };
+                        let has_some_property = match js_object.has_own_property("Some", context) {
+                            Ok(has_some_property) => has_some_property,
+                            Err(err) => return Err(CdkActTryFromVmValueError(err.to_string())),
+                        };
+
+                        if has_none_property && has_some_property {
+                            Err(CdkActTryFromVmValueError(
+                                "TypeError: value is not an Opt".to_string(),
+                            ))
+                        } else if has_none_property {
+                            match js_object.get("None", context) {
+                                Ok(none_value) => {
+                                    if none_value.is_null() {
+                                        Ok(None)
+                                    } else {
+                                        Err(CdkActTryFromVmValueError(
+                                            "TypeError: value is not null".to_string(),
+                                        ))
+                                    }
+                                }
+                                Err(err) => Err(CdkActTryFromVmValueError(err.to_string())),
+                            }
+                        } else if has_some_property {
+                            match js_object.get("Some", context) {
+                                Ok(some_value) => match some_value.try_from_vm_value(context) {
+                                    Ok(value) => Ok(Some(value)),
+                                    Err(err) => Err(err),
+                                },
+                                Err(err) => Err(CdkActTryFromVmValueError(err.to_string())),
+                            }
+                        } else {
+                            Err(CdkActTryFromVmValueError(
+                                "TypeError: value is not an Opt".to_string(),
+                            ))
+                        }
                     }
+                    None => Err(CdkActTryFromVmValueError(
+                        "TypeError: value is not an Opt".to_string(),
+                    )),
                 }
             }
         }

--- a/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_from_vm_value_impls/generic.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_from_vm_value_impls/generic.rs
@@ -29,7 +29,7 @@ pub fn generate() -> proc_macro2::TokenStream {
                 self,
                 context: &mut boa_engine::Context,
             ) -> Result<Option<T>, CdkActTryFromVmValueError> {
-                let err_msg = "TypeError: value is not an Opt".to_string();
+                let err_msg = "value is not an Opt".to_string();
                 let not_an_opt_err = CdkActTryFromVmValueError(err_msg.clone());
 
                 let js_object = self
@@ -56,7 +56,7 @@ pub fn generate() -> proc_macro2::TokenStream {
                     if none_value.is_null() {
                         Ok(None)
                     } else {
-                        Err(not_an_opt_err)
+                        Err(CdkActTryFromVmValueError("value is not null".to_string()))
                     }
                 } else if has_some_property {
                     let some_value = js_object

--- a/src/lib/candid_types/index.ts
+++ b/src/lib/candid_types/index.ts
@@ -1,3 +1,5 @@
+import { Variant } from './variant';
+
 export { Principal } from '@dfinity/principal';
 export { Func } from './func';
 export { Service } from './service';
@@ -22,7 +24,11 @@ export type nat32 = number;
 export type nat16 = number;
 export type nat8 = number;
 
-export type Opt<T> = T | null;
+export type Opt<Value> = Variant<{
+    Some: Value;
+    None: null;
+}>;
+
 /**
  * Used to mark an object as a Candid record.
  */

--- a/src/lib/candid_types/index.ts
+++ b/src/lib/candid_types/index.ts
@@ -29,6 +29,13 @@ export type Opt<Value> = Variant<{
     None: null;
 }>;
 
+export const Opt = {
+    Some: <Value>(value: Value): Opt<Value> => ({
+        Some: value
+    }),
+    None: { None: null } as Opt<never>
+};
+
 /**
  * Used to mark an object as a Candid record.
  */

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -47,7 +47,7 @@ export {
 export { Oneway, Query, Update } from './candid_types/func';
 export { match } from './candid_types/variant';
 export { serviceQuery, serviceUpdate } from './candid_types/service';
-export { CallResult, FinalCallResult, GuardResult } from './results';
+export { CallResult, FinalCallResult, GuardResult, Result } from './results';
 export { StableBTreeMap } from './stable_b_tree_map';
 
 export type Manual<T> = void;

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -7,6 +7,15 @@ export type Result<Ok, Err> = Variant<{
     Err: Err;
 }>;
 
+export const Result = {
+    Ok: <Ok, Err>(value: Ok): Result<Ok, Err> => ({
+        Ok: value
+    }),
+    Err: <Ok, Err>(value: Err): Result<Ok, Err> => ({
+        Err: value
+    })
+};
+
 export type CallResult<T> = {
     call: () => Promise<FinalCallResult<T>>;
     notify: () => NotifyResult;


### PR DESCRIPTION
The syntax for Opt types hasn't changed. It's still `Opt<SomeTime>`. Creating opts has changed.

Opt values are now created using the Opt.Some and Opt.None helpers.

```ts
import {Opt} from "azle"

const someValue: Opt<string> = Opt.Some("some value");
const noneValue: Opt<string> = Opt.None
```

> **Note**
> The type annotations on `someValue` and `noneValue` aren't necessary, but rather for illustrative purposes