### PR TITLE
Patched name clashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 [[package]]
 name = "cdk_framework"
 version = "0.0.0"
-source = "git+https://github.com/demergent-labs/cdk_framework?rev=4993d8218acaa9102e4545fd9024e2008060d268#4993d8218acaa9102e4545fd9024e2008060d268"
+source = "git+https://github.com/demergent-labs/cdk_framework?rev=13c4abdd72bdcfa6a5b1ddf7f08a4fd83eacb419#13c4abdd72bdcfa6a5b1ddf7f08a4fd83eacb419"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/compiler/typescript_to_rust/azle_generate/Cargo.toml
+++ b/src/compiler/typescript_to_rust/azle_generate/Cargo.toml
@@ -12,5 +12,5 @@ swc_ecma_parser = "0.117.4"
 derive-syn-parse = "0.1.5"
 swc_ecma_ast = "0.90.10"
 annotate-snippets = "0.9.1"
-cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "4993d8218acaa9102e4545fd9024e2008060d268" }
+cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "13c4abdd72bdcfa6a5b1ddf7f08a4fd83eacb419" }
 # cdk_framework = { path = "/home/cdk_framework" }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/async_await_result_handler.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/async_await_result_handler.rs
@@ -10,7 +10,7 @@ use crate::ts_keywords;
 pub fn generate(methods: &Vec<QueryOrUpdateMethod>) -> TokenStream {
     let match_arms = generate_match_arms(methods);
     quote! {
-        fn _azle_async_await_result_handler(
+        fn async_await_result_handler(
             boa_context: &mut boa_engine::Context,
             boa_return_value: &boa_engine::JsValue,
             uuid: &str,
@@ -56,7 +56,7 @@ pub fn generate(methods: &Vec<QueryOrUpdateMethod>) -> TokenStream {
                         promise_map.remove(uuid);
                     });
 
-                    let error_message = _azle_js_value_to_string(js_value.clone(), boa_context);
+                    let error_message = js_value_to_string(js_value.clone(), boa_context);
 
                     ic_cdk::api::trap(&format!("Uncaught {}", error_message));
                 },

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/boa_error_handlers.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/boa_error_handlers.rs
@@ -3,21 +3,21 @@ use quote::quote;
 
 pub fn generate() -> TokenStream {
     quote! {
-        pub fn _azle_unwrap_boa_result(
+        pub fn unwrap_boa_result(
             boa_result: boa_engine::JsResult<boa_engine::JsValue>,
             context: &mut boa_engine::Context
         ) -> boa_engine::JsValue {
             match boa_result {
                 Ok(boa_return_value) => boa_return_value,
                 Err(boa_error) => {
-                    let error_message = _azle_js_value_to_string(boa_error.to_opaque(context), context);
+                    let error_message = js_value_to_string(boa_error.to_opaque(context), context);
 
                     ic_cdk::api::trap(&format!("Uncaught {}", error_message));
                 },
             }
         }
 
-        fn _azle_js_value_to_string(error_value: boa_engine::JsValue, context: &mut boa_engine::Context) -> String {
+        fn js_value_to_string(error_value: boa_engine::JsValue, context: &mut boa_engine::Context) -> String {
             match &error_value {
                 boa_engine::JsValue::BigInt(bigint) => bigint.to_string(),
                 boa_engine::JsValue::Boolean(boolean) => boolean.to_string(),

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/accept_message.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/accept_message.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_accept_message(
+        fn accept_message(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/arg_data_raw.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/arg_data_raw.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_arg_data_raw(
+        fn arg_data_raw(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/arg_data_raw_size.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/arg_data_raw_size.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_arg_data_raw_size(
+        fn arg_data_raw_size(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/async_call/promise_fulfillment.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/async_call/promise_fulfillment.rs
@@ -46,7 +46,7 @@ pub fn generate() -> proc_macro2::TokenStream {
                 main_promise.clone()
             });
 
-            _azle_async_await_result_handler(&mut *boa_context, &main_promise, &uuid, &method_name, manual);
+            async_await_result_handler(&mut *boa_context, &main_promise, &uuid, &method_name, manual);
         });
     }
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/call_raw.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/call_raw.rs
@@ -8,7 +8,7 @@ pub fn generate() -> proc_macro2::TokenStream {
     let promise_fulfillment = promise_fulfillment::generate();
 
     quote::quote! {
-        fn _azle_ic_call_raw(
+        fn call_raw(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/call_raw128.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/call_raw128.rs
@@ -8,7 +8,7 @@ pub fn generate() -> proc_macro2::TokenStream {
     let promise_fulfillment = promise_fulfillment::generate();
 
     quote::quote! {
-        fn _azle_ic_call_raw128(
+        fn call_raw128(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/caller.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/caller.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_caller(
+        fn caller(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/candid_decode.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/candid_decode.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_candid_decode(
+        fn candid_decode(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/candid_encode.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/candid_encode.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_candid_encode(
+        fn candid_encode(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/canister_balance.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/canister_balance.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_canister_balance(
+        fn canister_balance(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/canister_balance128.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/canister_balance128.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_canister_balance128(
+        fn canister_balance128(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/clear_timer.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/clear_timer.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_clear_timer(
+        fn clear_timer(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/data_certificate.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/data_certificate.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_data_certificate(
+        fn data_certificate(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/id.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/id.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_id(
+        fn id(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/method_name.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/method_name.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_method_name(
+        fn method_name(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             _context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_accept.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_accept.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_msg_cycles_accept(
+        fn msg_cycles_accept(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_accept128.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_accept128.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_msg_cycles_accept128(
+        fn msg_cycles_accept128(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_available.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_available.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_msg_cycles_available(
+        fn msg_cycles_available(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             _context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_available128.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_available128.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-            fn _azle_ic_msg_cycles_available128(
+            fn msg_cycles_available128(
                 _this: &boa_engine::JsValue,
                 _aargs: &[boa_engine::JsValue],
                 _context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_refunded.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_refunded.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_msg_cycles_refunded(
+        fn msg_cycles_refunded(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             _context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_refunded128.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/msg_cycles_refunded128.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_msg_cycles_refunded128(
+        fn msg_cycles_refunded128(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             _context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/notify_raw.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/notify_raw.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_notify_raw(
+        fn notify_raw(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/performance_counter.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/performance_counter.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_performance_counter(
+        fn performance_counter(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/print.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/print.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_print(
+        fn print(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             _context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reject.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reject.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_reject(
+        fn reject(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context,

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reject_code.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reject_code.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_reject_code(
+        fn reject_code(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context,

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reject_message.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reject_message.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_reject_message(
+        fn reject_message(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context,

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reply.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reply.rs
@@ -11,7 +11,7 @@ use crate::ts_keywords;
 pub fn generate(methods: &Vec<QueryOrUpdateMethod>) -> TokenStream {
     let match_arms = generate_match_arms(methods);
     quote! {
-        fn _azle_ic_reply(
+        fn reply(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reply_raw.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/reply_raw.rs
@@ -3,7 +3,7 @@ use quote::quote;
 
 pub fn generate() -> TokenStream {
     quote! {
-        fn _azle_ic_reply_raw(
+        fn reply_raw(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context,

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/call.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/call.rs
@@ -9,7 +9,7 @@ pub fn generate(
     post_await_state_management: &TokenStream,
     promise_fulfillment: &TokenStream,
 ) -> TokenStream {
-    let call_function_name_string = format!("_azle_call_{}_{}", service.name, method.name);
+    let call_function_name_string = format!("call_{}_{}", service.name, method.name);
     let call_function_name_ident = format_ident!("{}", call_function_name_string);
     let call_wrapper_fn_name = format_ident!("{}_wrapper", call_function_name_string);
     let param_variables = super::generate_param_variables(method, &service.name);

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/call_with_payment.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/call_with_payment.rs
@@ -10,7 +10,7 @@ pub fn generate(
     promise_fulfillment: &TokenStream,
 ) -> TokenStream {
     let call_with_payment_function_name_string =
-        format!("_azle_call_with_payment_{}_{}", service.name, method.name);
+        format!("call_with_payment_{}_{}", service.name, method.name);
     let call_with_payment_function_name_ident =
         format_ident!("{}", call_with_payment_function_name_string);
     let call_with_payment_wrapper_fn_name =

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/call_with_payment128.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/call_with_payment128.rs
@@ -9,10 +9,8 @@ pub fn generate(
     post_await_state_management: &TokenStream,
     promise_fulfillment: &TokenStream,
 ) -> TokenStream {
-    let call_with_payment128_function_name_string = format!(
-        "_azle_call_with_payment128_{}_{}",
-        service.name, method.name
-    );
+    let call_with_payment128_function_name_string =
+        format!("call_with_payment128_{}_{}", service.name, method.name);
     let call_with_payment128_function_name_ident =
         format_ident!("{}", call_with_payment128_function_name_string);
     let call_with_payment128_wrapper_fn_name =

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/notify.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/notify.rs
@@ -3,7 +3,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 pub fn generate(service: &Service, method: &Method) -> TokenStream {
-    let function_name_string = format!("_azle_notify_{}_{}", service.name, method.name);
+    let function_name_string = format!("notify_{}_{}", service.name, method.name);
     let real_function_name = format_ident!("{}", function_name_string);
     let wrapper_fn_name = format_ident!("{}_wrapper", function_name_string);
     let param_variables = super::generate_param_variables(method, &service.name);

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/notify_with_payment128.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/service/notify_with_payment128.rs
@@ -3,10 +3,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 pub fn generate(service: &Service, method: &Method) -> TokenStream {
-    let function_name_string = format!(
-        "_azle_notify_with_payment128_{}_{}",
-        service.name, method.name
-    );
+    let function_name_string = format!("notify_with_payment128_{}_{}", service.name, method.name);
     let real_function_name = format_ident!("{}", function_name_string);
     let wrapper_fn_name = format_ident!("{}_wrapper", function_name_string);
     let param_variables = super::generate_param_variables(method, &service.name);

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_certified_data.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_certified_data.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_set_certified_data(
+        fn set_certified_data(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_timer.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_timer.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_set_timer(
+        fn set_timer(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context
@@ -36,7 +36,7 @@ pub fn generate() -> proc_macro2::TokenStream {
                         *manual_mut = false;
                     });
 
-                    let boa_return_value = _azle_unwrap_boa_result(
+                    let boa_return_value = unwrap_boa_result(
                         func_js_object.call(
                             &boa_engine::JsValue::Null,
                             &[],
@@ -45,7 +45,7 @@ pub fn generate() -> proc_macro2::TokenStream {
                         &mut *boa_context
                     );
 
-                    _azle_async_await_result_handler(
+                    async_await_result_handler(
                         &mut boa_context,
                         &boa_return_value,
                         &uuid,

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_timer_interval.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/set_timer_interval.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_set_timer_interval(
+        fn set_timer_interval(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context
@@ -36,7 +36,7 @@ pub fn generate() -> proc_macro2::TokenStream {
                         *manual_mut = false;
                     });
 
-                    let boa_return_value = _azle_unwrap_boa_result(
+                    let boa_return_value = unwrap_boa_result(
                         func_js_object.call(
                             &boa_engine::JsValue::Null,
                             &[],
@@ -45,7 +45,7 @@ pub fn generate() -> proc_macro2::TokenStream {
                         &mut *boa_context
                     );
 
-                    _azle_async_await_result_handler(
+                    async_await_result_handler(
                         &mut boa_context,
                         &boa_return_value,
                         &uuid,

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_grow.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_grow.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_stable64_grow(
+        fn stable64_grow(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context,

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_read.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_read.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_stable64_read(
+        fn stable64_read(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context,

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_size.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_size.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_stable64_size(
+        fn stable64_size(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_write.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable64_write.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_stable64_write(
+        fn stable64_write(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context,

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/contains_key.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/contains_key.rs
@@ -6,7 +6,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     let match_arms = generate_match_arms(stable_b_tree_map_nodes);
 
     quote! {
-        fn _azle_ic_stable_b_tree_map_contains_key(
+        fn stable_b_tree_map_contains_key(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/get.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/get.rs
@@ -6,7 +6,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     let match_arms = generate_match_arms(stable_b_tree_map_nodes);
 
     quote::quote! {
-        fn _azle_ic_stable_b_tree_map_get(
+        fn stable_b_tree_map_get(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/insert.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/insert.rs
@@ -6,7 +6,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     let match_arms = generate_match_arms(stable_b_tree_map_nodes);
 
     quote::quote! {
-        fn _azle_ic_stable_b_tree_map_insert(
+        fn stable_b_tree_map_insert(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/is_empty.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/is_empty.rs
@@ -6,7 +6,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     let match_arms = generate_match_arms(stable_b_tree_map_nodes);
 
     quote! {
-        fn _azle_ic_stable_b_tree_map_is_empty(
+        fn stable_b_tree_map_is_empty(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/items.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/items.rs
@@ -6,7 +6,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     let match_arms = generate_match_arms(stable_b_tree_map_nodes);
 
     quote! {
-        fn _azle_ic_stable_b_tree_map_items(
+        fn stable_b_tree_map_items(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/keys.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/keys.rs
@@ -7,7 +7,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     let match_arms = generate_match_arms(stable_b_tree_map_nodes);
 
     quote! {
-        fn _azle_ic_stable_b_tree_map_keys(
+        fn stable_b_tree_map_keys(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/len.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/len.rs
@@ -6,7 +6,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     let match_arms = generate_match_arms(stable_b_tree_map_nodes);
 
     quote! {
-        fn _azle_ic_stable_b_tree_map_len(
+        fn stable_b_tree_map_len(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/remove.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/remove.rs
@@ -6,7 +6,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     let match_arms = generate_match_arms(stable_b_tree_map_nodes);
 
     quote! {
-        fn _azle_ic_stable_b_tree_map_remove(
+        fn stable_b_tree_map_remove(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/values.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_b_tree_map/values.rs
@@ -7,7 +7,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> proc_macro
     let match_arms = generate_match_arms(stable_b_tree_map_nodes);
 
     quote! {
-        fn _azle_ic_stable_b_tree_map_values(
+        fn stable_b_tree_map_values(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_bytes.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_bytes.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_stable_bytes(
+        fn stable_bytes(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context,

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_grow.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_grow.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_stable_grow(
+        fn stable_grow(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context,

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_read.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_read.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_stable_read(
+        fn stable_read(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context,

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_size.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_size.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_stable_size(
+        fn stable_size(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_write.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/stable_write.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_stable_write(
+        fn stable_write(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context,

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/time.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/time.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_time(
+        fn time(
             _this: &boa_engine::JsValue,
             _aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/trap.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/functions/trap.rs
@@ -1,6 +1,6 @@
 pub fn generate() -> proc_macro2::TokenStream {
     quote::quote! {
-        fn _azle_ic_trap(
+        fn trap(
             _this: &boa_engine::JsValue,
             aargs: &[boa_engine::JsValue],
             context: &mut boa_engine::Context

--- a/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/register_function.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/body/ic_object/register_function.rs
@@ -11,61 +11,61 @@ pub fn generate(ts_ast: &TsAst) -> TokenStream {
     let cross_canister_functions = generate_cross_canister_functions(&services);
 
     quote::quote! {
-        fn _azle_register_ic_object(boa_context: &mut boa_engine::Context) {
+        fn register_ic_object(boa_context: &mut boa_engine::Context) {
             let ic = boa_engine::object::ObjectInitializer::new(boa_context)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_accept_message), "acceptMessage", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_arg_data_raw), "argDataRaw", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_arg_data_raw_size), "argDataRawSize", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_call_raw), "callRaw", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_call_raw128), "callRaw128", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_caller), "caller", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_candid_decode), "candidDecode", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_candid_encode), "candidEncode", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_canister_balance), "canisterBalance", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_canister_balance128), "canisterBalance128", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_clear_timer), "clearTimer", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_data_certificate), "dataCertificate", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_id), "id", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_method_name), "methodName", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_msg_cycles_accept), "msgCyclesAccept", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_msg_cycles_accept128), "msgCyclesAccept128", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_msg_cycles_available), "msgCyclesAvailable", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_msg_cycles_available128), "msgCyclesAvailable128", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_msg_cycles_refunded), "msgCyclesRefunded", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_msg_cycles_refunded128), "msgCyclesRefunded128", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(accept_message), "acceptMessage", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(arg_data_raw), "argDataRaw", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(arg_data_raw_size), "argDataRawSize", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(call_raw), "callRaw", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(call_raw128), "callRaw128", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(caller), "caller", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(candid_decode), "candidDecode", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(candid_encode), "candidEncode", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(canister_balance), "canisterBalance", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(canister_balance128), "canisterBalance128", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(clear_timer), "clearTimer", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(data_certificate), "dataCertificate", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(id), "id", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(method_name), "methodName", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(msg_cycles_accept), "msgCyclesAccept", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(msg_cycles_accept128), "msgCyclesAccept128", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(msg_cycles_available), "msgCyclesAvailable", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(msg_cycles_available128), "msgCyclesAvailable128", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(msg_cycles_refunded), "msgCyclesRefunded", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(msg_cycles_refunded128), "msgCyclesRefunded128", 0)
                 #(#notify_functions)*
                 #(#cross_canister_functions)*
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_notify_raw), "notifyRaw", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_performance_counter), "performanceCounter", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_print), "print", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_reject), "reject", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_reject_code), "rejectCode", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_reject_message), "rejectMessage", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_reply), "reply", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_reply_raw), "replyRaw", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_set_certified_data), "setCertifiedData", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_set_timer), "setTimer", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_set_timer_interval), "setTimerInterval", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable_bytes), "stableBytes", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable_b_tree_map_contains_key), "stableBTreeMapContainsKey", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable_b_tree_map_get), "stableBTreeMapGet", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable_b_tree_map_insert), "stableBTreeMapInsert", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable_b_tree_map_is_empty), "stableBTreeMapIsEmpty", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable_b_tree_map_items), "stableBTreeMapItems", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable_b_tree_map_keys), "stableBTreeMapKeys", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable_b_tree_map_values), "stableBTreeMapValues", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable_b_tree_map_len), "stableBTreeMapLen", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable_b_tree_map_remove), "stableBTreeMapRemove", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable_grow), "stableGrow", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable_read), "stableRead", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable_size), "stableSize", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable_write), "stableWrite", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable64_grow), "stable64Grow", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable64_read), "stable64Read", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable64_size), "stable64Size", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_stable64_write), "stable64Write", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_time), "time", 0)
-                .function(boa_engine::NativeFunction::from_fn_ptr(_azle_ic_trap), "trap", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(notify_raw), "notifyRaw", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(performance_counter), "performanceCounter", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(print), "print", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(reject), "reject", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(reject_code), "rejectCode", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(reject_message), "rejectMessage", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(reply), "reply", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(reply_raw), "replyRaw", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(set_certified_data), "setCertifiedData", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(set_timer), "setTimer", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(set_timer_interval), "setTimerInterval", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable_bytes), "stableBytes", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable_b_tree_map_contains_key), "stableBTreeMapContainsKey", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable_b_tree_map_get), "stableBTreeMapGet", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable_b_tree_map_insert), "stableBTreeMapInsert", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable_b_tree_map_is_empty), "stableBTreeMapIsEmpty", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable_b_tree_map_items), "stableBTreeMapItems", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable_b_tree_map_keys), "stableBTreeMapKeys", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable_b_tree_map_values), "stableBTreeMapValues", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable_b_tree_map_len), "stableBTreeMapLen", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable_b_tree_map_remove), "stableBTreeMapRemove", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable_grow), "stableGrow", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable_read), "stableRead", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable_size), "stableSize", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable_write), "stableWrite", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable64_grow), "stable64Grow", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable64_read), "stable64Read", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable64_size), "stable64Size", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(stable64_write), "stable64Write", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(time), "time", 0)
+                .function(boa_engine::NativeFunction::from_fn_ptr(trap), "trap", 0)
                 .build();
 
             boa_context.register_global_property(
@@ -80,10 +80,10 @@ pub fn generate(ts_ast: &TsAst) -> TokenStream {
 fn generate_notify_functions(services: &Vec<Service>) -> Vec<TokenStream> {
     services.iter().map(|canister| {
         canister.methods.iter().map(|method| {
-            let notify_function_name_string = format!("_azle_notify_{}_{}", canister.name, method.name);
+            let notify_function_name_string = format!("notify_{}_{}", canister.name, method.name);
             let notify_wrapper_function_name = format_ident!("{}_wrapper", notify_function_name_string);
 
-            let notify_with_payment128_function_name_string = format!("_azle_notify_with_payment128_{}_{}", canister.name, method.name);
+            let notify_with_payment128_function_name_string = format!("notify_with_payment128_{}_{}", canister.name, method.name);
             let notify_with_payment128_wrapper_function_name = format_ident!("{}_wrapper", notify_with_payment128_function_name_string);
 
             quote! {
@@ -103,17 +103,17 @@ fn generate_cross_canister_functions(services: &Vec<Service>) -> Vec<TokenStream
                 .iter()
                 .map(|method| {
                     let call_function_name_string =
-                        format!("_azle_call_{}_{}", canister.name, method.name);
+                        format!("call_{}_{}", canister.name, method.name);
                     let call_wrapper_function_name =
                         format_ident!("{}_wrapper", call_function_name_string);
 
                     let call_with_payment_function_name_string =
-                        format!("_azle_call_with_payment_{}_{}", canister.name, method.name);
+                        format!("call_with_payment_{}_{}", canister.name, method.name);
                     let call_with_payment_wrapper_function_name =
                         format_ident!("{}_wrapper", call_with_payment_function_name_string);
 
                     let call_with_payment128_function_name_string =
-                        format!("_azle_call_with_payment128_{}_{}", canister.name, method.name);
+                        format!("call_with_payment128_{}_{}", canister.name, method.name);
                     let call_with_payment128_wrapper_function_name =
                         format_ident!("{}_wrapper", call_with_payment128_function_name_string);
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/candid_type/func/rust.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/candid_type/func/rust.rs
@@ -18,7 +18,7 @@ pub fn generate_list_into_vm_value_impl(function_name: String) -> TokenStream {
     quote! {
         impl CdkActTryIntoVmValue<&mut boa_engine::Context<'_>, boa_engine::JsValue> for Vec<#function_name> {
             fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
-                _azle_try_into_vm_value_generic_array(self, context)
+                try_into_vm_value_generic_array(self, context)
             }
         }
     }
@@ -41,7 +41,7 @@ pub fn generate_list_from_vm_value_impl(function_name: String) -> TokenStream {
     quote! {
         impl CdkActTryFromVmValue<Vec<#function_name>, &mut boa_engine::Context<'_>> for boa_engine::JsValue {
             fn try_from_vm_value(self, context: &mut boa_engine::Context) -> Result<Vec<#function_name>, CdkActTryFromVmValueError> {
-                _azle_try_from_vm_value_generic_array(self, context)
+                try_from_vm_value_generic_array(self, context)
             }
         }
     }

--- a/src/compiler/typescript_to_rust/azle_generate/src/candid_type/service/vm_value_conversions.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/candid_type/service/vm_value_conversions.rs
@@ -8,7 +8,7 @@ pub fn to_vm_value(name: String) -> TokenStream {
     quote! {
         impl CdkActTryIntoVmValue<&mut boa_engine::Context<'_>, boa_engine::JsValue> for #service_name {
             fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
-                Ok(_azle_unwrap_boa_result(context.eval_script(
+                Ok(unwrap_boa_result(context.eval_script(
                     boa_engine::Source::from_bytes(
                         &format!(
                             "new {}(Principal.fromText(\"{}\"))",
@@ -28,7 +28,7 @@ pub fn list_to_vm_value(name: String) -> TokenStream {
     quote! {
         impl CdkActTryIntoVmValue<&mut boa_engine::Context<'_>, boa_engine::JsValue> for Vec<#service_name> {
             fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
-                _azle_try_into_vm_value_generic_array(self, context)
+                try_into_vm_value_generic_array(self, context)
             }
         }
     }
@@ -41,11 +41,11 @@ pub fn from_vm_value(name: String) -> TokenStream {
         impl CdkActTryFromVmValue<#service_name, &mut boa_engine::Context<'_>> for boa_engine::JsValue {
             fn try_from_vm_value(self, context: &mut boa_engine::Context) -> Result<#service_name, CdkActTryFromVmValueError> {
                 let js_object = self.as_object().unwrap();
-                let canister_id_js_value = _azle_unwrap_boa_result(js_object.get("canisterId", context), context);
+                let canister_id_js_value = unwrap_boa_result(js_object.get("canisterId", context), context);
                 let canister_id_js_object = canister_id_js_value.as_object().unwrap();
-                let canister_id_to_string_js_value = _azle_unwrap_boa_result(canister_id_js_object.get("toText", context), context);
+                let canister_id_to_string_js_value = unwrap_boa_result(canister_id_js_object.get("toText", context), context);
                 let canister_id_to_string_js_object = canister_id_to_string_js_value.as_object().unwrap();
-                let canister_id_string_js_value = _azle_unwrap_boa_result(canister_id_to_string_js_object.call(
+                let canister_id_string_js_value = unwrap_boa_result(canister_id_to_string_js_object.call(
                     &canister_id_js_value,
                     &[],
                     context
@@ -65,7 +65,7 @@ pub fn list_from_vm_value(name: String) -> TokenStream {
     quote! {
         impl CdkActTryFromVmValue<Vec<#service_name>, &mut boa_engine::Context<'_>> for boa_engine::JsValue {
             fn try_from_vm_value(self, context: &mut boa_engine::Context) -> Result<Vec<#service_name>, CdkActTryFromVmValueError> {
-                _azle_try_from_vm_value_generic_array(self, context)
+                try_from_vm_value_generic_array(self, context)
             }
         }
     }

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/heartbeat/rust.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/heartbeat/rust.rs
@@ -31,7 +31,7 @@ pub fn generate(heartbeat_fn_decl: &AnnotatedFnDecl) -> proc_macro2::TokenStream
 
             #call_to_heartbeat_js_function
 
-            _azle_async_await_result_handler(
+            async_await_result_handler(
                 &mut boa_context,
                 &boa_return_value,
                 &uuid,

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/init/rust.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/init/rust.rs
@@ -18,9 +18,9 @@ pub fn generate(init_fn_decl_option: Option<&AnnotatedFnDecl>) -> proc_macro2::T
                 *method_name_mut = #function_name.to_string()
             });
 
-            _azle_register_ic_object(&mut boa_context);
+            register_ic_object(&mut boa_context);
 
-            _azle_unwrap_boa_result(boa_context.eval_script(boa_engine::Source::from_bytes(
+            unwrap_boa_result(boa_context.eval_script(boa_engine::Source::from_bytes(
                     &format!(
                         "let exports = {{}}; {compiled_js}",
                         compiled_js = MAIN_JS

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/post_upgrade/rust.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/post_upgrade/rust.rs
@@ -21,9 +21,9 @@ pub fn generate(post_upgrade_fn_decl_option: Option<&AnnotatedFnDecl>) -> TokenS
                 *method_name_mut = #function_name.to_string()
             });
 
-            _azle_register_ic_object(&mut boa_context);
+            register_ic_object(&mut boa_context);
 
-            _azle_unwrap_boa_result(boa_context.eval_script(boa_engine::Source::from_bytes(
+            unwrap_boa_result(boa_context.eval_script(boa_engine::Source::from_bytes(
                     &format!(
                         "let exports = {{}}; {compiled_js}",
                         compiled_js = MAIN_JS

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/query_and_update/shared/body.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/query_and_update/shared/body.rs
@@ -40,7 +40,7 @@ pub fn generate(fn_decl: &AnnotatedFnDecl) -> proc_macro2::TokenStream {
 
             #call_to_js_function
 
-            let final_return_value = _azle_async_await_result_handler(
+            let final_return_value = async_await_result_handler(
                 &mut boa_context,
                 &boa_return_value,
                 &uuid,

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/rust.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/rust.rs
@@ -22,13 +22,13 @@ pub fn generate_call_to_js_function(annotated_fn_decl: &AnnotatedFnDecl) -> Toke
         .collect();
 
     quote! {
-        let exports_js_value = _azle_unwrap_boa_result(boa_context.eval_script(boa_engine::Source::from_bytes("exports")), &mut boa_context);
+        let exports_js_value = unwrap_boa_result(boa_context.eval_script(boa_engine::Source::from_bytes("exports")), &mut boa_context);
         let exports_js_object = exports_js_value.as_object().unwrap();
 
         let function_js_value = exports_js_object.get(#function_name, &mut boa_context).unwrap();
         let function_js_object = function_js_value.as_object().unwrap();
 
-        let boa_return_value = _azle_unwrap_boa_result(
+        let boa_return_value = unwrap_boa_result(
             function_js_object.call(
                 &boa_engine::JsValue::Null,
                 &[

--- a/src/compiler/typescript_to_rust/azle_generate/src/guard_function/rust.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/guard_function/rust.rs
@@ -8,7 +8,7 @@ pub fn generate(function_name: &String) -> TokenStream {
             let mut boa_context = box_context_ref_cell.borrow_mut();
 
             let js_guard_fn_return_value =
-                _azle_unwrap_boa_result(boa_context.eval_script(boa_engine::Source::from_bytes(#function_call)), &mut boa_context);
+                unwrap_boa_result(boa_context.eval_script(boa_engine::Source::from_bytes(#function_call)), &mut boa_context);
 
             match js_guard_fn_return_value.try_from_vm_value(&mut *boa_context) {
                 Ok(return_value) => return_value,

--- a/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_from_vm_value_impls/vec.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_from_vm_value_impls/vec.rs
@@ -34,7 +34,7 @@ pub fn generate() -> proc_macro2::TokenStream {
             boa_engine::JsValue: for<'a, 'b> CdkActTryFromVmValue<T, &'a mut boa_engine::Context<'b>>
         {
             fn try_from_vm_value(self, context: &mut boa_engine::Context) -> Result<Vec<T>, CdkActTryFromVmValueError> {
-                _azle_try_from_vm_value_generic_array::<T>(self, context)
+                try_from_vm_value_generic_array::<T>(self, context)
             }
         }
 
@@ -62,7 +62,7 @@ pub fn generate() -> proc_macro2::TokenStream {
         }
 
         // TODO this seems like such a messy and inefficient way to do it
-        fn _azle_try_from_vm_value_generic_array<T>(js_value: boa_engine::JsValue, context: &mut boa_engine::Context) -> Result<Vec<T>, CdkActTryFromVmValueError>
+        fn try_from_vm_value_generic_array<T>(js_value: boa_engine::JsValue, context: &mut boa_engine::Context) -> Result<Vec<T>, CdkActTryFromVmValueError>
         where
             boa_engine::JsValue: for<'a, 'b> CdkActTryFromVmValue<T, &'a mut boa_engine::Context<'b>>
         {

--- a/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_into_vm_value_impls/basic.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_into_vm_value_impls/basic.rs
@@ -41,7 +41,7 @@ pub fn generate() -> proc_macro2::TokenStream {
 
         impl CdkActTryIntoVmValue<&mut boa_engine::Context<'_>, boa_engine::JsValue> for ic_cdk::export::Principal {
             fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
-                let exports_js_value = _azle_unwrap_boa_result(context.eval_script(boa_engine::Source::from_bytes("exports")), context);
+                let exports_js_value = unwrap_boa_result(context.eval_script(boa_engine::Source::from_bytes("exports")), context);
                 let exports_js_object = exports_js_value.as_object().unwrap();
 
                 let principal_class_js_value = exports_js_object.get("Principal", context).unwrap();
@@ -50,7 +50,7 @@ pub fn generate() -> proc_macro2::TokenStream {
                 let from_text_js_value = principal_class_js_object.get("fromText", context).unwrap();
                 let from_text_js_object = from_text_js_value.as_object().unwrap();
 
-                let principal_js_value = _azle_unwrap_boa_result(from_text_js_object.call(&principal_class_js_value, &[self.to_text().into()], context), context);
+                let principal_js_value = unwrap_boa_result(from_text_js_object.call(&principal_class_js_value, &[self.to_text().into()], context), context);
 
                 Ok(principal_js_value)
             }

--- a/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_into_vm_value_impls/vec.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_into_vm_value_impls/vec.rs
@@ -66,7 +66,7 @@ pub fn generate() -> proc_macro2::TokenStream {
             T: for<'a, 'b> CdkActTryIntoVmValue<&'a mut boa_engine::Context<'b>, boa_engine::JsValue>
         {
             fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
-                _azle_try_into_vm_value_generic_array(self, context)
+                try_into_vm_value_generic_array(self, context)
             }
         }
 
@@ -80,7 +80,7 @@ pub fn generate() -> proc_macro2::TokenStream {
             }
         }
 
-        fn _azle_try_into_vm_value_generic_array<T>(generic_array: Vec<T>, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError>
+        fn try_into_vm_value_generic_array<T>(generic_array: Vec<T>, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError>
         where
             T: for<'a, 'b> CdkActTryIntoVmValue<&'a mut boa_engine::Context<'b>, boa_engine::JsValue>
         {

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_enum.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_enum.rs
@@ -27,7 +27,7 @@ pub fn derive_try_from_vm_value_enum(
 
     quote! {
         impl #impl_generics CdkActTryFromVmValue<#enum_name #ty_generics, &mut boa_engine::Context<'_>> for boa_engine::JsValue #where_clause {
-            fn try_from_vm_value(self, _azle_context: &mut boa_engine::Context) -> Result<#enum_name #ty_generics, CdkActTryFromVmValueError> {
+            fn try_from_vm_value(self, context: &mut boa_engine::Context) -> Result<#enum_name #ty_generics, CdkActTryFromVmValueError> {
                 let object_option = self.as_object();
 
                 if let Some(object) = object_option {
@@ -42,7 +42,7 @@ pub fn derive_try_from_vm_value_enum(
         }
 
         impl #impl_generics CdkActTryFromVmValue<Vec<#enum_name #ty_generics>, &mut boa_engine::Context<'_>> for boa_engine::JsValue #where_clause {
-            fn try_from_vm_value(self, _azle_context: &mut boa_engine::Context) -> Result<Vec<#enum_name #ty_generics>, CdkActTryFromVmValueError> {
+            fn try_from_vm_value(self, context: &mut boa_engine::Context) -> Result<Vec<#enum_name #ty_generics>, CdkActTryFromVmValueError> {
                 match self.as_object() {
                     Some(js_object) => {
                         if js_object.is_array() {
@@ -52,13 +52,13 @@ pub fn derive_try_from_vm_value_enum(
                             let mut result = vec![];
 
                             while processing == true {
-                                match js_object.get(index, _azle_context) {
+                                match js_object.get(index, context) {
                                     Ok(js_value) => {
                                         if js_value.is_undefined() {
                                             processing = false;
                                         }
                                         else {
-                                            match js_value.try_from_vm_value(&mut *_azle_context) {
+                                            match js_value.try_from_vm_value(&mut *context) {
                                                 Ok(value) => {
                                                     result.push(value);
                                                     index += 1;
@@ -148,7 +148,7 @@ fn derive_property_for_named_fields(
         let variable_name = format_ident!("{}_js_value_result", field_name);
 
         quote! {
-            let #variable_name = #object_variant_js_value_var_name.as_object().unwrap().get(stringify!(#field_name), _azle_context);
+            let #variable_name = #object_variant_js_value_var_name.as_object().unwrap().get(stringify!(#field_name), context);
         }
     });
 
@@ -168,7 +168,7 @@ fn derive_property_for_named_fields(
         let named_field_js_value_variable_name = format_ident!("{}_js_value", field_name);
 
         quote! {
-            let #variable_name = #named_field_js_value_variable_name.try_from_vm_value(&mut *_azle_context);
+            let #variable_name = #named_field_js_value_variable_name.try_from_vm_value(&mut *context);
         }
     });
 
@@ -198,7 +198,7 @@ fn derive_property_for_named_fields(
     });
 
     quote! {
-        let #object_variant_js_value_result_var_name = object.get(stringify!(#variant_name), _azle_context);
+        let #object_variant_js_value_result_var_name = object.get(stringify!(#variant_name), context);
 
         if let Ok(#object_variant_js_value_var_name) = #object_variant_js_value_result_var_name {
             if #object_variant_js_value_var_name.is_undefined() == false {
@@ -237,7 +237,7 @@ fn derive_property_for_unnamed_fields(
 ) -> proc_macro2::TokenStream {
     if unnamed_fields.len() == 0 {
         quote! {
-            let #object_variant_js_value_result_var_name = object.get(stringify!(#variant_name), _azle_context);
+            let #object_variant_js_value_result_var_name = object.get(stringify!(#variant_name), context);
 
             if let Ok(#object_variant_js_value_var_name) = #object_variant_js_value_result_var_name {
                 if #object_variant_js_value_var_name.is_undefined() == false {
@@ -250,11 +250,11 @@ fn derive_property_for_unnamed_fields(
         let object_variant_var_name = format_ident!("object_{}", variant_name);
 
         quote! {
-            let #object_variant_js_value_result_var_name = object.get(stringify!(#variant_name), _azle_context);
+            let #object_variant_js_value_result_var_name = object.get(stringify!(#variant_name), context);
 
             if let Ok(#object_variant_js_value_var_name) = #object_variant_js_value_result_var_name {
                 if #object_variant_js_value_var_name.is_undefined() == false {
-                    let #object_variant_result_var_name = #object_variant_js_value_var_name.try_from_vm_value(&mut *_azle_context);
+                    let #object_variant_result_var_name = #object_variant_js_value_var_name.try_from_vm_value(&mut *context);
 
                     match #object_variant_result_var_name {
                         Ok(#object_variant_var_name) => {

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_struct.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_struct.rs
@@ -25,7 +25,7 @@ pub fn derive_try_from_vm_value_struct(
 
     quote! {
         impl #impl_generics CdkActTryFromVmValue<#struct_name #ty_generics, &mut boa_engine::Context<'_>> for boa_engine::JsValue #where_clause {
-            fn try_from_vm_value(self, _azle_context: &mut boa_engine::Context) -> Result<#struct_name #ty_generics, CdkActTryFromVmValueError> {
+            fn try_from_vm_value(self, context: &mut boa_engine::Context) -> Result<#struct_name #ty_generics, CdkActTryFromVmValueError> {
                 let object_option = self.as_object();
 
                 if let Some(object) = object_option {
@@ -57,7 +57,7 @@ pub fn derive_try_from_vm_value_struct(
 
         // TODO the body of this function is repeated in try_from_vm_value_trait.ts
         impl #impl_generics CdkActTryFromVmValue<Vec<#struct_name #ty_generics>, &mut boa_engine::Context<'_>> for boa_engine::JsValue #where_clause {
-            fn try_from_vm_value(self, _azle_context: &mut boa_engine::Context) -> Result<Vec<#struct_name #ty_generics>, CdkActTryFromVmValueError> {
+            fn try_from_vm_value(self, context: &mut boa_engine::Context) -> Result<Vec<#struct_name #ty_generics>, CdkActTryFromVmValueError> {
                 match self.as_object() {
                     Some(js_object) => {
                         if js_object.is_array() {
@@ -67,13 +67,13 @@ pub fn derive_try_from_vm_value_struct(
                             let mut result = vec![];
 
                             while processing == true {
-                                match js_object.get(index, _azle_context) {
+                                match js_object.get(index, context) {
                                     Ok(js_value) => {
                                         if js_value.is_undefined() {
                                             processing = false;
                                         }
                                         else {
-                                            match js_value.try_from_vm_value(&mut *_azle_context) {
+                                            match js_value.try_from_vm_value(&mut *context) {
                                                 Ok(value) => {
                                                     result.push(value);
                                                     index += 1;
@@ -165,7 +165,7 @@ fn derive_field_js_value_result_variable_definitions(
             let field_js_value_result_name = format_ident!("object_{}_js_value_result", field_name);
 
             quote! {
-                let #field_js_value_result_name = object.get(stringify!(#field_name), _azle_context);
+                let #field_js_value_result_name = object.get(stringify!(#field_name), context);
             }
         },
         |field_name, index| {
@@ -174,7 +174,7 @@ fn derive_field_js_value_result_variable_definitions(
             let syn_index = Index::from(index);
 
             quote! {
-                let #field_js_value_result_name = object.get(stringify!(#syn_index), _azle_context);
+                let #field_js_value_result_name = object.get(stringify!(#syn_index), context);
             }
         },
     )
@@ -210,7 +210,7 @@ fn derive_field_result_variable_definitions(
         let field_js_value_name = format_ident!("object_{}_js_value", field_name);
         let field_result_name = format_ident!("object_{}_result", field_name);
 
-        quote! { let #field_result_name = #field_js_value_name.try_from_vm_value(&mut *_azle_context); }
+        quote! { let #field_result_name = #field_js_value_name.try_from_vm_value(&mut *context); }
     })
 }
 

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_struct.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_struct.rs
@@ -15,10 +15,10 @@ pub fn derive_try_into_vm_value_struct(
 
     quote! {
         impl #impl_generics CdkActTryIntoVmValue<&mut boa_engine::Context<'_>, boa_engine::JsValue> for #struct_name #ty_generics #where_clause {
-            fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
+            fn try_into_vm_value(self, _azle_context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
                 #(#variable_definitions)*
 
-                let object = boa_engine::object::ObjectInitializer::new(context)
+                let object = boa_engine::object::ObjectInitializer::new(_azle_context)
                     #(#property_definitions)*
                     .build();
 
@@ -28,9 +28,9 @@ pub fn derive_try_into_vm_value_struct(
 
         // TODO the body of this function is repeated in azle_into_js_value_trait.ts
         impl #impl_generics CdkActTryIntoVmValue<&mut boa_engine::Context<'_>, boa_engine::JsValue> for Vec<#struct_name #ty_generics> #where_clause {
-            fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
-                let js_values = self.into_iter().map(|item| item.try_into_vm_value(context).unwrap()).collect::<Vec<boa_engine::JsValue>>();
-                Ok(boa_engine::object::builtins::JsArray::from_iter(js_values, context).into())
+            fn try_into_vm_value(self, _azle_context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
+                let js_values = self.into_iter().map(|item| item.try_into_vm_value(_azle_context).unwrap()).collect::<Vec<boa_engine::JsValue>>();
+                Ok(boa_engine::object::builtins::JsArray::from_iter(js_values, _azle_context).into())
             }
         }
     }
@@ -47,7 +47,7 @@ fn derive_struct_fields_variable_definitions(
                 let field_name = &field.ident;
 
                 quote! {
-                    let #field_name = self.#field_name.try_into_vm_value(context).unwrap();
+                    let #field_name = self.#field_name.try_into_vm_value(_azle_context).unwrap();
                 }
             })
             .collect(),
@@ -60,7 +60,7 @@ fn derive_struct_fields_variable_definitions(
                 let syn_index = Index::from(index);
 
                 quote! {
-                    let #field_name = self.#syn_index.try_into_vm_value(context).unwrap();
+                    let #field_name = self.#syn_index.try_into_vm_value(_azle_context).unwrap();
                 }
             })
             .collect(),

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_struct.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_struct.rs
@@ -15,10 +15,10 @@ pub fn derive_try_into_vm_value_struct(
 
     quote! {
         impl #impl_generics CdkActTryIntoVmValue<&mut boa_engine::Context<'_>, boa_engine::JsValue> for #struct_name #ty_generics #where_clause {
-            fn try_into_vm_value(self, _azle_context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
+            fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
                 #(#variable_definitions)*
 
-                let object = boa_engine::object::ObjectInitializer::new(_azle_context)
+                let object = boa_engine::object::ObjectInitializer::new(context)
                     #(#property_definitions)*
                     .build();
 
@@ -28,9 +28,9 @@ pub fn derive_try_into_vm_value_struct(
 
         // TODO the body of this function is repeated in azle_into_js_value_trait.ts
         impl #impl_generics CdkActTryIntoVmValue<&mut boa_engine::Context<'_>, boa_engine::JsValue> for Vec<#struct_name #ty_generics> #where_clause {
-            fn try_into_vm_value(self, _azle_context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
-                let js_values = self.into_iter().map(|item| item.try_into_vm_value(_azle_context).unwrap()).collect::<Vec<boa_engine::JsValue>>();
-                Ok(boa_engine::object::builtins::JsArray::from_iter(js_values, _azle_context).into())
+            fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
+                let js_values = self.into_iter().map(|item| item.try_into_vm_value(context).unwrap()).collect::<Vec<boa_engine::JsValue>>();
+                Ok(boa_engine::object::builtins::JsArray::from_iter(js_values, context).into())
             }
         }
     }
@@ -47,7 +47,7 @@ fn derive_struct_fields_variable_definitions(
                 let field_name = &field.ident;
 
                 quote! {
-                    let #field_name = self.#field_name.try_into_vm_value(_azle_context).unwrap();
+                    let #field_name = self.#field_name.try_into_vm_value(context).unwrap();
                 }
             })
             .collect(),
@@ -60,7 +60,7 @@ fn derive_struct_fields_variable_definitions(
                 let syn_index = Index::from(index);
 
                 quote! {
-                    let #field_name = self.#syn_index.try_into_vm_value(_azle_context).unwrap();
+                    let #field_name = self.#syn_index.try_into_vm_value(context).unwrap();
                 }
             })
             .collect(),

--- a/src/lib/candid_types/service.ts
+++ b/src/lib/candid_types/service.ts
@@ -71,25 +71,25 @@ function serviceMethodDecoration(target: any, name: string) {
                 return {
                     call: () => {
                         return (ic as any)[
-                            `_azle_call_${target.constructor.name}_${name}`
+                            `call_${target.constructor.name}_${name}`
                         ](this.canisterId, args);
                     },
                     notify: () => {
                         return (ic as any)[
-                            `_azle_notify_${target.constructor.name}_${name}`
+                            `notify_${target.constructor.name}_${name}`
                         ](this.canisterId, args);
                     },
                     cycles: (cycles: nat64) => {
                         return {
                             call: () => {
                                 return (ic as any)[
-                                    `_azle_call_with_payment_${target.constructor.name}_${name}`
+                                    `call_with_payment_${target.constructor.name}_${name}`
                                 ](this.canisterId, [...args, cycles]);
                             },
                             notify: () => {
                                 // There is no notifyWithPayment, there is only a notifyWithPayment128
                                 return (ic as any)[
-                                    `_azle_notify_with_payment128_${target.constructor.name}_${name}`
+                                    `notify_with_payment128_${target.constructor.name}_${name}`
                                 ](this.canisterId, args, cycles);
                             }
                         };
@@ -99,12 +99,12 @@ function serviceMethodDecoration(target: any, name: string) {
                             notify: () => {
                                 // There is no notifyWithPayment, there is only a notifyWithPayment128
                                 return (ic as any)[
-                                    `_azle_notify_with_payment128_${target.constructor.name}_${name}`
+                                    `notify_with_payment128_${target.constructor.name}_${name}`
                                 ](this.canisterId, args, cycles);
                             },
                             call: () => {
                                 return (ic as any)[
-                                    `_azle_call_with_payment128_${target.constructor.name}_${name}`
+                                    `call_with_payment128_${target.constructor.name}_${name}`
                                 ](this.canisterId, [...args, cycles]);
                             }
                         };


### PR DESCRIPTION
I forgot to remove all other `_azle_` prefixes once we prefixed user-defined functions.

Additionally this fixes an issue in the derive macro for structs where names could clash with internal names.

> **Warning**
> This shouldn't be merged until after #1008. It also depends on https://github.com/demergent-labs/cdk_framework/pull/70