### PR TITLE
Removed remaining `panic`, `unwrap` and `expect` statements

### DIFF
--- a/examples/run_time_errors/src/index.did
+++ b/examples/run_time_errors/src/index.did
@@ -18,6 +18,7 @@ service : () -> {
   alsoInaccessible : () -> (bool);
   getInitialized : () -> (bool) query;
   inaccessible : () -> (bool);
+  returnArrayWithInvalidUserDefinedRecord : () -> (vec UserDefinedRecord) query;
   returnArrayWithInvalidUserDefinedVariant : () -> (
       vec UserDefinedVariant,
     ) query;

--- a/examples/run_time_errors/src/index.did
+++ b/examples/run_time_errors/src/index.did
@@ -22,6 +22,7 @@ service : () -> {
   returnArrayWithInvalidUserDefinedVariant : () -> (
       vec UserDefinedVariant,
     ) query;
+  returnArrayWithInvalidVecItem : () -> (vec text) query;
   returnArrayWithOnlyPrincipalAsInvalidFunc : () -> (func () -> () query) query;
   returnBothSomeAndNone : () -> (opt text) query;
   returnEmptyArrayAsInvalidFunc : () -> (func () -> () query) query;

--- a/examples/run_time_errors/src/index.did
+++ b/examples/run_time_errors/src/index.did
@@ -1,14 +1,35 @@
+type OtherUserDefinedRecord = record { id : text };
+type UserDefinedRecord = record {
+  "int" : int;
+  string : text;
+  boolean : bool;
+  otherUserDefinedRecord : OtherUserDefinedRecord;
+};
+type UserDefinedVariant = variant {
+  Gamma : int;
+  Beta : bool;
+  Delta : text;
+  Epsilon : UserDefinedRecord;
+  Alpha;
+};
 service : () -> {
   accessible : () -> (bool);
   alsoInaccessible : () -> (bool);
   getInitialized : () -> (bool) query;
   inaccessible : () -> (bool);
+  returnArrayWithInvalidUserDefinedVariant : () -> (
+      vec UserDefinedVariant,
+    ) query;
   returnArrayWithOnlyPrincipalAsInvalidFunc : () -> (func () -> () query) query;
   returnBothSomeAndNone : () -> (opt text) query;
   returnEmptyArrayAsInvalidFunc : () -> (func () -> () query) query;
   returnEmptyObjectAsInvalidBlob : () -> (vec nat8) query;
   returnEmptyObjectAsInvalidFunc : () -> (func () -> () query) query;
   returnEmptyObjectAsInvalidPrincipal : () -> (principal) query;
+  returnEmptyObjectAsInvalidUserDefinedRecord : () -> (UserDefinedRecord) query;
+  returnEmptyObjectAsInvalidUserDefinedVariant : () -> (
+      UserDefinedVariant,
+    ) query;
   returnEmptyObjectPrincipalAsInvalidFunc : () -> (func () -> () query) query;
   returnInvalidBooleanValue : () -> (bool) query;
   returnInvalidEmptyValue : () -> (empty) query;
@@ -43,8 +64,28 @@ service : () -> {
   returnNonStringCanisterMethodNameAsInvalidFunc : () -> (
       func () -> () query,
     ) query;
+  returnObjectAsInvalidVecUserDefinedRecord : () -> (
+      vec UserDefinedRecord,
+    ) query;
+  returnObjectAsInvalidVecUserDefinedVariant : () -> (
+      vec UserDefinedVariant,
+    ) query;
+  returnObjectWithInvalidTagAsInvalidUserDefinedVariant : () -> (
+      UserDefinedVariant,
+    ) query;
+  returnObjectWithMultipleTagsAsInvalidUserDefinedVariant : () -> (
+      UserDefinedVariant,
+    ) query;
   returnObjectWithNeitherSomeNorNone : () -> (opt text) query;
   returnStringAsInvalidPrincipal : () -> (principal) query;
+  returnStringAsInvalidUserDefinedRecord : () -> (UserDefinedRecord) query;
+  returnStringAsInvalidUserDefinedVariant : () -> (UserDefinedVariant) query;
+  returnStringAsInvalidVecUserDefinedRecord : () -> (
+      vec UserDefinedRecord,
+    ) query;
+  returnStringAsInvalidVecUserDefinedVariant : () -> (
+      vec UserDefinedVariant,
+    ) query;
   throwBigint : () -> () query;
   throwBoolean : () -> () query;
   throwClass : () -> () query;

--- a/examples/run_time_errors/src/index.did
+++ b/examples/run_time_errors/src/index.did
@@ -8,6 +8,7 @@ type UserDefinedRecord = record {
 type UserDefinedVariant = variant {
   Gamma : int;
   Beta : bool;
+  Zeta : record { int; text };
   Delta : text;
   Epsilon : UserDefinedRecord;
   Alpha;
@@ -69,6 +70,9 @@ service : () -> {
     ) query;
   returnObjectAsInvalidVecUserDefinedVariant : () -> (
       vec UserDefinedVariant,
+    ) query;
+  returnObjectWithInvalidFieldsAsInvalidUserDefinedVariant : () -> (
+      UserDefinedVariant,
     ) query;
   returnObjectWithInvalidTagAsInvalidUserDefinedVariant : () -> (
       UserDefinedVariant,

--- a/examples/run_time_errors/src/index.ts
+++ b/examples/run_time_errors/src/index.ts
@@ -6,3 +6,5 @@ export * from './primitives';
 export * from './principals';
 export * from './throws';
 export * from './vecs';
+export * from './records';
+export * from './variants';

--- a/examples/run_time_errors/src/records.ts
+++ b/examples/run_time_errors/src/records.ts
@@ -1,0 +1,40 @@
+import { $query, Record, Vec, int } from 'azle';
+
+export type OtherUserDefinedRecord = Record<{
+    id: string;
+}>;
+
+export type UserDefinedRecord = Record<{
+    boolean: boolean;
+    int: int;
+    string: string;
+    otherUserDefinedRecord: OtherUserDefinedRecord;
+}>;
+
+// #region UserDefinedRecord
+$query;
+export function returnStringAsInvalidUserDefinedRecord(): UserDefinedRecord {
+    // @ts-ignore
+    return 'invalid type';
+}
+
+$query;
+export function returnEmptyObjectAsInvalidUserDefinedRecord(): UserDefinedRecord {
+    // @ts-ignore
+    return {};
+}
+// #endregion UserDefinedRecord
+
+// #region Vec<UserDefinedRecord>
+$query;
+export function returnStringAsInvalidVecUserDefinedRecord(): Vec<UserDefinedRecord> {
+    // @ts-ignore
+    return '';
+}
+
+$query;
+export function returnObjectAsInvalidVecUserDefinedRecord(): Vec<UserDefinedRecord> {
+    // @ts-ignore
+    return {};
+}
+// #endregion Vec<UserDefinedRecord>

--- a/examples/run_time_errors/src/records.ts
+++ b/examples/run_time_errors/src/records.ts
@@ -37,4 +37,10 @@ export function returnObjectAsInvalidVecUserDefinedRecord(): Vec<UserDefinedReco
     // @ts-ignore
     return {};
 }
+
+$query;
+export function returnArrayWithInvalidUserDefinedRecord(): Vec<UserDefinedRecord> {
+    // @ts-ignore
+    return ['invalid type'];
+}
 // #endregion Vec<UserDefinedRecord>

--- a/examples/run_time_errors/src/variants.ts
+++ b/examples/run_time_errors/src/variants.ts
@@ -1,0 +1,61 @@
+import { $query, Variant, Vec, int } from 'azle';
+import { UserDefinedRecord } from './records';
+
+export type UserDefinedVariant = Variant<{
+    Alpha: null;
+    Beta: boolean;
+    Gamma: int;
+    Delta: string;
+    Epsilon: UserDefinedRecord;
+}>;
+
+// #region UserDefinedVariant
+$query;
+export function returnStringAsInvalidUserDefinedVariant(): UserDefinedVariant {
+    // @ts-ignore
+    return 'invalid type';
+}
+
+$query;
+export function returnEmptyObjectAsInvalidUserDefinedVariant(): UserDefinedVariant {
+    // @ts-ignore
+    return {};
+}
+
+$query;
+export function returnObjectWithInvalidTagAsInvalidUserDefinedVariant(): UserDefinedVariant {
+    return {
+        // @ts-ignore
+        TotallyInvalid: undefined
+    };
+}
+
+$query;
+export function returnObjectWithMultipleTagsAsInvalidUserDefinedVariant(): UserDefinedVariant {
+    // @ts-ignore
+    return {
+        Alpha: null,
+        Beta: true
+    };
+}
+// #endregion UserDefinedVariant
+
+// #region Vec<UserDefinedVariant>
+$query;
+export function returnStringAsInvalidVecUserDefinedVariant(): Vec<UserDefinedVariant> {
+    // @ts-ignore
+    return '';
+}
+
+$query;
+export function returnObjectAsInvalidVecUserDefinedVariant(): Vec<UserDefinedVariant> {
+    // @ts-ignore
+    return {};
+}
+
+$query;
+export function returnArrayWithInvalidUserDefinedVariant(): Vec<UserDefinedVariant> {
+    // @ts-ignore
+    return ['invalid type'];
+}
+// #endregion Vec<UserDefinedVariant>

--- a/examples/run_time_errors/src/variants.ts
+++ b/examples/run_time_errors/src/variants.ts
@@ -53,7 +53,7 @@ export function returnObjectWithInvalidFieldsAsInvalidUserDefinedVariant(): User
 $query;
 export function returnStringAsInvalidVecUserDefinedVariant(): Vec<UserDefinedVariant> {
     // @ts-ignore
-    return '';
+    return 'invalid type';
 }
 
 $query;

--- a/examples/run_time_errors/src/variants.ts
+++ b/examples/run_time_errors/src/variants.ts
@@ -1,4 +1,4 @@
-import { $query, Variant, Vec, int } from 'azle';
+import { $query, Tuple, Variant, Vec, int } from 'azle';
 import { UserDefinedRecord } from './records';
 
 export type UserDefinedVariant = Variant<{
@@ -7,6 +7,7 @@ export type UserDefinedVariant = Variant<{
     Gamma: int;
     Delta: string;
     Epsilon: UserDefinedRecord;
+    Zeta: Tuple<[int, string]>;
 }>;
 
 // #region UserDefinedVariant
@@ -36,6 +37,14 @@ export function returnObjectWithMultipleTagsAsInvalidUserDefinedVariant(): UserD
     return {
         Alpha: null,
         Beta: true
+    };
+}
+
+$query;
+export function returnObjectWithInvalidFieldsAsInvalidUserDefinedVariant(): UserDefinedVariant {
+    return {
+        // @ts-ignore
+        Zeta: [true, true]
     };
 }
 // #endregion UserDefinedVariant

--- a/examples/run_time_errors/src/vecs.ts
+++ b/examples/run_time_errors/src/vecs.ts
@@ -11,3 +11,9 @@ export function returnNonArrayAsInvalidVec(): Vec<string> {
     // @ts-expect-error
     return {};
 }
+
+$query;
+export function returnArrayWithInvalidVecItem(): Vec<string> {
+    // @ts-expect-error
+    return [true];
+}

--- a/examples/run_time_errors/test/invalid_funcs.ts
+++ b/examples/run_time_errors/test/invalid_funcs.ts
@@ -19,9 +19,7 @@ const valueIsNotOfTypePrincipalErrorMessage = `[TypeError: Value is not of type 
   }
 }`;
 
-// TODO: We need a more robust error nesting. Notice how "[TypeError: value is
-// not of type 'Principal']" has square brackets and its inner error's
-// indentation is not correct.
+// TODO: Fix the formatting. See https://github.com/demergent-labs/azle/issues/1111
 const propertyToTextIsNotAFunctionErrorMessage = `[TypeError: Value is not of type 'Func'] {
   [cause]: TypeError: Index '0' is not of type 'Principal' {
     [cause]: [TypeError: Value is not of type 'Principal'] {

--- a/examples/run_time_errors/test/invalid_records.ts
+++ b/examples/run_time_errors/test/invalid_records.ts
@@ -1,0 +1,29 @@
+import { ActorSubclass } from '@dfinity/agent';
+import { Test } from 'azle/test';
+import { _SERVICE } from './dfx_generated/run_time_errors/run_time_errors.did';
+import { expectError } from './tests';
+
+const valueIsNotAnObjectErrorMessage = `[TypeError: Value is not of type 'UserDefinedRecord'] {
+  [cause]: TypeError: Value is not an object
+}`;
+
+const invalidPropertiesErrorMessage = `[TypeError: Value is not of type 'UserDefinedRecord'] {
+  [cause]: TypeError: One or more properties are of an incorrect type
+}`;
+
+export function getInvalidRecordTests(
+    errorCanister: ActorSubclass<_SERVICE>
+): Test[] {
+    return [
+        expectError(
+            'return string as invalid user-defined record',
+            errorCanister.returnStringAsInvalidUserDefinedRecord,
+            valueIsNotAnObjectErrorMessage
+        ),
+        expectError(
+            'return an empty object as an invalid user-defined record',
+            errorCanister.returnEmptyObjectAsInvalidUserDefinedRecord,
+            invalidPropertiesErrorMessage
+        )
+    ];
+}

--- a/examples/run_time_errors/test/invalid_records.ts
+++ b/examples/run_time_errors/test/invalid_records.ts
@@ -11,6 +11,13 @@ const invalidPropertiesErrorMessage = `[TypeError: Value is not of type 'UserDef
   [cause]: TypeError: One or more properties are of an incorrect type
 }`;
 
+// TODO: Fix the formatting. See https://github.com/demergent-labs/azle/issues/1111
+const vecInnerValueIsNotAUserDefinedRecordErrorMessage = `[TypeError: Value is not of type 'Vec'] {
+  [cause]: [TypeError: Value is not of type 'UserDefinedRecord'] {
+  [cause]: TypeError: Value is not an object
+}
+}`;
+
 export function getInvalidRecordTests(
     errorCanister: ActorSubclass<_SERVICE>
 ): Test[] {
@@ -24,6 +31,11 @@ export function getInvalidRecordTests(
             'return an empty object as an invalid user-defined record',
             errorCanister.returnEmptyObjectAsInvalidUserDefinedRecord,
             invalidPropertiesErrorMessage
+        ),
+        expectError(
+            'return an array with an invalid user-defined record',
+            errorCanister.returnArrayWithInvalidUserDefinedRecord,
+            vecInnerValueIsNotAUserDefinedRecordErrorMessage
         )
     ];
 }

--- a/examples/run_time_errors/test/invalid_variants.ts
+++ b/examples/run_time_errors/test/invalid_variants.ts
@@ -8,15 +8,19 @@ const valueIsNotAnObjectErrorMessage = `[TypeError: Value is not of type 'UserDe
 }`;
 
 const variantMustContainExactlyOnePropertyErrorMessage = `[TypeError: Value is not of type 'UserDefinedVariant'] {
-  [cause]: TypeError: Value must contain exactly one of the following properties: ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon']
+  [cause]: TypeError: Value must contain exactly one of the following properties: ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon', 'Zeta']
 }`;
 
-// TODO: The formatting on this should be better like the following comment.
-// const vecInnerValueIsNotAUserDefinedTypeErrorMessage = `[TypeError: Value is not of type 'Vec'] {
-//   [cause]: TypeError: Value is not of type 'UserDefinedVariant' {
-//     [cause]: TypeError: Value is not an object
-//   }
-// }`;
+// TODO: Fix the formatting. See https://github.com/demergent-labs/azle/issues/1111
+const fieldIsNotOfCorrectTypeErrorMessage = `[TypeError: Value is not of type 'UserDefinedVariant'] {
+  [cause]: TypeError: Property 'Zeta' is not of the correct type {
+    [cause]: [TypeError: Value is not of type '_InlineUserDefinedVariantZeta'] {
+  [cause]: TypeError: One or more properties are of an incorrect type
+}
+  }
+}`;
+
+// TODO: Fix the formatting. See https://github.com/demergent-labs/azle/issues/1111
 const vecInnerValueIsNotAUserDefinedTypeErrorMessage = `[TypeError: Value is not of type 'Vec'] {
   [cause]: [TypeError: Value is not of type 'UserDefinedVariant'] {
   [cause]: TypeError: Value is not an object
@@ -49,17 +53,22 @@ export function getInvalidVariantTests(
         //     variantMustContainExactlyOnePropertyErrorMessage
         // ),
         expectError(
-            'returnStringAsInvalidVecUserDefinedVariant',
+            'return a field with invalid types',
+            errorCanister.returnObjectWithInvalidFieldsAsInvalidUserDefinedVariant,
+            fieldIsNotOfCorrectTypeErrorMessage
+        ),
+        expectError(
+            'return a string as an invalid vec of user-defined variant',
             errorCanister.returnStringAsInvalidVecUserDefinedVariant,
             "TypeError: Value is not of type 'Vec'"
         ),
         expectError(
-            'returnObjectAsInvalidVecUserDefinedVariant',
+            'return an object as an invalid vec of user-defined variant',
             errorCanister.returnObjectAsInvalidVecUserDefinedVariant,
             "TypeError: Value is not of type 'Vec'"
         ),
         expectError(
-            'returnArrayWithInvalidUserDefinedVariant',
+            'return an array with an invalid user-defined variant',
             errorCanister.returnArrayWithInvalidUserDefinedVariant,
             vecInnerValueIsNotAUserDefinedTypeErrorMessage
         )

--- a/examples/run_time_errors/test/invalid_variants.ts
+++ b/examples/run_time_errors/test/invalid_variants.ts
@@ -1,0 +1,67 @@
+import { ActorSubclass } from '@dfinity/agent';
+import { Test } from 'azle/test';
+import { _SERVICE } from './dfx_generated/run_time_errors/run_time_errors.did';
+import { expectError } from './tests';
+
+const valueIsNotAnObjectErrorMessage = `[TypeError: Value is not of type 'UserDefinedVariant'] {
+  [cause]: TypeError: Value is not an object
+}`;
+
+const variantMustContainExactlyOnePropertyErrorMessage = `[TypeError: Value is not of type 'UserDefinedVariant'] {
+  [cause]: TypeError: Value must contain exactly one of the following properties: ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon']
+}`;
+
+// TODO: The formatting on this should be better like the following comment.
+// const vecInnerValueIsNotAUserDefinedTypeErrorMessage = `[TypeError: Value is not of type 'Vec'] {
+//   [cause]: TypeError: Value is not of type 'UserDefinedVariant' {
+//     [cause]: TypeError: Value is not an object
+//   }
+// }`;
+const vecInnerValueIsNotAUserDefinedTypeErrorMessage = `[TypeError: Value is not of type 'Vec'] {
+  [cause]: [TypeError: Value is not of type 'UserDefinedVariant'] {
+  [cause]: TypeError: Value is not an object
+}
+}`;
+
+export function getInvalidVariantTests(
+    errorCanister: ActorSubclass<_SERVICE>
+): Test[] {
+    return [
+        expectError(
+            'return string as invalid user-defined variant',
+            errorCanister.returnStringAsInvalidUserDefinedVariant,
+            valueIsNotAnObjectErrorMessage
+        ),
+        expectError(
+            'return an empty object as an invalid user-defined variant',
+            errorCanister.returnEmptyObjectAsInvalidUserDefinedVariant,
+            variantMustContainExactlyOnePropertyErrorMessage
+        ),
+        expectError(
+            'return an empty object as an invalid user-defined variant',
+            errorCanister.returnObjectWithInvalidTagAsInvalidUserDefinedVariant,
+            variantMustContainExactlyOnePropertyErrorMessage
+        ),
+        // TODO: We should return an error if multiple-tags are included in a type
+        // expectError(
+        //     'return an object with multiple tags as an invalid user-defined variant',
+        //     errorCanister.returnObjectWithMultipleTagsAsInvalidUserDefinedVariant,
+        //     variantMustContainExactlyOnePropertyErrorMessage
+        // ),
+        expectError(
+            'returnStringAsInvalidVecUserDefinedVariant',
+            errorCanister.returnStringAsInvalidVecUserDefinedVariant,
+            "TypeError: Value is not of type 'Vec'"
+        ),
+        expectError(
+            'returnObjectAsInvalidVecUserDefinedVariant',
+            errorCanister.returnObjectAsInvalidVecUserDefinedVariant,
+            "TypeError: Value is not of type 'Vec'"
+        ),
+        expectError(
+            'returnArrayWithInvalidUserDefinedVariant',
+            errorCanister.returnArrayWithInvalidUserDefinedVariant,
+            vecInnerValueIsNotAUserDefinedTypeErrorMessage
+        )
+    ];
+}

--- a/examples/run_time_errors/test/invalid_vecs.ts
+++ b/examples/run_time_errors/test/invalid_vecs.ts
@@ -3,6 +3,10 @@ import { Test } from 'azle/test';
 import { _SERVICE } from './dfx_generated/run_time_errors/run_time_errors.did';
 import { expectError } from './tests';
 
+const invalidVecMemberErrorMessage = `[TypeError: Value is not of type 'Vec'] {
+  [cause]: TypeError: Value is not of type 'string'
+}`;
+
 export function getInvalidVecTests(
     errorCanister: ActorSubclass<_SERVICE>
 ): Test[] {
@@ -16,9 +20,11 @@ export function getInvalidVecTests(
             'return an empty object as invalid Vec',
             errorCanister.returnNonArrayAsInvalidVec,
             "TypeError: Value is not of type 'Vec'"
+        ),
+        expectError(
+            'return an empty object as invalid Vec',
+            errorCanister.returnArrayWithInvalidVecItem,
+            invalidVecMemberErrorMessage
         )
-        // TODO: Add test here for returning a vec with an invalid item
-        // I believe it only says the error of the inner item, not that
-        // it's not of type 'Vec'
     ];
 }

--- a/examples/run_time_errors/test/invalid_vecs.ts
+++ b/examples/run_time_errors/test/invalid_vecs.ts
@@ -17,5 +17,8 @@ export function getInvalidVecTests(
             errorCanister.returnNonArrayAsInvalidVec,
             "TypeError: Value is not of type 'Vec'"
         )
+        // TODO: Add test here for returning a vec with an invalid item
+        // I believe it only says the error of the inner item, not that
+        // it's not of type 'Vec'
     ];
 }

--- a/examples/run_time_errors/test/tests.ts
+++ b/examples/run_time_errors/test/tests.ts
@@ -10,6 +10,8 @@ import { getInvalidFuncTests } from './invalid_funcs';
 import { getInvalidPrincipalTests } from './invalid_principals';
 import { getInvalidBlobTests } from './invalid_blobs';
 import { getInvalidVecTests } from './invalid_vecs';
+import { getInvalidRecordTests } from './invalid_records';
+import { getInvalidVariantTests } from './invalid_variants';
 
 export function getTests(errorCanister: ActorSubclass<_SERVICE>): Test[] {
     return [
@@ -20,7 +22,9 @@ export function getTests(errorCanister: ActorSubclass<_SERVICE>): Test[] {
         ...getInvalidFuncTests(errorCanister),
         ...getInvalidPrincipalTests(errorCanister),
         ...getInvalidBlobTests(errorCanister),
-        ...getInvalidVecTests(errorCanister)
+        ...getInvalidVecTests(errorCanister),
+        ...getInvalidRecordTests(errorCanister),
+        ...getInvalidVariantTests(errorCanister)
     ];
 }
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_from_vm_value_impls/vec.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/vm_value_conversion/try_from_vm_value_impls/vec.rs
@@ -91,15 +91,23 @@ pub fn generate() -> proc_macro2::TokenStream {
             let mut result = vec![];
 
             loop {
-                let js_value = js_object
-                    .get(index, context)
-                    .map_err(|err| err.to_string())?;
+                let js_value = js_object.get(index, context).map_err(|err| {
+                    format!(
+                        "[TypeError: Value is not of type 'Vec'] {{\n  [cause]: {}\n}}",
+                        err.to_string()
+                    )
+                })?;
 
                 if js_value.is_undefined() {
                     break;
                 }
 
-                result.push(js_value.try_from_vm_value(context)?);
+                result.push(js_value.try_from_vm_value(context).map_err(|err| {
+                    format!(
+                        "[TypeError: Value is not of type 'Vec'] {{\n  [cause]: {}\n}}",
+                        err.0
+                    )
+                })?);
                 index += 1;
             }
 

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_enum.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_enum.rs
@@ -23,7 +23,7 @@ impl TryGetEnumVariantFieldIdent for Field {
                 Span::call_site(),
                 format!(
                     "Internal Error: expected field {field_index} in \
-                    {enum_name}::{variant_name} to have a name but received None"
+                        {enum_name}::{variant_name} to have a name but received None"
                 ),
             )
         })
@@ -39,7 +39,8 @@ pub fn derive_try_from_vm_value_enum(
 
     let value_is_not_an_object_error_message = format!(
         "[TypeError: Value is not of type '{}'] {{\n  \
-            [cause]: TypeError: Value is not an object\n}}",
+            [cause]: TypeError: Value is not an object\n\
+        }}",
         &enum_name_string
     );
 
@@ -51,13 +52,13 @@ pub fn derive_try_from_vm_value_enum(
 
     let variant_names_vec_string = format!("[{}]", variant_names.join(", "));
 
-    let missing_valid_variant_error_message =
-        format!(
-            "[TypeError: Value is not of type '{}'] {{\n  \
-                [cause]: TypeError: Value must contain exactly one of the following properties: {}\n}}",
-            &enum_name_string,
-            variant_names_vec_string,
-        );
+    let missing_valid_variant_error_message = format!(
+        "[TypeError: Value is not of type '{}'] {{\n  \
+            [cause]: TypeError: Value must contain exactly one of the following properties: \
+                {}\n\
+        }}",
+        &enum_name_string, variant_names_vec_string,
+    );
 
     let properties = derive_properties(enum_name, data_enum)?;
 
@@ -322,7 +323,11 @@ fn derive_property_for_unnamed_fields(
     let variant_name_string = variant_name.to_string();
 
     let todo_rename_this_error_message = format!(
-        "[TypeError: Value is not of type '{}'] {{{{\n  [cause]: TypeError: Property '{{}}' is not of the correct type {{{{\n    [cause]: {{}}\n  }}}}\n}}}}",
+        "[TypeError: Value is not of type '{}'] {{{{\n  \
+            [cause]: TypeError: Property '{{}}' is not of the correct type {{{{\n    \
+                [cause]: {{}}\n  \
+            }}}}\n\
+        }}}}",
         &enum_name_string
     );
 

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_enum.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_enum.rs
@@ -37,30 +37,8 @@ pub fn derive_try_from_vm_value_enum(
     data_enum: &DataEnum,
     generics: &Generics,
 ) -> Result<TokenStream, Error> {
-    let enum_name_string = enum_name.to_string();
-
-    let value_is_not_an_object_error_message = format!(
-        "[TypeError: Value is not of type '{}'] {{\n  \
-            [cause]: TypeError: Value is not an object\n\
-        }}",
-        &enum_name_string
-    );
-
-    let variant_names = data_enum
-        .variants
-        .iter()
-        .map(|variant| format!("'{}'", variant.ident))
-        .collect::<Vec<_>>();
-
-    let variant_names_vec_string = format!("[{}]", variant_names.join(", "));
-
-    let missing_valid_variant_error_message = format!(
-        "[TypeError: Value is not of type '{}'] {{\n  \
-            [cause]: TypeError: Value must contain exactly one of the following properties: \
-                {}\n\
-        }}",
-        &enum_name_string, variant_names_vec_string,
-    );
+    let (value_is_not_an_object_error_message, missing_valid_variant_error_message) =
+        derive_error_messages(enum_name, data_enum);
 
     let properties = derive_properties(enum_name, data_enum)?;
 
@@ -94,6 +72,38 @@ pub fn derive_try_from_vm_value_enum(
 
         #try_from_vm_value_vec_impl
     })
+}
+
+fn derive_error_messages(enum_name: &Ident, data_enum: &DataEnum) -> (String, String) {
+    let enum_name_string = enum_name.to_string();
+
+    let value_is_not_an_object_error_message = format!(
+        "[TypeError: Value is not of type '{}'] {{\n  \
+            [cause]: TypeError: Value is not an object\n\
+        }}",
+        &enum_name_string
+    );
+
+    let variant_names = data_enum
+        .variants
+        .iter()
+        .map(|variant| format!("'{}'", variant.ident))
+        .collect::<Vec<_>>();
+
+    let variant_names_vec_string = format!("[{}]", variant_names.join(", "));
+
+    let missing_valid_variant_error_message = format!(
+        "[TypeError: Value is not of type '{}'] {{\n  \
+            [cause]: TypeError: Value must contain exactly one of the following properties: \
+                {}\n\
+        }}",
+        &enum_name_string, variant_names_vec_string,
+    );
+
+    (
+        value_is_not_an_object_error_message,
+        missing_valid_variant_error_message,
+    )
 }
 
 fn derive_properties(enum_name: &Ident, data_enum: &DataEnum) -> Result<Vec<TokenStream>, Error> {

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_enum.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_enum.rs
@@ -2,6 +2,8 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::{DataEnum, Error, Field, Fields, Generics};
 
+use crate::derive_try_from_vm_value::derive_try_from_vm_value_vec::derive_try_from_vm_value_vec;
+
 trait TryGetEnumVariantFieldIdent {
     fn try_get_ident(
         &self,
@@ -64,6 +66,8 @@ pub fn derive_try_from_vm_value_enum(
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let try_from_vm_value_vec_impl = derive_try_from_vm_value_vec(enum_name, generics);
+
     Ok(quote! {
         impl #impl_generics CdkActTryFromVmValue<
             #enum_name #ty_generics,
@@ -88,57 +92,7 @@ pub fn derive_try_from_vm_value_enum(
             }
         }
 
-        // TODO: The implementation for this is the same as for Records and
-        // any other vec as seen in vm_value_conversion/try_from.../vec.rs
-        // We should pull all this code together
-        impl #impl_generics CdkActTryFromVmValue<
-            Vec<#enum_name #ty_generics>,
-            &mut boa_engine::Context<'_>
-        >
-            for boa_engine::JsValue
-            #where_clause
-        {
-            fn try_from_vm_value(
-                self,
-                context: &mut boa_engine::Context
-            ) -> Result<Vec<#enum_name #ty_generics>, CdkActTryFromVmValueError> {
-                let js_object = self
-                    .as_object()
-                    .ok_or_else(|| "TypeError: Value is not of type 'Vec'")?;
-
-                if !js_object.is_array() {
-                    return Err(CdkActTryFromVmValueError(
-                        "TypeError: Value is not of type 'Vec'".to_string(),
-                    ));
-                }
-
-
-                let mut index: usize = 0;
-                let mut result = vec![];
-
-                loop {
-                    let js_value = js_object
-                        .get(index, context)
-                        .map_err(|err| err.to_string())?;
-
-                    if js_value.is_undefined() {
-                        break;
-                    }
-
-                    result.push(js_value
-                        .try_from_vm_value(&mut *context)
-                        .map_err(|variant_err| {
-                            format!(
-                                "[TypeError: Value is not of type 'Vec'] {{\n  [cause]: {}\n}}",
-                                variant_err.0
-                            )
-                        })?);
-                    index += 1;
-                }
-
-                Ok(result)
-            }
-        }
+        #try_from_vm_value_vec_impl
     })
 }
 

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_struct.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_struct.rs
@@ -11,11 +11,17 @@ pub fn derive_try_from_vm_value_struct(
     let value_is_not_of_struct_type_error_message =
         format!("TypeError: Value is not of type '{}'", &struct_name_string);
 
-    let value_is_not_an_object_error_message =
-        format!("[TypeError: Value is not of type '{}'] {{\n  [cause]: TypeError: Value is not an object\n}}", &struct_name_string);
+    let value_is_not_an_object_error_message = format!(
+        "[TypeError: Value is not of type '{}'] {{\n  \
+            [cause]: TypeError: Value is not an object\n}}",
+        &struct_name_string
+    );
 
-    let value_is_missing_properties_error_message =
-        format!("[TypeError: Value is not of type '{}'] {{\n  [cause]: TypeError: One or more properties are of an incorrect type\n}}", &struct_name_string);
+    let value_is_missing_properties_error_message = format!(
+        "[TypeError: Value is not of type '{}'] {{\n  \
+            [cause]: TypeError: One or more properties are of an incorrect type\n}}",
+        &struct_name_string
+    );
 
     let field_js_value_result_variable_definitions =
         derive_field_js_value_result_variable_definitions(struct_name, data_struct);
@@ -34,8 +40,17 @@ pub fn derive_try_from_vm_value_struct(
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     quote! {
-        impl #impl_generics CdkActTryFromVmValue<#struct_name #ty_generics, &mut boa_engine::Context<'_>> for boa_engine::JsValue #where_clause {
-            fn try_from_vm_value(self, context: &mut boa_engine::Context) -> Result<#struct_name #ty_generics, CdkActTryFromVmValueError> {
+        impl #impl_generics CdkActTryFromVmValue<
+            #struct_name #ty_generics,
+            &mut boa_engine::Context<'_>
+        >
+            for boa_engine::JsValue
+            #where_clause
+        {
+            fn try_from_vm_value(
+                self,
+                context: &mut boa_engine::Context
+            ) -> Result<#struct_name #ty_generics, CdkActTryFromVmValueError> {
                 let object = self
                     .as_object()
                     .ok_or_else(|| #value_is_not_an_object_error_message.to_string())?;
@@ -67,8 +82,17 @@ pub fn derive_try_from_vm_value_struct(
         }
 
         // TODO the body of this function is repeated in try_from_vm_value_trait.ts
-        impl #impl_generics CdkActTryFromVmValue<Vec<#struct_name #ty_generics>, &mut boa_engine::Context<'_>> for boa_engine::JsValue #where_clause {
-            fn try_from_vm_value(self, context: &mut boa_engine::Context) -> Result<Vec<#struct_name #ty_generics>, CdkActTryFromVmValueError> {
+        impl #impl_generics CdkActTryFromVmValue<
+            Vec<#struct_name #ty_generics>,
+            &mut boa_engine::Context<'_>
+        >
+            for boa_engine::JsValue
+            #where_clause
+        {
+            fn try_from_vm_value(
+                self,
+                context: &mut boa_engine::Context
+            ) -> Result<Vec<#struct_name #ty_generics>, CdkActTryFromVmValueError> {
                 match self.as_object() {
                     Some(js_object) => {
                         if js_object.is_array() {
@@ -96,7 +120,10 @@ pub fn derive_try_from_vm_value_struct(
                                         }
                                     },
                                     Err(_) => {
-                                        return Err(CdkActTryFromVmValueError(format!("RangeError: Item at array index {} does not exist", index)))
+                                        return Err(CdkActTryFromVmValueError(format!(
+                                            "RangeError: Item at array index {} does not exist",
+                                            index
+                                        )))
                                     }
                                 }
                             }
@@ -104,10 +131,14 @@ pub fn derive_try_from_vm_value_struct(
                             Ok(result)
                         }
                         else {
-                            Err(CdkActTryFromVmValueError("TypeError: Value is not of type 'Vec'".to_string()))
+                            Err(CdkActTryFromVmValueError(
+                                "TypeError: Value is not of type 'Vec'".to_string()
+                            ))
                         }
                     },
-                    None => Err(CdkActTryFromVmValueError("TypeError: Value is not of type 'Vec'".to_string()))
+                    None => Err(CdkActTryFromVmValueError(
+                        "TypeError: Value is not of type 'Vec'".to_string()
+                    ))
                 }
             }
         }

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_struct.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_struct.rs
@@ -2,7 +2,9 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::{DataStruct, Error, Fields, Generics, Index};
 
-use crate::derive_try_from_vm_value::derive_try_from_vm_value_vec;
+use crate::{
+    derive_try_from_vm_value::derive_try_from_vm_value_vec, traits::TryGetStructFieldIdent,
+};
 
 pub fn generate(
     struct_name: &Ident,
@@ -145,15 +147,7 @@ where
             .iter()
             .enumerate()
             .map(|(index, field)| {
-                let field_name = field.ident.as_ref().ok_or_else(|| {
-                    Error::new(
-                        Span::call_site(),
-                        format!(
-                            "Internal Error: expected field {index} in \
-                                {struct_name} to have a name but received None"
-                        ),
-                    )
-                })?;
+                let field_name = field.try_get_ident(struct_name, index)?;
 
                 Ok(named_field_closure(field_name))
             })

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_struct.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_struct.rs
@@ -9,23 +9,11 @@ pub fn derive_try_from_vm_value_struct(
     data_struct: &DataStruct,
     generics: &Generics,
 ) -> proc_macro2::TokenStream {
-    let struct_name_string = struct_name.to_string();
-    let value_is_not_of_struct_type_error_message =
-        format!("TypeError: Value is not of type '{}'", &struct_name_string);
-
-    let value_is_not_an_object_error_message = format!(
-        "[TypeError: Value is not of type '{}'] {{\n  \
-            [cause]: TypeError: Value is not an object\n\
-        }}",
-        &struct_name_string
-    );
-
-    let value_is_missing_properties_error_message = format!(
-        "[TypeError: Value is not of type '{}'] {{\n  \
-            [cause]: TypeError: One or more properties are of an incorrect type\n\
-        }}",
-        &struct_name_string
-    );
+    let (
+        value_is_not_of_struct_type_error_message,
+        value_is_not_an_object_error_message,
+        value_is_missing_properties_error_message,
+    ) = derive_error_messages(struct_name);
 
     let field_js_value_result_variable_definitions =
         derive_field_js_value_result_variable_definitions(struct_name, data_struct);
@@ -89,6 +77,33 @@ pub fn derive_try_from_vm_value_struct(
 
         #try_from_vm_value_vec_impl
     }
+}
+
+fn derive_error_messages(struct_name: &Ident) -> (String, String, String) {
+    let struct_name_string = struct_name.to_string();
+
+    let value_is_not_of_struct_type_error_message =
+        format!("TypeError: Value is not of type '{}'", &struct_name_string);
+
+    let value_is_not_an_object_error_message = format!(
+        "[TypeError: Value is not of type '{}'] {{\n  \
+            [cause]: TypeError: Value is not an object\n\
+        }}",
+        &struct_name_string
+    );
+
+    let value_is_missing_properties_error_message = format!(
+        "[TypeError: Value is not of type '{}'] {{\n  \
+            [cause]: TypeError: One or more properties are of an incorrect type\n\
+        }}",
+        &struct_name_string
+    );
+
+    (
+        value_is_not_of_struct_type_error_message,
+        value_is_not_an_object_error_message,
+        value_is_missing_properties_error_message,
+    )
 }
 
 fn uniformly_map_fields<F>(

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_struct.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_struct.rs
@@ -2,9 +2,9 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::{DataStruct, Error, Fields, Generics, Index};
 
-use crate::derive_try_from_vm_value::derive_try_from_vm_value_vec::derive_try_from_vm_value_vec;
+use crate::derive_try_from_vm_value::derive_try_from_vm_value_vec;
 
-pub fn derive_try_from_vm_value_struct(
+pub fn generate(
     struct_name: &Ident,
     data_struct: &DataStruct,
     generics: &Generics,
@@ -15,7 +15,7 @@ pub fn derive_try_from_vm_value_struct(
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
-    let try_from_vm_value_vec_impl = derive_try_from_vm_value_vec(struct_name, generics);
+    let try_from_vm_value_vec_impl = derive_try_from_vm_value_vec::generate(struct_name, generics);
 
     Ok(quote! {
         impl #impl_generics CdkActTryFromVmValue<

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_vec.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_vec.rs
@@ -1,0 +1,58 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+use syn::Generics;
+
+pub fn derive_try_from_vm_value_vec(name: &Ident, generics: &Generics) -> TokenStream {
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics CdkActTryFromVmValue<
+            Vec<#name #ty_generics>,
+            &mut boa_engine::Context<'_>
+        >
+            for boa_engine::JsValue
+            #where_clause
+        {
+            fn try_from_vm_value(
+                self,
+                context: &mut boa_engine::Context
+            ) -> Result<Vec<#name #ty_generics>, CdkActTryFromVmValueError> {
+                let js_object = self
+                    .as_object()
+                    .ok_or_else(|| "TypeError: Value is not of type 'Vec'")?;
+
+                if !js_object.is_array() {
+                    return Err(CdkActTryFromVmValueError(
+                        "TypeError: Value is not of type 'Vec'".to_string(),
+                    ));
+                }
+
+
+                let mut index: usize = 0;
+                let mut result = vec![];
+
+                loop {
+                    let js_value = js_object
+                        .get(index, context)
+                        .map_err(|err| err.to_string())?;
+
+                    if js_value.is_undefined() {
+                        break;
+                    }
+
+                    result.push(js_value
+                        .try_from_vm_value(&mut *context)
+                        .map_err(|variant_err| {
+                            format!(
+                                "[TypeError: Value is not of type 'Vec'] {{\n  [cause]: {}\n}}",
+                                variant_err.0
+                            )
+                        })?);
+                    index += 1;
+                }
+
+                Ok(result)
+            }
+        }
+    }
+}

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_vec.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_vec.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use syn::Generics;
 
-pub fn derive_try_from_vm_value_vec(name: &Ident, generics: &Generics) -> TokenStream {
+pub fn generate(name: &Ident, generics: &Generics) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     quote! {

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_vec.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_vec.rs
@@ -32,9 +32,12 @@ pub fn generate(name: &Ident, generics: &Generics) -> TokenStream {
                 let mut result = vec![];
 
                 loop {
-                    let js_value = js_object
-                        .get(index, context)
-                        .map_err(|err| err.to_string())?;
+                    let js_value = js_object.get(index, context).map_err(|err| {
+                        format!(
+                            "[TypeError: Value is not of type 'Vec'] {{\n  [cause]: {}\n}}",
+                            err.to_string()
+                        )
+                    })?;
 
                     if js_value.is_undefined() {
                         break;

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_from_vm_value/mod.rs
@@ -1,0 +1,3 @@
+pub mod derive_try_from_vm_value_enum;
+pub mod derive_try_from_vm_value_struct;
+pub mod derive_try_from_vm_value_vec;

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_enum.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_enum.rs
@@ -2,7 +2,7 @@ use proc_macro2::Ident;
 use quote::{format_ident, quote};
 use syn::{DataEnum, Field, Fields, Generics};
 
-pub fn derive_try_into_vm_value_enum(
+pub fn generate(
     enum_name: &Ident,
     data_enum: &DataEnum,
     generics: &Generics,

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_enum.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_enum.rs
@@ -1,43 +1,47 @@
-use proc_macro2::Ident;
+use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
-use syn::{DataEnum, Field, Fields, Generics};
+use syn::{DataEnum, Error, Field, Fields, Generics};
+
+use crate::{derive_try_into_vm_value::derive_try_into_vm_value_vec, traits::TryGetIdent};
 
 pub fn generate(
     enum_name: &Ident,
     data_enum: &DataEnum,
     generics: &Generics,
-) -> proc_macro2::TokenStream {
-    let variant_branches = derive_variant_branches(&enum_name, &data_enum);
+) -> Result<TokenStream, Error> {
+    let variant_branches = derive_variant_branches(&enum_name, &data_enum)?;
 
     // Capture generic parameters and their bounds
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
-    quote! {
-        impl #impl_generics CdkActTryIntoVmValue<&mut boa_engine::Context<'_>, boa_engine::JsValue> for #enum_name #ty_generics #where_clause {
-            fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
+    let try_into_vm_value_vec_impl = derive_try_into_vm_value_vec::generate(enum_name, generics);
+
+    Ok(quote! {
+        impl #impl_generics CdkActTryIntoVmValue<
+            &mut boa_engine::Context<'_>,
+            boa_engine::JsValue
+        >
+            for #enum_name #ty_generics
+            #where_clause
+        {
+            fn try_into_vm_value(
+                self,
+                context: &mut boa_engine::Context
+            ) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
                 match self {
                     #(#variant_branches)*,
                 }
             }
         }
 
-        impl #impl_generics CdkActTryIntoVmValue<&mut boa_engine::Context<'_>, boa_engine::JsValue> for Vec<#enum_name #ty_generics> #where_clause {
-            fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
-                let js_values: Vec<_> = self
-                    .into_iter()
-                    .map(|item| item.try_into_vm_value(context))
-                    .collect::<Result<_, _>>()?;
-
-                Ok(boa_engine::object::builtins::JsArray::from_iter(js_values, context).into())
-            }
-        }
-    }
+        #try_into_vm_value_vec_impl
+    })
 }
 
 fn derive_variant_branches(
     enum_name: &Ident,
     data_enum: &DataEnum,
-) -> Vec<proc_macro2::TokenStream> {
+) -> Result<Vec<TokenStream>, Error> {
     data_enum
         .variants
         .iter()
@@ -50,62 +54,71 @@ fn derive_variant_branches(
                     variant_name,
                     fields_named.named.iter().collect(),
                 ),
-                Fields::Unnamed(fields_unnamed) => derive_variant_branches_unnamed_fields(
+                Fields::Unnamed(fields_unnamed) => Ok(derive_variant_branches_unnamed_fields(
                     enum_name,
                     variant_name,
                     fields_unnamed.unnamed.iter().collect(),
-                ),
-                Fields::Unit => {
-                    derive_variant_branches_unnamed_fields(enum_name, variant_name, vec![])
-                }
+                )),
+                Fields::Unit => Ok(derive_variant_branches_unnamed_fields(
+                    enum_name,
+                    variant_name,
+                    vec![],
+                )),
             }
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()
 }
 
 fn derive_variant_branches_named_fields(
     enum_name: &Ident,
     variant_name: &Ident,
     named_fields: Vec<&Field>,
-) -> proc_macro2::TokenStream {
-    let fields_must_be_named = format!(
-        "All fields of variant {} in enum {} must be named",
-        variant_name, enum_name
-    );
+) -> Result<TokenStream, Error> {
+    let field_names = named_fields
+        .iter()
+        .enumerate()
+        .map(|(field_index, named_field)| {
+            let field_name = named_field.try_get_ident(enum_name, variant_name, field_index)?;
 
-    let field_names = named_fields.iter().map(|named_field| {
-        let field_name = &named_field.ident.as_ref().expect(&fields_must_be_named);
+            Ok(quote! {
+                #field_name
+            })
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
 
-        quote! {
-            #field_name
-        }
-    });
+    let named_field_variable_declarations = named_fields
+        .iter()
+        .enumerate()
+        .map(|(field_index, named_field)| {
+            let field_name = named_field.try_get_ident(enum_name, variant_name, field_index)?;
+            let variable_name = format_ident!("{}_js_value", field_name);
 
-    let named_field_variable_declarations = named_fields.iter().map(|named_field| {
-        let field_name = &named_field.ident.as_ref().expect(&fields_must_be_named);
-        let variable_name = format_ident!("{}_js_value", field_name);
+            Ok(quote! {
+                let #variable_name = #field_name.try_into_vm_value(context)?;
+            })
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
 
-        quote! {
-            let #variable_name = #field_name.try_into_vm_value(context)?;
-        }
-    });
+    let named_field_property_definitions = named_fields
+        .iter()
+        .enumerate()
+        .map(|(field_index, named_field)| {
+            let field_name = named_field.try_get_ident(enum_name, variant_name, field_index)?;
+            let variable_name = format_ident!("{}_js_value", field_name);
 
-    let named_field_property_definitions = named_fields.iter().map(|named_field| {
-        let field_name = &named_field.ident.as_ref().expect(&fields_must_be_named);
-        let variable_name = format_ident!("{}_js_value", field_name);
-
-        quote! {
-            .property(
-                stringify!(#field_name),
-                #variable_name,
-                boa_engine::property::Attribute::all()
-            )
-        }
-    });
+            Ok(quote! {
+                .property(
+                    stringify!(#field_name),
+                    #variable_name,
+                    boa_engine::property::Attribute::all()
+                )
+            })
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
 
     let variant_object_variable_name = format_ident!("{}_js_object", variant_name);
 
-    quote! {
+    Ok(quote! {
         #enum_name::#variant_name { #(#field_names),* } => {
             #(#named_field_variable_declarations)*
 
@@ -123,14 +136,14 @@ fn derive_variant_branches_named_fields(
 
             Ok(object.into())
         }
-    }
+    })
 }
 
 fn derive_variant_branches_unnamed_fields(
     enum_name: &Ident,
     variant_name: &Ident,
     unnamed_fields: Vec<&Field>,
-) -> proc_macro2::TokenStream {
+) -> TokenStream {
     if unnamed_fields.len() == 0 {
         quote! {
             #enum_name::#variant_name => {

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_enum.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_enum.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use syn::{DataEnum, Error, Field, Fields, Generics};
 
-use crate::{derive_try_into_vm_value::derive_try_into_vm_value_vec, traits::TryGetIdent};
+use crate::{derive_try_into_vm_value::derive_try_into_vm_value_vec, traits::TryGetEnumFieldIdent};
 
 pub fn generate(
     enum_name: &Ident,

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_struct.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_struct.rs
@@ -1,25 +1,36 @@
-use proc_macro2::Ident;
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
-use syn::{DataStruct, Fields, Generics, Index};
+use syn::{DataStruct, Error, Fields, Generics, Index};
 
-use crate::derive_try_into_vm_value::derive_try_into_vm_value_vec;
+use crate::{
+    derive_try_into_vm_value::derive_try_into_vm_value_vec, traits::TryGetStructFieldIdent,
+};
 
 pub fn generate(
     struct_name: &Ident,
     data_struct: &DataStruct,
     generics: &Generics,
-) -> proc_macro2::TokenStream {
-    let variable_definitions = derive_struct_fields_variable_definitions(data_struct);
-    let property_definitions = derive_struct_fields_property_definitions(data_struct);
+) -> Result<TokenStream, Error> {
+    let variable_definitions = derive_struct_fields_variable_definitions(struct_name, data_struct)?;
+    let property_definitions = derive_struct_fields_property_definitions(struct_name, data_struct)?;
 
     // Capture generic parameters and their bounds
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let try_into_vm_value_vec_impl = derive_try_into_vm_value_vec::generate(struct_name, generics);
 
-    quote! {
-        impl #impl_generics CdkActTryIntoVmValue<&mut boa_engine::Context<'_>, boa_engine::JsValue> for #struct_name #ty_generics #where_clause {
-            fn try_into_vm_value(self, context: &mut boa_engine::Context) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
+    Ok(quote! {
+        impl #impl_generics CdkActTryIntoVmValue<
+            &mut boa_engine::Context<'_>,
+            boa_engine::JsValue
+        >
+            for #struct_name #ty_generics
+            #where_clause
+        {
+            fn try_into_vm_value(
+                self,
+                context: &mut boa_engine::Context
+            ) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
                 #(#variable_definitions)*
 
                 let object = boa_engine::object::ObjectInitializer::new(context)
@@ -31,26 +42,28 @@ pub fn generate(
         }
 
         #try_into_vm_value_vec_impl
-    }
+    })
 }
 
 fn derive_struct_fields_variable_definitions(
+    struct_name: &Ident,
     data_struct: &DataStruct,
-) -> Vec<proc_macro2::TokenStream> {
+) -> Result<Vec<TokenStream>, Error> {
     match &data_struct.fields {
         Fields::Named(fields_named) => fields_named
             .named
             .iter()
-            .map(|field| {
-                let field_name = field.ident.as_ref().expect("Named field must have a name");
+            .enumerate()
+            .map(|(index, field)| {
+                let field_name = field.try_get_ident(struct_name, index)?;
                 let variable_name = format_ident!("{}_js_value", field_name);
 
-                quote! {
+                Ok(quote! {
                     let #variable_name = self.#field_name.try_into_vm_value(context)?;
-                }
+                })
             })
-            .collect(),
-        Fields::Unnamed(fields_unnamed) => fields_unnamed
+            .collect::<Result<Vec<_>, Error>>(),
+        Fields::Unnamed(fields_unnamed) => Ok(fields_unnamed
             .unnamed
             .iter()
             .enumerate()
@@ -62,32 +75,37 @@ fn derive_struct_fields_variable_definitions(
                     let #variable_name = self.#syn_index.try_into_vm_value(context)?;
                 }
             })
-            .collect(),
-        _ => panic!("Only named and unnamed fields supported for Structs"),
+            .collect()),
+        Fields::Unit => Err(Error::new(
+            Span::call_site(),
+            format!("CdkActTryIntoVmValue not supported for unit-like structs"),
+        )),
     }
 }
 
 fn derive_struct_fields_property_definitions(
+    struct_name: &Ident,
     data_struct: &DataStruct,
-) -> Vec<proc_macro2::TokenStream> {
+) -> Result<Vec<TokenStream>, Error> {
     match &data_struct.fields {
         Fields::Named(fields_named) => fields_named
             .named
             .iter()
-            .map(|field| {
-                let field_name = field.ident.as_ref().expect("Named field must have a name");
+            .enumerate()
+            .map(|(index, field)| {
+                let field_name = field.try_get_ident(struct_name, index)?;
                 let variable_name = format_ident!("{}_js_value", field_name);
 
-                quote! {
+                Ok(quote! {
                     .property(
                         stringify!(#field_name),
                         #variable_name,
                         boa_engine::property::Attribute::all()
                     )
-                }
+                })
             })
-            .collect(),
-        Fields::Unnamed(fields_unnamed) => fields_unnamed
+            .collect::<Result<Vec<_>, Error>>(),
+        Fields::Unnamed(fields_unnamed) => Ok(fields_unnamed
             .unnamed
             .iter()
             .enumerate()
@@ -103,7 +121,10 @@ fn derive_struct_fields_property_definitions(
                     )
                 }
             })
-            .collect(),
-        _ => panic!("Only named and unnamed fields supported for Structs"),
+            .collect()),
+        Fields::Unit => Err(Error::new(
+            Span::call_site(),
+            format!("CdkActTryIntoVmValue not supported for unit-like structs"),
+        )),
     }
 }

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_struct.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_struct.rs
@@ -2,7 +2,7 @@ use proc_macro2::Ident;
 use quote::{format_ident, quote};
 use syn::{DataStruct, Fields, Generics, Index};
 
-pub fn derive_try_into_vm_value_struct(
+pub fn generate(
     struct_name: &Ident,
     data_struct: &DataStruct,
     generics: &Generics,

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_vec.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/derive_try_into_vm_value_vec.rs
@@ -1,0 +1,29 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+use syn::Generics;
+
+pub fn generate(name: &Ident, generics: &Generics) -> TokenStream {
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics CdkActTryIntoVmValue<
+            &mut boa_engine::Context<'_>,
+            boa_engine::JsValue
+        >
+            for Vec<#name #ty_generics>
+            #where_clause
+        {
+            fn try_into_vm_value(
+                self,
+                context: &mut boa_engine::Context
+            ) -> Result<boa_engine::JsValue, CdkActTryIntoVmValueError> {
+                let js_values: Vec<_> = self
+                    .into_iter()
+                    .map(|item| item.try_into_vm_value(context))
+                    .collect::<Result<_, _>>()?;
+
+                Ok(boa_engine::object::builtins::JsArray::from_iter(js_values, context).into())
+            }
+        }
+    }
+}

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/mod.rs
@@ -1,0 +1,2 @@
+pub mod derive_try_into_vm_value_enum;
+pub mod derive_try_into_vm_value_struct;

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/derive_try_into_vm_value/mod.rs
@@ -1,2 +1,3 @@
 pub mod derive_try_into_vm_value_enum;
 pub mod derive_try_into_vm_value_struct;
+pub mod derive_try_into_vm_value_vec;

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/lib.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/lib.rs
@@ -20,11 +20,9 @@ pub fn derive_azle_try_into_vm_value(tokens: TokenStream) -> TokenStream {
         Data::Enum(data_enum) => {
             derive_try_into_vm_value_enum::generate(&name, &data_enum, &generics)
         }
-        Data::Struct(data_struct) => Ok(derive_try_into_vm_value_struct::generate(
-            &name,
-            &data_struct,
-            &generics,
-        )),
+        Data::Struct(data_struct) => {
+            derive_try_into_vm_value_struct::generate(&name, &data_struct, &generics)
+        }
         Data::Union(_) => Err(Error::new(
             Span::call_site(),
             format!("CdkActTryIntoVmValue not supported for unions"),

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/lib.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/lib.rs
@@ -17,9 +17,9 @@ pub fn derive_azle_try_into_vm_value(tokens: TokenStream) -> TokenStream {
     let generics = input.generics;
 
     let generated_code = match input.data {
-        Data::Enum(data_enum) => Ok(derive_try_into_vm_value_enum::generate(
-            &name, &data_enum, &generics,
-        )),
+        Data::Enum(data_enum) => {
+            derive_try_into_vm_value_enum::generate(&name, &data_enum, &generics)
+        }
         Data::Struct(data_struct) => Ok(derive_try_into_vm_value_struct::generate(
             &name,
             &data_struct,

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/lib.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/lib.rs
@@ -8,6 +8,7 @@ mod derive_try_into_vm_value {
 mod derive_try_from_vm_value {
     pub mod derive_try_from_vm_value_enum;
     pub mod derive_try_from_vm_value_struct;
+    pub mod derive_try_from_vm_value_vec;
 }
 
 use derive_try_from_vm_value::{

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/lib.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/lib.rs
@@ -49,14 +49,12 @@ pub fn derive_azle_try_from_vm_value(tokens: TokenStream) -> TokenStream {
 
     let generated_code = match input.data {
         Data::Enum(data_enum) => derive_try_from_vm_value_enum(&name, &data_enum, &generics),
-        Data::Struct(data_struct) => Ok(derive_try_from_vm_value_struct(
-            &name,
-            &data_struct,
-            &generics,
-        )),
+        Data::Struct(data_struct) => {
+            derive_try_from_vm_value_struct(&name, &data_struct, &generics)
+        }
         Data::Union(_) => Err(Error::new(
             Span::call_site(),
-            format!("CdkActTryIntoVmValue not supported for Unions"),
+            format!("CdkActTryFromVmValue not supported for Unions"),
         )),
     };
 

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/lib.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/lib.rs
@@ -1,26 +1,13 @@
-use proc_macro2::Span;
-use syn::Error;
-
-mod derive_try_into_vm_value {
-    pub mod derive_try_into_vm_value_enum;
-    pub mod derive_try_into_vm_value_struct;
-}
-mod derive_try_from_vm_value {
-    pub mod derive_try_from_vm_value_enum;
-    pub mod derive_try_from_vm_value_struct;
-    pub mod derive_try_from_vm_value_vec;
-}
-
-use derive_try_from_vm_value::{
-    derive_try_from_vm_value_enum::derive_try_from_vm_value_enum,
-    derive_try_from_vm_value_struct::derive_try_from_vm_value_struct,
-};
-use derive_try_into_vm_value::{
-    derive_try_into_vm_value_enum::derive_try_into_vm_value_enum,
-    derive_try_into_vm_value_struct::derive_try_into_vm_value_struct,
-};
 use proc_macro::TokenStream;
-use syn::{parse_macro_input, Data, DeriveInput};
+use proc_macro2::Span;
+use syn::{parse_macro_input, Data, DeriveInput, Error};
+
+use derive_try_from_vm_value::{derive_try_from_vm_value_enum, derive_try_from_vm_value_struct};
+use derive_try_into_vm_value::{derive_try_into_vm_value_enum, derive_try_into_vm_value_struct};
+
+mod derive_try_from_vm_value;
+mod derive_try_into_vm_value;
+mod traits;
 
 #[proc_macro_derive(CdkActTryIntoVmValue)]
 pub fn derive_azle_try_into_vm_value(tokens: TokenStream) -> TokenStream {
@@ -30,8 +17,10 @@ pub fn derive_azle_try_into_vm_value(tokens: TokenStream) -> TokenStream {
     let generics = input.generics;
 
     let generated_code = match input.data {
-        Data::Enum(data_enum) => Ok(derive_try_into_vm_value_enum(&name, &data_enum, &generics)),
-        Data::Struct(data_struct) => Ok(derive_try_into_vm_value_struct(
+        Data::Enum(data_enum) => Ok(derive_try_into_vm_value_enum::generate(
+            &name, &data_enum, &generics,
+        )),
+        Data::Struct(data_struct) => Ok(derive_try_into_vm_value_struct::generate(
             &name,
             &data_struct,
             &generics,
@@ -56,9 +45,11 @@ pub fn derive_azle_try_from_vm_value(tokens: TokenStream) -> TokenStream {
     let generics = input.generics;
 
     let generated_code = match input.data {
-        Data::Enum(data_enum) => derive_try_from_vm_value_enum(&name, &data_enum, &generics),
+        Data::Enum(data_enum) => {
+            derive_try_from_vm_value_enum::generate(&name, &data_enum, &generics)
+        }
         Data::Struct(data_struct) => {
-            derive_try_from_vm_value_struct(&name, &data_struct, &generics)
+            derive_try_from_vm_value_struct::generate(&name, &data_struct, &generics)
         }
         Data::Union(_) => Err(Error::new(
             Span::call_site(),

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/traits/map_to.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/traits/map_to.rs
@@ -1,0 +1,41 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::format_ident;
+use syn::{Error, Field};
+
+use crate::traits::TryGetIdent;
+
+pub trait MapTo {
+    fn map_to<T>(
+        &self,
+        enum_name: &Ident,
+        variant_name: &Ident,
+        callback: T,
+    ) -> Result<Vec<TokenStream>, Error>
+    where
+        T: Fn(&Ident, Ident) -> TokenStream;
+}
+
+impl MapTo for Vec<&Field> {
+    fn map_to<T>(
+        &self,
+        enum_name: &Ident,
+        variant_name: &Ident,
+        callback: T,
+    ) -> Result<Vec<TokenStream>, Error>
+    where
+        T: Fn(&Ident, Ident) -> TokenStream,
+    {
+        let named_field_js_value_result_variable_names = self
+            .iter()
+            .enumerate()
+            .map(|(field_index, named_field)| -> Result<TokenStream, Error> {
+                let field_name = named_field.try_get_ident(enum_name, variant_name, field_index)?;
+                let variable_name = format_ident!("{}_js_value_result", field_name);
+
+                Ok(callback(&field_name, variable_name))
+            })
+            .collect::<Result<Vec<_>, _>>();
+
+        named_field_js_value_result_variable_names
+    }
+}

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/traits/map_to.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/traits/map_to.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Ident, TokenStream};
 use quote::format_ident;
 use syn::{Error, Field};
 
-use crate::traits::TryGetIdent;
+use crate::traits::TryGetEnumFieldIdent;
 
 pub trait MapTo {
     fn map_to<T>(

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/traits/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/traits/mod.rs
@@ -1,0 +1,5 @@
+pub use map_to::MapTo;
+pub use try_get_ident::TryGetIdent;
+
+pub mod map_to;
+pub mod try_get_ident;

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/traits/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/traits/mod.rs
@@ -1,5 +1,7 @@
 pub use map_to::MapTo;
-pub use try_get_ident::TryGetIdent;
+pub use try_get_enum_field_ident::TryGetEnumFieldIdent;
+pub use try_get_struct_field_ident::TryGetStructFieldIdent;
 
 pub mod map_to;
-pub mod try_get_ident;
+pub mod try_get_enum_field_ident;
+pub mod try_get_struct_field_ident;

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/traits/try_get_enum_field_ident.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/traits/try_get_enum_field_ident.rs
@@ -1,7 +1,7 @@
 use proc_macro2::{Ident, Span};
 use syn::{Error, Field};
 
-pub trait TryGetIdent {
+pub trait TryGetEnumFieldIdent {
     fn try_get_ident(
         &self,
         enum_name: &Ident,
@@ -10,7 +10,7 @@ pub trait TryGetIdent {
     ) -> Result<&Ident, Error>;
 }
 
-impl TryGetIdent for Field {
+impl TryGetEnumFieldIdent for Field {
     fn try_get_ident(
         &self,
         enum_name: &Ident,

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/traits/try_get_ident.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/traits/try_get_ident.rs
@@ -1,0 +1,30 @@
+use proc_macro2::{Ident, Span};
+use syn::{Error, Field};
+
+pub trait TryGetIdent {
+    fn try_get_ident(
+        &self,
+        enum_name: &Ident,
+        variant_name: &Ident,
+        field_index: usize,
+    ) -> Result<&Ident, Error>;
+}
+
+impl TryGetIdent for Field {
+    fn try_get_ident(
+        &self,
+        enum_name: &Ident,
+        variant_name: &Ident,
+        field_index: usize,
+    ) -> Result<&Ident, Error> {
+        self.ident.as_ref().ok_or_else(|| {
+            Error::new(
+                Span::call_site(),
+                format!(
+                    "Internal Error: expected field {field_index} in \
+                        {enum_name}::{variant_name} to have a name but received None"
+                ),
+            )
+        })
+    }
+}

--- a/src/compiler/typescript_to_rust/azle_vm_value_derive/src/traits/try_get_struct_field_ident.rs
+++ b/src/compiler/typescript_to_rust/azle_vm_value_derive/src/traits/try_get_struct_field_ident.rs
@@ -1,0 +1,20 @@
+use proc_macro2::{Ident, Span};
+use syn::{Error, Field};
+
+pub trait TryGetStructFieldIdent {
+    fn try_get_ident(&self, struct_name: &Ident, field_index: usize) -> Result<&Ident, Error>;
+}
+
+impl TryGetStructFieldIdent for Field {
+    fn try_get_ident(&self, struct_name: &Ident, field_index: usize) -> Result<&Ident, Error> {
+        self.ident.as_ref().ok_or_else(|| {
+            Error::new(
+                Span::call_site(),
+                format!(
+                    "Internal Error: expected field {field_index} in \
+                        {struct_name} to have a name but received None"
+                ),
+            )
+        })
+    }
+}


### PR DESCRIPTION
After #1097 was merged there were only a few `expect` and `panic` statements left, all in the derive crate. This removes all of them. There are now no `expect` or `panic` statements in the codebase. There are still a few unwraps where we try to form our nice error messages. We will take care of those in the [ 🄴 Very Very Nice Error Messages](https://github.com/demergent-labs/azle#workspaces/engineering-63eff82fd9fe250011f32225/epics/Z2lkOi8vcmFwdG9yL1plbmh1YkVwaWMvMTE5NDg1) epic.

Additionally this PR improves the runtime errors for user-defined Records and Variants.

Closes #1055 