### PR TITLE
Added check to ensure init and post-upgrade params are of same length

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
                     "examples/candid_encoding",
                     "examples/complex_init",
                     "examples/complex_types",
+                    "examples/compiler_errors/mismatched_init_and_post_upgrade_params",
                     "examples/composite_queries",
                     "examples/counter",
                     "examples/cross_canister_calls",

--- a/examples/compiler_errors/mismatched_init_and_post_upgrade_params/.gitignore
+++ b/examples/compiler_errors/mismatched_init_and_post_upgrade_params/.gitignore
@@ -1,0 +1,5 @@
+.azle
+.dfx
+dfx_generated
+node_modules
+*.did

--- a/examples/compiler_errors/mismatched_init_and_post_upgrade_params/dfx.json
+++ b/examples/compiler_errors/mismatched_init_and_post_upgrade_params/dfx.json
@@ -1,0 +1,16 @@
+{
+    "canisters": {
+        "canister": {
+            "type": "custom",
+            "build": "npx azle canister",
+            "root": "src",
+            "ts": "src/index.ts",
+            "candid": "src/index.did",
+            "wasm": ".azle/canister/canister.wasm.gz",
+            "declarations": {
+                "output": "test/dfx_generated/canister",
+                "node_compatibility": true
+            }
+        }
+    }
+}

--- a/examples/compiler_errors/mismatched_init_and_post_upgrade_params/package-lock.json
+++ b/examples/compiler_errors/mismatched_init_and_post_upgrade_params/package-lock.json
@@ -1,0 +1,1663 @@
+{
+    "name": "mismatched_init_and_post_upgrade_params",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "dependencies": {
+                "azle": "0.16.3"
+            },
+            "devDependencies": {
+                "@dfinity/agent": "0.11.1",
+                "ts-node": "10.7.0",
+                "typescript": "4.6.3"
+            }
+        },
+        "node_modules/@cspotcode/source-map-consumer": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+            "dependencies": {
+                "@cspotcode/source-map-consumer": "0.8.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@dfinity/agent": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.11.1.tgz",
+            "integrity": "sha512-Z1zw8l3d+AG3uu7d8G/Rd9Q5MWT9gB+Cori/Rqb6IjSEribRhL36ulCSkDYZJU/dhqSUp1VlvX5u51+wgv+MLg==",
+            "dev": true,
+            "dependencies": {
+                "base64-arraybuffer": "^0.2.0",
+                "bignumber.js": "^9.0.0",
+                "borc": "^2.1.1",
+                "js-sha256": "0.9.0",
+                "simple-cbor": "^0.4.1"
+            },
+            "peerDependencies": {
+                "@dfinity/candid": "^0.11.1",
+                "@dfinity/principal": "^0.11.1"
+            }
+        },
+        "node_modules/@dfinity/candid": {
+            "version": "0.11.3",
+            "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.11.3.tgz",
+            "integrity": "sha512-xX7xNj2lLt7SIlvy0sqNp4fpcTD/xnwEu9APj0tnIF64cnsxIiS12T1Z8jl9g80jCQ1CbRPQf4cfsOfS3Cd2OA==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@dfinity/principal": {
+            "version": "0.11.3",
+            "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.11.3.tgz",
+            "integrity": "sha512-+AJGDJ+RsveybSdxuTQFr2DPNZFpPfXnyixAOFWWdElVniSwnO/SwqQChR0AWvJdy/fKqoAXK+ZzyLG0uqSetA==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@swc/core": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.151.tgz",
+            "integrity": "sha512-oHgqKwK/Djv765zUHPiGqfMCaKIxXTgQyyCUBKLBQfAJwe/7FVobQ2fghBp4FsZA/NE1LZBmMPpRZNQwlGjeHw==",
+            "bin": {
+                "swcx": "run_swcx.js"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/swc"
+            },
+            "optionalDependencies": {
+                "@swc/core-android-arm-eabi": "1.2.151",
+                "@swc/core-android-arm64": "1.2.151",
+                "@swc/core-darwin-arm64": "1.2.151",
+                "@swc/core-darwin-x64": "1.2.151",
+                "@swc/core-freebsd-x64": "1.2.151",
+                "@swc/core-linux-arm-gnueabihf": "1.2.151",
+                "@swc/core-linux-arm64-gnu": "1.2.151",
+                "@swc/core-linux-arm64-musl": "1.2.151",
+                "@swc/core-linux-x64-gnu": "1.2.151",
+                "@swc/core-linux-x64-musl": "1.2.151",
+                "@swc/core-win32-arm64-msvc": "1.2.151",
+                "@swc/core-win32-ia32-msvc": "1.2.151",
+                "@swc/core-win32-x64-msvc": "1.2.151"
+            }
+        },
+        "node_modules/@swc/core-android-arm-eabi": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.151.tgz",
+            "integrity": "sha512-Suk3IcHdha33K4hq9tfBCwkXJsENh7kjXCseLqL8Yvy8QobqkXjf1fcoJxX9BdCmPwsKmIw0ZgCBYR+Hl83M2w==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-android-arm64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.151.tgz",
+            "integrity": "sha512-HZVy69dVWT5RgrMJMRK5aiicPmhzkyCHAexApYAHYLgAIhsxL7uoAIPmuRKRkrKNJjrwsWL7H27bBH5bddRDvg==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-darwin-arm64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.151.tgz",
+            "integrity": "sha512-Ql7rXMu+IC76TemRtkt+opl5iSpX2ApAXVSfvf6afNVTrfTKLpDwiR3ySRRlG0FnNIv6TfOCJpHf655xp01S/g==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-darwin-x64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.151.tgz",
+            "integrity": "sha512-N1OBIB7xatR5eybLo91ZhvMJMxT0zxRQURV/a9I8o5CyP4iLd1k8gmrYvBbtj08ohS8F9z7k/dFjxk/9ve5Drw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-freebsd-x64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.151.tgz",
+            "integrity": "sha512-WVIRiDzuz+/W7BMjVtg1Cmk1+zmDT18Qq+Ygr9J6aFQ1JQUkLEE1pvtkGD3JIEa6Jhz/VwM6AFHtY5o1CrZ21w==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm-gnueabihf": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.151.tgz",
+            "integrity": "sha512-pfBrIUwu3cR/M7DzDCUJAw9jFKXvJ/Ge8auFk07lRb+JcDnPm0XxLyrLqGvNQWdcHgXeXfmnS4fMQxdb9GUN1w==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-gnu": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.151.tgz",
+            "integrity": "sha512-M+BTkTdPY7gteM+0dYz9wrU/j9taL4ccqPEHkDEKP21lS24y99UtuKsvdBLzDm/6ShBVLFAkgIBPu5cEb7y6ig==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-musl": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.151.tgz",
+            "integrity": "sha512-7A+yTtSvPJVwO8X1cxUbD/PVCx8G9MKn83G9pH/r+9sQMBXqxyw6/NR0DG6nMMiyOmJkmYWgh5mO47BN7WC4dQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-gnu": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.151.tgz",
+            "integrity": "sha512-ORlbN3wf1w0IQGjGToYYC/hV/Vwfcs88Ohfxc4X+IQaw/VxKG6/XT65c0btK640F2TVhvhH1MbYFJJlsycsW7g==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-musl": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.151.tgz",
+            "integrity": "sha512-r6odKE3+9+ReVdnNTZnICt5tscyFFtP4GFcmPQzBSlVoD9LZX6O4WeOlFXn77rVK/+205n2ag/KkKgZH+vdPuQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-arm64-msvc": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.151.tgz",
+            "integrity": "sha512-jnjJTNHpLhBaPwRgiKv1TdrMljL88ePqMCdVMantyd7yl4lP0D2e5/xR9ysR9S4EGcUnOyo9w8WUYhx/TioMZw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-ia32-msvc": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.151.tgz",
+            "integrity": "sha512-hSCxAiyDDXKvdUExj4jSIhzWFePqoqak1qdNUjlhEhEinDG8T8PTRCLalyW6fqZDcLf6Tqde7H79AqbfhRlYGQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-x64-msvc": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.151.tgz",
+            "integrity": "sha512-HOkqcJWCChps83Maj0M5kifPDuZ2sGPqpLM67poawspTFkBh0QJ9TMmxW1doQw+74cqsTpRi1ewr/KhsN18i5g==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+            "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+        },
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+            "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
+        },
+        "node_modules/@types/node": {
+            "version": "18.8.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
+            "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
+            "peer": true
+        },
+        "node_modules/acorn": {
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+        },
+        "node_modules/azle": {
+            "version": "0.16.3",
+            "resolved": "https://registry.npmjs.org/azle/-/azle-0.16.3.tgz",
+            "integrity": "sha512-6JWTLCg261bKZACL0BiCZQ93gHhoB0dv5g6Tn1ixAkuIlWASyQjvpth4PJ/e9AkNh1kI3sltwjqVfrmtll48qg==",
+            "dependencies": {
+                "@dfinity/principal": "0.11.2",
+                "@swc/core": "1.2.151",
+                "azle-syn": "0.0.0",
+                "esbuild": "0.14.25",
+                "fs-extra": "10.0.1",
+                "js-sha256": "0.9.0",
+                "ts-node": "10.3.1",
+                "typescript": "4.4.4"
+            },
+            "bin": {
+                "azle": "bin.js"
+            }
+        },
+        "node_modules/azle-syn": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/azle-syn/-/azle-syn-0.0.0.tgz",
+            "integrity": "sha512-fWExJb5/hOEJOuBQ8hMMHRs9WryYeLLa9/ydqPWxbwjMEpE8RKdU1dTK6mdZtzNMhbeHdyne2pU1iVKiKmImGw=="
+        },
+        "node_modules/azle/node_modules/@dfinity/principal": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.11.2.tgz",
+            "integrity": "sha512-vReWruqIl16yQeKOrCLDLDf2aTEJsXcKeW9qbwVfmV0kwLNE3B2Z6tbRjYbY7s+KwpysD5B1b48ZbIwI00BeyQ=="
+        },
+        "node_modules/azle/node_modules/ts-node": {
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.3.1.tgz",
+            "integrity": "sha512-Yw3W2mYzhHfCHOICGNJqa0i+rbL0rAyg7ZIHxU+K4pgY8gd2Lh1j+XbHCusJMykbj6RZMJVOY0MlHVd+GOivcw==",
+            "dependencies": {
+                "@cspotcode/source-map-support": "0.7.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/azle/node_modules/typescript": {
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+            "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/base64-arraybuffer": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+            "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/bignumber.js": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
+            "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/borc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
+            "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+            "dev": true,
+            "dependencies": {
+                "bignumber.js": "^9.0.0",
+                "buffer": "^5.5.0",
+                "commander": "^2.15.0",
+                "ieee754": "^1.1.13",
+                "iso-url": "~0.4.7",
+                "json-text-sequence": "~0.1.0",
+                "readable-stream": "^3.6.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
+        },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+        },
+        "node_modules/delimit-stream": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+            "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ==",
+            "dev": true
+        },
+        "node_modules/diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.25.tgz",
+            "integrity": "sha512-4JHEIOMNFvK09ziiL+iVmldIhLbn49V4NAVo888tcGFKedEZY/Y8YapfStJ6zSE23tzYPKxqKwQBnQoIO0BI/Q==",
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "esbuild-android-64": "0.14.25",
+                "esbuild-android-arm64": "0.14.25",
+                "esbuild-darwin-64": "0.14.25",
+                "esbuild-darwin-arm64": "0.14.25",
+                "esbuild-freebsd-64": "0.14.25",
+                "esbuild-freebsd-arm64": "0.14.25",
+                "esbuild-linux-32": "0.14.25",
+                "esbuild-linux-64": "0.14.25",
+                "esbuild-linux-arm": "0.14.25",
+                "esbuild-linux-arm64": "0.14.25",
+                "esbuild-linux-mips64le": "0.14.25",
+                "esbuild-linux-ppc64le": "0.14.25",
+                "esbuild-linux-riscv64": "0.14.25",
+                "esbuild-linux-s390x": "0.14.25",
+                "esbuild-netbsd-64": "0.14.25",
+                "esbuild-openbsd-64": "0.14.25",
+                "esbuild-sunos-64": "0.14.25",
+                "esbuild-windows-32": "0.14.25",
+                "esbuild-windows-64": "0.14.25",
+                "esbuild-windows-arm64": "0.14.25"
+            }
+        },
+        "node_modules/esbuild-android-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.25.tgz",
+            "integrity": "sha512-L5vCUk7TzFbBnoESNoXjU3x9+/+7TDIE/1mTfy/erAfvZAqC+S3sp/Qa9wkypFMcFvN9FzvESkTlpeQDolREtQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-android-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.25.tgz",
+            "integrity": "sha512-4jv5xPjM/qNm27T5j3ZEck0PvjgQtoMHnz4FzwF5zNP56PvY2CT0WStcAIl6jNlsuDdN63rk2HRBIsO6xFbcFw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-darwin-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.25.tgz",
+            "integrity": "sha512-TGp8tuudIxOyWd1+8aYPxQmC1ZQyvij/AfNBa35RubixD0zJ1vkKHVAzo0Zao1zcG6pNqiSyzfPto8vmg0s7oA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-darwin-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.25.tgz",
+            "integrity": "sha512-oTcDgdm0MDVEmw2DWu8BV68pYuImpFgvWREPErBZmNA4MYKGuBRaCiJqq6jZmBR1x+3y1DWCjez+5uLtuAm6mw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-freebsd-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.25.tgz",
+            "integrity": "sha512-ueAqbnMZ8arnuLH8tHwTCQYeptnHOUV7vA6px6j4zjjQwDx7TdP7kACPf3TLZLdJQ3CAD1XCvQ2sPhX+8tacvQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-freebsd-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.25.tgz",
+            "integrity": "sha512-+ZVWud2HKh+Ob6k/qiJWjBtUg4KmJGGmbvEXXW1SNKS7hW7HU+Zq2ZCcE1akFxOPkVB+EhOty/sSek30tkCYug==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-32": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.25.tgz",
+            "integrity": "sha512-3OP/lwV3kCzEz45tobH9nj+uE4ubhGsfx+tn0L26WAGtUbmmcRpqy7XRG/qK7h1mClZ+eguIANcQntYMdYklfw==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.25.tgz",
+            "integrity": "sha512-+aKHdHZmX9qwVlQmu5xYXh7GsBFf4TWrePgeJTalhXHOG7NNuUwoHmketGiZEoNsWyyqwH9rE5BC+iwcLY30Ug==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-arm": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.25.tgz",
+            "integrity": "sha512-aTLcE2VBoLydL943REcAcgnDi3bHtmULSXWLbjtBdtykRatJVSxKMjK9YlBXUZC4/YcNQfH7AxwVeQr9fNxPhw==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.25.tgz",
+            "integrity": "sha512-UxfenPx/wSZx55gScCImPtXekvZQLI2GW3qe5dtlmU7luiqhp5GWPzGeQEbD3yN3xg/pHc671m5bma5Ns7lBHw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-mips64le": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.25.tgz",
+            "integrity": "sha512-wLWYyqVfYx9Ur6eU5RT92yJVsaBGi5RdkoWqRHOqcJ38Kn60QMlcghsKeWfe9jcYut8LangYZ98xO1LxIoSXrQ==",
+            "cpu": [
+                "mips64el"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-ppc64le": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.25.tgz",
+            "integrity": "sha512-0dR6Csl6Zas3g4p9ULckEl8Mo8IInJh33VCJ3eaV1hj9+MHGdmDOakYMN8MZP9/5nl+NU/0ygpd14cWgy8uqRw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-riscv64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.25.tgz",
+            "integrity": "sha512-J4d20HDmTrgvhR0bdkDhvvJGaikH3LzXQnNaseo8rcw9Yqby9A90gKUmWpfwqLVNRILvNnAmKLfBjCKU9ajg8w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-s390x": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.25.tgz",
+            "integrity": "sha512-YI2d5V6nTE73ZnhEKQD7MtsPs1EtUZJ3obS21oxQxGbbRw1G+PtJKjNyur+3t6nzHP9oTg6GHQ3S3hOLLmbDIQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-netbsd-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.25.tgz",
+            "integrity": "sha512-TKIVgNWLUOkr+Exrye70XTEE1lJjdQXdM4tAXRzfHE9iBA7LXWcNtVIuSnphTqpanPzTDFarF0yqq4kpbC6miA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-openbsd-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.25.tgz",
+            "integrity": "sha512-QgFJ37A15D7NIXBTYEqz29+uw3nNBOIyog+3kFidANn6kjw0GHZ0lEYQn+cwjyzu94WobR+fes7cTl/ZYlHb1A==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-sunos-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.25.tgz",
+            "integrity": "sha512-rmWfjUItYIVlqr5EnTH1+GCxXiBOC42WBZ3w++qh7n2cS9Xo0lO5pGSG2N+huOU2fX5L+6YUuJ78/vOYvefeFw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-32": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.25.tgz",
+            "integrity": "sha512-HGAxVUofl3iUIz9W10Y9XKtD0bNsK9fBXv1D55N/ljNvkrAYcGB8YCm0v7DjlwtyS6ws3dkdQyXadbxkbzaKOA==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.25.tgz",
+            "integrity": "sha512-TirEohRkfWU9hXLgoDxzhMQD1g8I2mOqvdQF2RS9E/wbkORTAqJHyh7wqGRCQAwNzdNXdg3JAyhQ9/177AadWA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.25.tgz",
+            "integrity": "sha512-4ype9ERiI45rSh+R8qUoBtaj6kJvUOI7oVLhKqPEpcF4Pa5PpT3hm/mXAyotJHREkHpM87PAJcA442mLnbtlNA==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/fs-extra": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+            "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+        },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "node_modules/iso-url": {
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
+            "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/js-sha256": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+            "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+        },
+        "node_modules/json-text-sequence": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+            "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
+            "dev": true,
+            "dependencies": {
+                "delimit-stream": "0.1.0"
+            }
+        },
+        "node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+        },
+        "node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dev": true,
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/simple-cbor": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
+            "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
+            "dev": true
+        },
+        "node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "node_modules/ts-node": {
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+            "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+            "dev": true,
+            "dependencies": {
+                "@cspotcode/source-map-support": "0.7.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.0",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-esm": "dist/bin-esm.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true
+        },
+        "node_modules/v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true
+        },
+        "node_modules/yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "engines": {
+                "node": ">=6"
+            }
+        }
+    },
+    "dependencies": {
+        "@cspotcode/source-map-consumer": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg=="
+        },
+        "@cspotcode/source-map-support": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+            "requires": {
+                "@cspotcode/source-map-consumer": "0.8.0"
+            }
+        },
+        "@dfinity/agent": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.11.1.tgz",
+            "integrity": "sha512-Z1zw8l3d+AG3uu7d8G/Rd9Q5MWT9gB+Cori/Rqb6IjSEribRhL36ulCSkDYZJU/dhqSUp1VlvX5u51+wgv+MLg==",
+            "dev": true,
+            "requires": {
+                "base64-arraybuffer": "^0.2.0",
+                "bignumber.js": "^9.0.0",
+                "borc": "^2.1.1",
+                "js-sha256": "0.9.0",
+                "simple-cbor": "^0.4.1"
+            }
+        },
+        "@dfinity/candid": {
+            "version": "0.11.3",
+            "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.11.3.tgz",
+            "integrity": "sha512-xX7xNj2lLt7SIlvy0sqNp4fpcTD/xnwEu9APj0tnIF64cnsxIiS12T1Z8jl9g80jCQ1CbRPQf4cfsOfS3Cd2OA==",
+            "dev": true,
+            "peer": true
+        },
+        "@dfinity/principal": {
+            "version": "0.11.3",
+            "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.11.3.tgz",
+            "integrity": "sha512-+AJGDJ+RsveybSdxuTQFr2DPNZFpPfXnyixAOFWWdElVniSwnO/SwqQChR0AWvJdy/fKqoAXK+ZzyLG0uqSetA==",
+            "dev": true,
+            "peer": true
+        },
+        "@swc/core": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.151.tgz",
+            "integrity": "sha512-oHgqKwK/Djv765zUHPiGqfMCaKIxXTgQyyCUBKLBQfAJwe/7FVobQ2fghBp4FsZA/NE1LZBmMPpRZNQwlGjeHw==",
+            "requires": {
+                "@swc/core-android-arm-eabi": "1.2.151",
+                "@swc/core-android-arm64": "1.2.151",
+                "@swc/core-darwin-arm64": "1.2.151",
+                "@swc/core-darwin-x64": "1.2.151",
+                "@swc/core-freebsd-x64": "1.2.151",
+                "@swc/core-linux-arm-gnueabihf": "1.2.151",
+                "@swc/core-linux-arm64-gnu": "1.2.151",
+                "@swc/core-linux-arm64-musl": "1.2.151",
+                "@swc/core-linux-x64-gnu": "1.2.151",
+                "@swc/core-linux-x64-musl": "1.2.151",
+                "@swc/core-win32-arm64-msvc": "1.2.151",
+                "@swc/core-win32-ia32-msvc": "1.2.151",
+                "@swc/core-win32-x64-msvc": "1.2.151"
+            }
+        },
+        "@swc/core-android-arm-eabi": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.151.tgz",
+            "integrity": "sha512-Suk3IcHdha33K4hq9tfBCwkXJsENh7kjXCseLqL8Yvy8QobqkXjf1fcoJxX9BdCmPwsKmIw0ZgCBYR+Hl83M2w==",
+            "optional": true
+        },
+        "@swc/core-android-arm64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.151.tgz",
+            "integrity": "sha512-HZVy69dVWT5RgrMJMRK5aiicPmhzkyCHAexApYAHYLgAIhsxL7uoAIPmuRKRkrKNJjrwsWL7H27bBH5bddRDvg==",
+            "optional": true
+        },
+        "@swc/core-darwin-arm64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.151.tgz",
+            "integrity": "sha512-Ql7rXMu+IC76TemRtkt+opl5iSpX2ApAXVSfvf6afNVTrfTKLpDwiR3ySRRlG0FnNIv6TfOCJpHf655xp01S/g==",
+            "optional": true
+        },
+        "@swc/core-darwin-x64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.151.tgz",
+            "integrity": "sha512-N1OBIB7xatR5eybLo91ZhvMJMxT0zxRQURV/a9I8o5CyP4iLd1k8gmrYvBbtj08ohS8F9z7k/dFjxk/9ve5Drw==",
+            "optional": true
+        },
+        "@swc/core-freebsd-x64": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.151.tgz",
+            "integrity": "sha512-WVIRiDzuz+/W7BMjVtg1Cmk1+zmDT18Qq+Ygr9J6aFQ1JQUkLEE1pvtkGD3JIEa6Jhz/VwM6AFHtY5o1CrZ21w==",
+            "optional": true
+        },
+        "@swc/core-linux-arm-gnueabihf": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.151.tgz",
+            "integrity": "sha512-pfBrIUwu3cR/M7DzDCUJAw9jFKXvJ/Ge8auFk07lRb+JcDnPm0XxLyrLqGvNQWdcHgXeXfmnS4fMQxdb9GUN1w==",
+            "optional": true
+        },
+        "@swc/core-linux-arm64-gnu": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.151.tgz",
+            "integrity": "sha512-M+BTkTdPY7gteM+0dYz9wrU/j9taL4ccqPEHkDEKP21lS24y99UtuKsvdBLzDm/6ShBVLFAkgIBPu5cEb7y6ig==",
+            "optional": true
+        },
+        "@swc/core-linux-arm64-musl": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.151.tgz",
+            "integrity": "sha512-7A+yTtSvPJVwO8X1cxUbD/PVCx8G9MKn83G9pH/r+9sQMBXqxyw6/NR0DG6nMMiyOmJkmYWgh5mO47BN7WC4dQ==",
+            "optional": true
+        },
+        "@swc/core-linux-x64-gnu": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.151.tgz",
+            "integrity": "sha512-ORlbN3wf1w0IQGjGToYYC/hV/Vwfcs88Ohfxc4X+IQaw/VxKG6/XT65c0btK640F2TVhvhH1MbYFJJlsycsW7g==",
+            "optional": true
+        },
+        "@swc/core-linux-x64-musl": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.151.tgz",
+            "integrity": "sha512-r6odKE3+9+ReVdnNTZnICt5tscyFFtP4GFcmPQzBSlVoD9LZX6O4WeOlFXn77rVK/+205n2ag/KkKgZH+vdPuQ==",
+            "optional": true
+        },
+        "@swc/core-win32-arm64-msvc": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.151.tgz",
+            "integrity": "sha512-jnjJTNHpLhBaPwRgiKv1TdrMljL88ePqMCdVMantyd7yl4lP0D2e5/xR9ysR9S4EGcUnOyo9w8WUYhx/TioMZw==",
+            "optional": true
+        },
+        "@swc/core-win32-ia32-msvc": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.151.tgz",
+            "integrity": "sha512-hSCxAiyDDXKvdUExj4jSIhzWFePqoqak1qdNUjlhEhEinDG8T8PTRCLalyW6fqZDcLf6Tqde7H79AqbfhRlYGQ==",
+            "optional": true
+        },
+        "@swc/core-win32-x64-msvc": {
+            "version": "1.2.151",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.151.tgz",
+            "integrity": "sha512-HOkqcJWCChps83Maj0M5kifPDuZ2sGPqpLM67poawspTFkBh0QJ9TMmxW1doQw+74cqsTpRi1ewr/KhsN18i5g==",
+            "optional": true
+        },
+        "@tsconfig/node10": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+            "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+        },
+        "@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+        },
+        "@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+        },
+        "@tsconfig/node16": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+            "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
+        },
+        "@types/node": {
+            "version": "18.8.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
+            "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
+            "peer": true
+        },
+        "acorn": {
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+        },
+        "acorn-walk": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+        },
+        "arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+        },
+        "azle": {
+            "version": "0.16.3",
+            "resolved": "https://registry.npmjs.org/azle/-/azle-0.16.3.tgz",
+            "integrity": "sha512-6JWTLCg261bKZACL0BiCZQ93gHhoB0dv5g6Tn1ixAkuIlWASyQjvpth4PJ/e9AkNh1kI3sltwjqVfrmtll48qg==",
+            "requires": {
+                "@dfinity/principal": "0.11.2",
+                "@swc/core": "1.2.151",
+                "azle-syn": "0.0.0",
+                "esbuild": "0.14.25",
+                "fs-extra": "10.0.1",
+                "js-sha256": "0.9.0",
+                "ts-node": "10.3.1",
+                "typescript": "4.4.4"
+            },
+            "dependencies": {
+                "@dfinity/principal": {
+                    "version": "0.11.2",
+                    "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.11.2.tgz",
+                    "integrity": "sha512-vReWruqIl16yQeKOrCLDLDf2aTEJsXcKeW9qbwVfmV0kwLNE3B2Z6tbRjYbY7s+KwpysD5B1b48ZbIwI00BeyQ=="
+                },
+                "ts-node": {
+                    "version": "10.3.1",
+                    "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.3.1.tgz",
+                    "integrity": "sha512-Yw3W2mYzhHfCHOICGNJqa0i+rbL0rAyg7ZIHxU+K4pgY8gd2Lh1j+XbHCusJMykbj6RZMJVOY0MlHVd+GOivcw==",
+                    "requires": {
+                        "@cspotcode/source-map-support": "0.7.0",
+                        "@tsconfig/node10": "^1.0.7",
+                        "@tsconfig/node12": "^1.0.7",
+                        "@tsconfig/node14": "^1.0.0",
+                        "@tsconfig/node16": "^1.0.2",
+                        "acorn": "^8.4.1",
+                        "acorn-walk": "^8.1.1",
+                        "arg": "^4.1.0",
+                        "create-require": "^1.1.0",
+                        "diff": "^4.0.1",
+                        "make-error": "^1.1.1",
+                        "yn": "3.1.1"
+                    }
+                },
+                "typescript": {
+                    "version": "4.4.4",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+                    "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
+                }
+            }
+        },
+        "azle-syn": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/azle-syn/-/azle-syn-0.0.0.tgz",
+            "integrity": "sha512-fWExJb5/hOEJOuBQ8hMMHRs9WryYeLLa9/ydqPWxbwjMEpE8RKdU1dTK6mdZtzNMhbeHdyne2pU1iVKiKmImGw=="
+        },
+        "base64-arraybuffer": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+            "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+            "dev": true
+        },
+        "base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true
+        },
+        "bignumber.js": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
+            "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
+            "dev": true
+        },
+        "borc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
+            "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+            "dev": true,
+            "requires": {
+                "bignumber.js": "^9.0.0",
+                "buffer": "^5.5.0",
+                "commander": "^2.15.0",
+                "ieee754": "^1.1.13",
+                "iso-url": "~0.4.7",
+                "json-text-sequence": "~0.1.0",
+                "readable-stream": "^3.6.0"
+            }
+        },
+        "buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
+        },
+        "create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+        },
+        "delimit-stream": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+            "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ==",
+            "dev": true
+        },
+        "diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+        },
+        "esbuild": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.25.tgz",
+            "integrity": "sha512-4JHEIOMNFvK09ziiL+iVmldIhLbn49V4NAVo888tcGFKedEZY/Y8YapfStJ6zSE23tzYPKxqKwQBnQoIO0BI/Q==",
+            "requires": {
+                "esbuild-android-64": "0.14.25",
+                "esbuild-android-arm64": "0.14.25",
+                "esbuild-darwin-64": "0.14.25",
+                "esbuild-darwin-arm64": "0.14.25",
+                "esbuild-freebsd-64": "0.14.25",
+                "esbuild-freebsd-arm64": "0.14.25",
+                "esbuild-linux-32": "0.14.25",
+                "esbuild-linux-64": "0.14.25",
+                "esbuild-linux-arm": "0.14.25",
+                "esbuild-linux-arm64": "0.14.25",
+                "esbuild-linux-mips64le": "0.14.25",
+                "esbuild-linux-ppc64le": "0.14.25",
+                "esbuild-linux-riscv64": "0.14.25",
+                "esbuild-linux-s390x": "0.14.25",
+                "esbuild-netbsd-64": "0.14.25",
+                "esbuild-openbsd-64": "0.14.25",
+                "esbuild-sunos-64": "0.14.25",
+                "esbuild-windows-32": "0.14.25",
+                "esbuild-windows-64": "0.14.25",
+                "esbuild-windows-arm64": "0.14.25"
+            }
+        },
+        "esbuild-android-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.25.tgz",
+            "integrity": "sha512-L5vCUk7TzFbBnoESNoXjU3x9+/+7TDIE/1mTfy/erAfvZAqC+S3sp/Qa9wkypFMcFvN9FzvESkTlpeQDolREtQ==",
+            "optional": true
+        },
+        "esbuild-android-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.25.tgz",
+            "integrity": "sha512-4jv5xPjM/qNm27T5j3ZEck0PvjgQtoMHnz4FzwF5zNP56PvY2CT0WStcAIl6jNlsuDdN63rk2HRBIsO6xFbcFw==",
+            "optional": true
+        },
+        "esbuild-darwin-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.25.tgz",
+            "integrity": "sha512-TGp8tuudIxOyWd1+8aYPxQmC1ZQyvij/AfNBa35RubixD0zJ1vkKHVAzo0Zao1zcG6pNqiSyzfPto8vmg0s7oA==",
+            "optional": true
+        },
+        "esbuild-darwin-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.25.tgz",
+            "integrity": "sha512-oTcDgdm0MDVEmw2DWu8BV68pYuImpFgvWREPErBZmNA4MYKGuBRaCiJqq6jZmBR1x+3y1DWCjez+5uLtuAm6mw==",
+            "optional": true
+        },
+        "esbuild-freebsd-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.25.tgz",
+            "integrity": "sha512-ueAqbnMZ8arnuLH8tHwTCQYeptnHOUV7vA6px6j4zjjQwDx7TdP7kACPf3TLZLdJQ3CAD1XCvQ2sPhX+8tacvQ==",
+            "optional": true
+        },
+        "esbuild-freebsd-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.25.tgz",
+            "integrity": "sha512-+ZVWud2HKh+Ob6k/qiJWjBtUg4KmJGGmbvEXXW1SNKS7hW7HU+Zq2ZCcE1akFxOPkVB+EhOty/sSek30tkCYug==",
+            "optional": true
+        },
+        "esbuild-linux-32": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.25.tgz",
+            "integrity": "sha512-3OP/lwV3kCzEz45tobH9nj+uE4ubhGsfx+tn0L26WAGtUbmmcRpqy7XRG/qK7h1mClZ+eguIANcQntYMdYklfw==",
+            "optional": true
+        },
+        "esbuild-linux-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.25.tgz",
+            "integrity": "sha512-+aKHdHZmX9qwVlQmu5xYXh7GsBFf4TWrePgeJTalhXHOG7NNuUwoHmketGiZEoNsWyyqwH9rE5BC+iwcLY30Ug==",
+            "optional": true
+        },
+        "esbuild-linux-arm": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.25.tgz",
+            "integrity": "sha512-aTLcE2VBoLydL943REcAcgnDi3bHtmULSXWLbjtBdtykRatJVSxKMjK9YlBXUZC4/YcNQfH7AxwVeQr9fNxPhw==",
+            "optional": true
+        },
+        "esbuild-linux-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.25.tgz",
+            "integrity": "sha512-UxfenPx/wSZx55gScCImPtXekvZQLI2GW3qe5dtlmU7luiqhp5GWPzGeQEbD3yN3xg/pHc671m5bma5Ns7lBHw==",
+            "optional": true
+        },
+        "esbuild-linux-mips64le": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.25.tgz",
+            "integrity": "sha512-wLWYyqVfYx9Ur6eU5RT92yJVsaBGi5RdkoWqRHOqcJ38Kn60QMlcghsKeWfe9jcYut8LangYZ98xO1LxIoSXrQ==",
+            "optional": true
+        },
+        "esbuild-linux-ppc64le": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.25.tgz",
+            "integrity": "sha512-0dR6Csl6Zas3g4p9ULckEl8Mo8IInJh33VCJ3eaV1hj9+MHGdmDOakYMN8MZP9/5nl+NU/0ygpd14cWgy8uqRw==",
+            "optional": true
+        },
+        "esbuild-linux-riscv64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.25.tgz",
+            "integrity": "sha512-J4d20HDmTrgvhR0bdkDhvvJGaikH3LzXQnNaseo8rcw9Yqby9A90gKUmWpfwqLVNRILvNnAmKLfBjCKU9ajg8w==",
+            "optional": true
+        },
+        "esbuild-linux-s390x": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.25.tgz",
+            "integrity": "sha512-YI2d5V6nTE73ZnhEKQD7MtsPs1EtUZJ3obS21oxQxGbbRw1G+PtJKjNyur+3t6nzHP9oTg6GHQ3S3hOLLmbDIQ==",
+            "optional": true
+        },
+        "esbuild-netbsd-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.25.tgz",
+            "integrity": "sha512-TKIVgNWLUOkr+Exrye70XTEE1lJjdQXdM4tAXRzfHE9iBA7LXWcNtVIuSnphTqpanPzTDFarF0yqq4kpbC6miA==",
+            "optional": true
+        },
+        "esbuild-openbsd-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.25.tgz",
+            "integrity": "sha512-QgFJ37A15D7NIXBTYEqz29+uw3nNBOIyog+3kFidANn6kjw0GHZ0lEYQn+cwjyzu94WobR+fes7cTl/ZYlHb1A==",
+            "optional": true
+        },
+        "esbuild-sunos-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.25.tgz",
+            "integrity": "sha512-rmWfjUItYIVlqr5EnTH1+GCxXiBOC42WBZ3w++qh7n2cS9Xo0lO5pGSG2N+huOU2fX5L+6YUuJ78/vOYvefeFw==",
+            "optional": true
+        },
+        "esbuild-windows-32": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.25.tgz",
+            "integrity": "sha512-HGAxVUofl3iUIz9W10Y9XKtD0bNsK9fBXv1D55N/ljNvkrAYcGB8YCm0v7DjlwtyS6ws3dkdQyXadbxkbzaKOA==",
+            "optional": true
+        },
+        "esbuild-windows-64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.25.tgz",
+            "integrity": "sha512-TirEohRkfWU9hXLgoDxzhMQD1g8I2mOqvdQF2RS9E/wbkORTAqJHyh7wqGRCQAwNzdNXdg3JAyhQ9/177AadWA==",
+            "optional": true
+        },
+        "esbuild-windows-arm64": {
+            "version": "0.14.25",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.25.tgz",
+            "integrity": "sha512-4ype9ERiI45rSh+R8qUoBtaj6kJvUOI7oVLhKqPEpcF4Pa5PpT3hm/mXAyotJHREkHpM87PAJcA442mLnbtlNA==",
+            "optional": true
+        },
+        "fs-extra": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+            "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+        },
+        "ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "iso-url": {
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
+            "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+            "dev": true
+        },
+        "js-sha256": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+            "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+        },
+        "json-text-sequence": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+            "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
+            "dev": true,
+            "requires": {
+                "delimit-stream": "0.1.0"
+            }
+        },
+        "jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+            }
+        },
+        "make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+        },
+        "readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true
+        },
+        "simple-cbor": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
+            "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "ts-node": {
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+            "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+            "dev": true,
+            "requires": {
+                "@cspotcode/source-map-support": "0.7.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.0",
+                "yn": "3.1.1"
+            }
+        },
+        "typescript": {
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+            "dev": true
+        },
+        "universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true
+        },
+        "v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true
+        },
+        "yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+        }
+    }
+}

--- a/examples/compiler_errors/mismatched_init_and_post_upgrade_params/package.json
+++ b/examples/compiler_errors/mismatched_init_and_post_upgrade_params/package.json
@@ -1,0 +1,13 @@
+{
+    "scripts": {
+        "test": "AZLE_REBUILD=true ts-node --transpile-only --ignore=false test/test.ts"
+    },
+    "dependencies": {
+        "azle": "0.16.3"
+    },
+    "devDependencies": {
+        "@dfinity/agent": "0.11.1",
+        "ts-node": "10.7.0",
+        "typescript": "4.6.3"
+    }
+}

--- a/examples/compiler_errors/mismatched_init_and_post_upgrade_params/src/index.ts
+++ b/examples/compiler_errors/mismatched_init_and_post_upgrade_params/src/index.ts
@@ -1,0 +1,11 @@
+import { $init, $postUpgrade, int32 } from 'azle';
+
+$init;
+export function init(p1: boolean, p2: string, p3: int32): void {
+    console.log('Initialization complete.');
+}
+
+$postUpgrade;
+export function postUpgrade(p1: int32, p2: boolean): void {
+    console.log('PostUpgrade complete.');
+}

--- a/examples/compiler_errors/mismatched_init_and_post_upgrade_params/test/test.ts
+++ b/examples/compiler_errors/mismatched_init_and_post_upgrade_params/test/test.ts
@@ -1,0 +1,4 @@
+import { runTests } from 'azle/test';
+import { getTests } from './tests';
+
+runTests(getTests());

--- a/examples/compiler_errors/mismatched_init_and_post_upgrade_params/test/tests.ts
+++ b/examples/compiler_errors/mismatched_init_and_post_upgrade_params/test/tests.ts
@@ -1,0 +1,68 @@
+import { execSync } from 'child_process';
+import { Test } from 'azle/test';
+
+interface ExecSyncError extends Error {
+    status: number;
+    signal: string;
+    output: Buffer[];
+    pid: number;
+    stdout: Buffer;
+    stderr: Buffer;
+}
+
+export function getTests(): Test[] {
+    return [
+        {
+            name: 'Using mismatched params in $init and $postUpgrade causes a compilation-time error',
+            test: async () => {
+                try {
+                    execSync(`npx azle canister`, { stdio: 'pipe' });
+
+                    return {
+                        Err: 'Expected the build to fail but it succeeded'
+                    };
+                } catch (e: any) {
+                    let stdErr = (e as ExecSyncError).stderr.toString();
+
+                    if (stdErr.includes(expectedError)) {
+                        return { Ok: true };
+                    } else {
+                        return {
+                            Err: unexpectedErrorMessage(expectedError, stdErr)
+                        };
+                    }
+                }
+            }
+        }
+    ];
+}
+
+const expectedError = `error: params for $init and $postUpgrade must be exactly the same
+  --> ./src/index.ts:4:17
+   |
+ 4 |   export function init(p1: boolean, p2: string, p3: int32): void {
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ these params
+...
+ 9 |   export function postUpgrade(p1: int32, p2: boolean): void {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^ and these params do not match
+   |
+help: update the params for either init or postUpgrade to match the other. E.g.:
+   |
+ 4 |   export function init(p1: boolean, p2: string, p3: int32): void {
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ copy these params
+...
+ 9 |   export function postUpgrade(p1: boolean, p2: string, p3: int32): void {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ to here
+   |`;
+
+function unexpectedErrorMessage(expectedError: string, stdErr: string) {
+    return `>  The output from std err does not contain the expected error
+
+Expected Error:
+
+${expectedError}
+
+ActualError:
+
+${stdErr}`;
+}

--- a/examples/compiler_errors/mismatched_init_and_post_upgrade_params/test/tests.ts
+++ b/examples/compiler_errors/mismatched_init_and_post_upgrade_params/test/tests.ts
@@ -16,29 +16,18 @@ export function getTests(): Test[] {
             name: 'Using mismatched params in $init and $postUpgrade causes a compilation-time error',
             test: async () => {
                 try {
-                    execSync(`npx azle canister`, { stdio: 'pipe' });
+                    execSync(`dfx deploy`, { stdio: 'pipe' });
 
                     return {
-                        Err: 'Expected the build to fail but it succeeded'
+                        Err: 'Expected the deploy to fail but it succeeded'
                     };
                 } catch (e: any) {
-                    let stdErr = (e as ExecSyncError).stderr.toString();
+                    const stdErr = (e as ExecSyncError).stderr.toString();
+                    const expectedError = `error: params for $init and $postUpgrade must be exactly the same`;
 
-                    if (!stdErr.includes(expectedErrorTitle)) {
+                    if (!stdErr.includes(expectedError)) {
                         return {
-                            Err: unexpectedErrorMessage(
-                                expectedErrorTitle,
-                                stdErr
-                            )
-                        };
-                    }
-
-                    if (!expectedErrorKeywords.test(stdErr)) {
-                        return {
-                            Err: unexpectedErrorMessage(
-                                expectedErrorKeywords,
-                                stdErr
-                            )
+                            Err: unexpectedErrorMessage(expectedError, stdErr)
                         };
                     }
 
@@ -48,10 +37,6 @@ export function getTests(): Test[] {
         }
     ];
 }
-
-const expectedErrorTitle = `error: params for $init and $postUpgrade must be exactly the same`;
-
-const expectedErrorKeywords = /these params.*and these params do not match/s;
 
 function unexpectedErrorMessage(
     expectedError: string | RegExp,

--- a/examples/compiler_errors/mismatched_init_and_post_upgrade_params/test/tests.ts
+++ b/examples/compiler_errors/mismatched_init_and_post_upgrade_params/test/tests.ts
@@ -24,38 +24,39 @@ export function getTests(): Test[] {
                 } catch (e: any) {
                     let stdErr = (e as ExecSyncError).stderr.toString();
 
-                    if (stdErr.includes(expectedError)) {
-                        return { Ok: true };
-                    } else {
+                    if (!stdErr.includes(expectedErrorTitle)) {
                         return {
-                            Err: unexpectedErrorMessage(expectedError, stdErr)
+                            Err: unexpectedErrorMessage(
+                                expectedErrorTitle,
+                                stdErr
+                            )
                         };
                     }
+
+                    if (!expectedErrorKeywords.test(stdErr)) {
+                        return {
+                            Err: unexpectedErrorMessage(
+                                expectedErrorKeywords,
+                                stdErr
+                            )
+                        };
+                    }
+
+                    return { Ok: true };
                 }
             }
         }
     ];
 }
 
-const expectedError = `error: params for $init and $postUpgrade must be exactly the same
-  --> ./src/index.ts:4:17
-   |
- 4 |   export function init(p1: boolean, p2: string, p3: int32): void {
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ these params
-...
- 9 |   export function postUpgrade(p1: int32, p2: boolean): void {
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^ and these params do not match
-   |
-help: update the params for either init or postUpgrade to match the other. E.g.:
-   |
- 4 |   export function init(p1: boolean, p2: string, p3: int32): void {
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ copy these params
-...
- 9 |   export function postUpgrade(p1: boolean, p2: string, p3: int32): void {
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ to here
-   |`;
+const expectedErrorTitle = `error: params for $init and $postUpgrade must be exactly the same`;
 
-function unexpectedErrorMessage(expectedError: string, stdErr: string) {
+const expectedErrorKeywords = /these params.*and these params do not match/s;
+
+function unexpectedErrorMessage(
+    expectedError: string | RegExp,
+    stdErr: string
+) {
     return `>  The output from std err does not contain the expected error
 
 Expected Error:

--- a/examples/compiler_errors/mismatched_init_and_post_upgrade_params/tsconfig.json
+++ b/examples/compiler_errors/mismatched_init_and_post_upgrade_params/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "target": "ES2020",
+        "experimentalDecorators": true,
+        "strictPropertyInitialization": false,
+        "moduleResolution": "node",
+        "allowJs": true,
+        "outDir": "HACK_BECAUSE_OF_ALLOW_JS"
+    }
+}

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/errors/mismatched_post_deploy_params.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/errors/mismatched_post_deploy_params.rs
@@ -1,16 +1,15 @@
-use annotate_snippets::{
-    display_list::{DisplayList, FormatOptions},
-    snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
-};
-use swc_common::{source_map::Pos, BytePos, Span};
+use swc_common::Span;
 
-use crate::{
-    canister_method::AnnotatedFnDecl,
-    traits::GetSourceFileInfo,
-    ts_ast::{source_map::Range, SourceMapped},
-};
+use crate::{canister_method::AnnotatedFnDecl, traits::GetSourceFileInfo, ts_ast::SourceMapped};
 
 pub type SmAnFnDecl<'a> = SourceMapped<'a, AnnotatedFnDecl>;
+
+// TODO: This error message needs snippets and nice formatting. The commented-out code in this file
+// is mostly correct, but doesn't work if the init and postUpgrade functions are declared in
+// separate files.
+//
+// This is a good starting point though so you can just uncomment this to pick up where I left off.
+// Also look back through the commits to see what it was like before I settled for the simple msg.
 
 /// Returned when Azle detects a difference between the params in $init and $postUpgrade
 ///
@@ -33,81 +32,106 @@ pub type SmAnFnDecl<'a> = SourceMapped<'a, AnnotatedFnDecl>;
 pub struct MismatchedPostDeployParams {
     pub origin: String,
     pub line_number: usize,
-    pub source: String,
-    pub ranges: Vec<(usize, usize)>,
+    // pub source: String, // TODO: Add back in for very nice error message
+    // pub ranges: Vec<(usize, usize)>, // TODO: Add back in for very nice error message
 }
 
 impl MismatchedPostDeployParams {
     pub fn from_annotated_fn_decls(
         init_fn_decl: &SmAnFnDecl,
-        post_upgrade_fn_decl: &SmAnFnDecl,
+        _post_upgrade_fn_decl: &SmAnFnDecl,
     ) -> Self {
-        // TODO: Might this be a problem if the fn_decls come from different
-        // typescript files?
         let source_map = init_fn_decl.source_map;
-
-        let ordered_fn_decls = order_fn_decls(init_fn_decl, post_upgrade_fn_decl);
-
-        let total_range = get_total_range(ordered_fn_decls);
-        let source = source_map.get_source_from_range(total_range);
-
-        let first_span = get_first_span(ordered_fn_decls);
-
-        let line_number = source_map.get_line_number(first_span);
-        let origin = source_map.get_origin(first_span);
-        let offset = total_range.0.to_usize() - source_map.get_range(first_span).0;
-
-        let ranges = get_ranges(ordered_fn_decls, offset);
+        let init_fn_decl_params_span = get_span(init_fn_decl);
+        let line_number = source_map.get_line_number(init_fn_decl_params_span);
+        let origin = source_map.get_origin(init_fn_decl_params_span);
 
         Self {
             origin,
             line_number,
-            source,
-            ranges,
         }
     }
 
     pub fn to_string(&self) -> String {
-        let error_snippet = Snippet {
-            title: Some(Annotation {
-                label: Some("params for $init and $postUpgrade must be exactly the same"),
-                id: None,
-                annotation_type: AnnotationType::Error,
-            }),
-            slices: vec![Slice {
-                source: &self.source,
-                line_start: self.line_number,
-                origin: Some(&self.origin),
-                fold: true,
-                annotations: vec![
-                    SourceAnnotation {
-                        label: "these params",
-                        annotation_type: AnnotationType::Error,
-                        range: self.ranges[0],
-                    },
-                    SourceAnnotation {
-                        label: "and these params do not match",
-                        annotation_type: AnnotationType::Error,
-                        range: self.ranges[1],
-                    },
-                ],
-            }],
-            footer: vec![Annotation {
-                label: Some(
-                    "update the params for either $init or $postUpgrade to match the other",
-                ),
-                id: None,
-                annotation_type: AnnotationType::Help,
-            }],
-            opt: FormatOptions {
-                color: true,
-                ..Default::default()
-            },
-        };
-
-        format!("{}", DisplayList::from(error_snippet))
+        format!(
+            "error: params for $init and $postUpgrade must be exactly the same\n  --> {}:{}",
+            self.origin, self.line_number
+        )
     }
 }
+
+// TODO: Change to this impl when adding snippets and making this a very nice error message
+// impl MismatchedPostDeployParams {
+//     pub fn from_annotated_fn_decls(
+//         init_fn_decl: &SmAnFnDecl,
+//         post_upgrade_fn_decl: &SmAnFnDecl,
+//     ) -> Self {
+//         // TODO: Might this be a problem if the fn_decls come from different
+//         // typescript files?
+//         let source_map = init_fn_decl.source_map;
+
+//         let ordered_fn_decls = order_fn_decls(init_fn_decl, post_upgrade_fn_decl);
+
+//         let total_range = get_total_range(ordered_fn_decls);
+//         let source = source_map.get_source_from_range(total_range);
+
+//         let first_span = get_first_span(ordered_fn_decls);
+
+//         let line_number = source_map.get_line_number(first_span);
+//         let origin = source_map.get_origin(first_span);
+//         let offset = total_range.0.to_usize() - source_map.get_range(first_span).0;
+
+//         let ranges = get_ranges(ordered_fn_decls, offset);
+
+//         Self {
+//             origin,
+//             line_number,
+//             source,
+//             ranges,
+//         }
+//     }
+
+//     pub fn to_string(&self) -> String {
+//         let error_snippet = Snippet {
+//             title: Some(Annotation {
+//                 label: Some("params for $init and $postUpgrade must be exactly the same"),
+//                 id: None,
+//                 annotation_type: AnnotationType::Error,
+//             }),
+//             slices: vec![Slice {
+//                 source: &self.source,
+//                 line_start: self.line_number,
+//                 origin: Some(&self.origin),
+//                 fold: true,
+//                 annotations: vec![
+//                     SourceAnnotation {
+//                         label: "these params",
+//                         annotation_type: AnnotationType::Error,
+//                         range: self.ranges[0],
+//                     },
+//                     SourceAnnotation {
+//                         label: "and these params do not match",
+//                         annotation_type: AnnotationType::Error,
+//                         range: self.ranges[1],
+//                     },
+//                 ],
+//             }],
+//             footer: vec![Annotation {
+//                 label: Some(
+//                     "update the params for either $init or $postUpgrade to match the other",
+//                 ),
+//                 id: None,
+//                 annotation_type: AnnotationType::Help,
+//             }],
+//             opt: FormatOptions {
+//                 color: true,
+//                 ..Default::default()
+//             },
+//         };
+
+//         format!("{}", DisplayList::from(error_snippet))
+//     }
+// }
 
 impl std::error::Error for MismatchedPostDeployParams {}
 
@@ -129,92 +153,104 @@ impl From<MismatchedPostDeployParams> for Vec<crate::Error> {
     }
 }
 
-fn order_fn_decls<'a>(
-    a: &'a SmAnFnDecl<'a>,
-    b: &'a SmAnFnDecl<'a>,
-) -> (&'a SmAnFnDecl<'a>, &'a SmAnFnDecl<'a>) {
-    let a_start_byte_pos = get_start_byte_pos(a);
-    let b_start_byte_pos = get_start_byte_pos(b);
+// TODO: Uncomment all these functions when adding snippets to make this a very nice error message
+// fn order_fn_decls<'a>(
+//     a: &'a SmAnFnDecl<'a>,
+//     b: &'a SmAnFnDecl<'a>,
+// ) -> (&'a SmAnFnDecl<'a>, &'a SmAnFnDecl<'a>) {
+//     let a_start_byte_pos = get_start_byte_pos(a);
+//     let b_start_byte_pos = get_start_byte_pos(b);
 
-    if a_start_byte_pos.lt(&b_start_byte_pos) {
-        (a, b)
-    } else {
-        (b, a)
-    }
-}
+//     if a_start_byte_pos.lt(&b_start_byte_pos) {
+//         (a, b)
+//     } else {
+//         (b, a)
+//     }
+// }
 
-fn get_start_byte_pos(sm_an_fn_decl: &SmAnFnDecl) -> BytePos {
-    let params = &sm_an_fn_decl.fn_decl.function.params;
+// fn get_start_byte_pos(sm_an_fn_decl: &SmAnFnDecl) -> BytePos {
+//     let params = &sm_an_fn_decl.fn_decl.function.params;
+
+//     if params.len() == 0 {
+//         return sm_an_fn_decl.fn_decl.ident.span.lo;
+//     }
+
+//     let first_param_span = params[0].span;
+
+//     first_param_span.lo
+// }
+
+// fn get_end_byte_pos(sm_an_fn_decl: &SmAnFnDecl) -> BytePos {
+//     let params = &sm_an_fn_decl.fn_decl.function.params;
+
+//     if params.len() == 0 {
+//         return sm_an_fn_decl.fn_decl.ident.span.hi;
+//     }
+
+//     let last_param_span = params[params.len() - 1].span;
+
+//     last_param_span.hi
+// }
+
+// fn get_total_range(ordered_fn_decls: (&SmAnFnDecl, &SmAnFnDecl)) -> (BytePos, BytePos) {
+//     let first_fn_decl = ordered_fn_decls.0;
+//     let last_fn_decl = ordered_fn_decls.1;
+
+//     let start_byte_pos = get_start_byte_pos(first_fn_decl);
+//     let end_byte_pos = get_end_byte_pos(last_fn_decl);
+
+//     (start_byte_pos, end_byte_pos)
+// }
+
+// fn get_first_span(ordered_fn_decls: (&SmAnFnDecl, &SmAnFnDecl)) -> Span {
+//     let first_fn_decl = ordered_fn_decls.0;
+
+//     let params = &first_fn_decl.fn_decl.function.params;
+
+//     if params.len() == 0 {
+//         return first_fn_decl.fn_decl.ident.span;
+//     }
+
+//     params[0].span
+// }
+
+// fn get_ranges(ordered_fn_decls: (&SmAnFnDecl, &SmAnFnDecl), offset: usize) -> Vec<Range> {
+//     let first_fn_decl = ordered_fn_decls.0;
+//     let last_fn_decl = ordered_fn_decls.1;
+
+//     vec![
+//         get_range(first_fn_decl, offset),
+//         get_range(last_fn_decl, offset),
+//     ]
+// }
+
+// fn get_range(sm_an_fn_decl: &SmAnFnDecl, offset: usize) -> Range {
+//     let params = &sm_an_fn_decl.fn_decl.function.params;
+
+//     let range: Range = if params.len() == 0 {
+//         let span = sm_an_fn_decl.fn_decl.ident.span;
+
+//         (span.lo.to_usize(), span.hi.to_usize())
+//     } else {
+//         let first_param_span = params[0].span;
+//         let last_param_span = params[params.len() - 1].span;
+
+//         (
+//             first_param_span.lo.to_usize(),
+//             last_param_span.hi.to_usize(),
+//         )
+//     };
+
+//     (range.0 - offset, range.1 - offset)
+// }
+
+// TODO: This function is not needed when making a very nice error message
+fn get_span(fn_decl: &SmAnFnDecl) -> Span {
+    let params = &fn_decl.fn_decl.function.params;
 
     if params.len() == 0 {
-        return sm_an_fn_decl.fn_decl.ident.span.lo;
-    }
-
-    let first_param_span = params[0].span;
-
-    first_param_span.lo
-}
-
-fn get_end_byte_pos(sm_an_fn_decl: &SmAnFnDecl) -> BytePos {
-    let params = &sm_an_fn_decl.fn_decl.function.params;
-
-    if params.len() == 0 {
-        return sm_an_fn_decl.fn_decl.ident.span.hi;
-    }
-
-    let last_param_span = params[params.len() - 1].span;
-
-    last_param_span.hi
-}
-
-fn get_total_range(ordered_fn_decls: (&SmAnFnDecl, &SmAnFnDecl)) -> (BytePos, BytePos) {
-    let first_fn_decl = ordered_fn_decls.0;
-    let last_fn_decl = ordered_fn_decls.1;
-
-    let start_byte_pos = get_start_byte_pos(first_fn_decl);
-    let end_byte_pos = get_end_byte_pos(last_fn_decl);
-
-    (start_byte_pos, end_byte_pos)
-}
-
-fn get_first_span(ordered_fn_decls: (&SmAnFnDecl, &SmAnFnDecl)) -> Span {
-    let first_fn_decl = ordered_fn_decls.0;
-
-    let params = &first_fn_decl.fn_decl.function.params;
-
-    if params.len() == 0 {
-        return first_fn_decl.fn_decl.ident.span;
+        return fn_decl.fn_decl.ident.span;
     }
 
     params[0].span
-}
-
-fn get_ranges(ordered_fn_decls: (&SmAnFnDecl, &SmAnFnDecl), offset: usize) -> Vec<Range> {
-    let first_fn_decl = ordered_fn_decls.0;
-    let last_fn_decl = ordered_fn_decls.1;
-
-    vec![
-        get_range(first_fn_decl, offset),
-        get_range(last_fn_decl, offset),
-    ]
-}
-
-fn get_range(sm_an_fn_decl: &SmAnFnDecl, offset: usize) -> Range {
-    let params = &sm_an_fn_decl.fn_decl.function.params;
-
-    let range: Range = if params.len() == 0 {
-        let span = sm_an_fn_decl.fn_decl.ident.span;
-
-        (span.lo.to_usize(), span.hi.to_usize())
-    } else {
-        let first_param_span = params[0].span;
-        let last_param_span = params[params.len() - 1].span;
-
-        (
-            first_param_span.lo.to_usize(),
-            last_param_span.hi.to_usize(),
-        )
-    };
-
-    (range.0 - offset, range.1 - offset)
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/errors/mismatched_post_deploy_params.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/errors/mismatched_post_deploy_params.rs
@@ -2,9 +2,15 @@ use annotate_snippets::{
     display_list::{DisplayList, FormatOptions},
     snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
 };
-use swc_common::source_map::Pos;
+use swc_common::{source_map::Pos, BytePos, Span};
 
-use crate::{canister_method::AnnotatedFnDecl, traits::GetSourceFileInfo, ts_ast::SourceMapped};
+use crate::{
+    canister_method::AnnotatedFnDecl,
+    traits::GetSourceFileInfo,
+    ts_ast::{source_map::Range, SourceMapped},
+};
+
+pub type SmAnFnDecl<'a> = SourceMapped<'a, AnnotatedFnDecl>;
 
 /// Returned when Azle detects a difference between the params in $init and $postUpgrade
 ///
@@ -33,31 +39,25 @@ pub struct MismatchedPostDeployParams {
 
 impl MismatchedPostDeployParams {
     pub fn from_annotated_fn_decls(
-        init_fn_decl: &SourceMapped<AnnotatedFnDecl>,
-        post_upgrade_fn_decl: &SourceMapped<AnnotatedFnDecl>,
+        init_fn_decl: &SmAnFnDecl,
+        post_upgrade_fn_decl: &SmAnFnDecl,
     ) -> Self {
         // TODO: Might this be a problem if the fn_decls come from different
         // typescript files?
         let source_map = init_fn_decl.source_map;
 
-        let init_span = init_fn_decl.fn_decl.function.span;
-        let post_upgrade_span = post_upgrade_fn_decl.fn_decl.function.span;
+        let ordered_fn_decls = order_fn_decls(init_fn_decl, post_upgrade_fn_decl);
 
-        // TODO: What if post_upgrade is before init?
-        // Consider checking for the bigger/smaller of the two
-        let total_range = (init_span.lo, post_upgrade_span.hi);
-
+        let total_range = get_total_range(ordered_fn_decls);
         let source = source_map.get_source_from_range(total_range);
 
-        let first_occurrence = init_span;
-        let line_number = source_map.get_line_number(first_occurrence);
-        let origin = source_map.get_origin(first_occurrence);
-        let offset = total_range.0.to_usize() - source_map.get_range(first_occurrence).0;
+        let first_span = get_first_span(ordered_fn_decls);
 
-        let ranges = vec![
-            source_map.get_multi_line_range(&init_span, offset),
-            source_map.get_multi_line_range(&post_upgrade_span, offset),
-        ];
+        let line_number = source_map.get_line_number(first_span);
+        let origin = source_map.get_origin(first_span);
+        let offset = total_range.0.to_usize() - source_map.get_range(first_span).0;
+
+        let ranges = get_ranges(ordered_fn_decls, offset);
 
         Self {
             origin,
@@ -121,4 +121,100 @@ impl From<MismatchedPostDeployParams> for crate::Error {
     fn from(error: MismatchedPostDeployParams) -> Self {
         Self::MismatchedPostDeployParams(error)
     }
+}
+
+impl From<MismatchedPostDeployParams> for Vec<crate::Error> {
+    fn from(error: MismatchedPostDeployParams) -> Self {
+        vec![crate::Error::MismatchedPostDeployParams(error)]
+    }
+}
+
+fn order_fn_decls<'a>(
+    a: &'a SmAnFnDecl<'a>,
+    b: &'a SmAnFnDecl<'a>,
+) -> (&'a SmAnFnDecl<'a>, &'a SmAnFnDecl<'a>) {
+    let a_start_byte_pos = get_start_byte_pos(a);
+    let b_start_byte_pos = get_start_byte_pos(b);
+
+    if a_start_byte_pos.lt(&b_start_byte_pos) {
+        (a, b)
+    } else {
+        (b, a)
+    }
+}
+
+fn get_start_byte_pos(sm_an_fn_decl: &SmAnFnDecl) -> BytePos {
+    let params = &sm_an_fn_decl.fn_decl.function.params;
+
+    if params.len() == 0 {
+        return sm_an_fn_decl.fn_decl.ident.span.lo;
+    }
+
+    let first_param_span = params[0].span;
+
+    first_param_span.lo
+}
+
+fn get_end_byte_pos(sm_an_fn_decl: &SmAnFnDecl) -> BytePos {
+    let params = &sm_an_fn_decl.fn_decl.function.params;
+
+    if params.len() == 0 {
+        return sm_an_fn_decl.fn_decl.ident.span.hi;
+    }
+
+    let last_param_span = params[params.len() - 1].span;
+
+    last_param_span.hi
+}
+
+fn get_total_range(ordered_fn_decls: (&SmAnFnDecl, &SmAnFnDecl)) -> (BytePos, BytePos) {
+    let first_fn_decl = ordered_fn_decls.0;
+    let last_fn_decl = ordered_fn_decls.1;
+
+    let start_byte_pos = get_start_byte_pos(first_fn_decl);
+    let end_byte_pos = get_end_byte_pos(last_fn_decl);
+
+    (start_byte_pos, end_byte_pos)
+}
+
+fn get_first_span(ordered_fn_decls: (&SmAnFnDecl, &SmAnFnDecl)) -> Span {
+    let first_fn_decl = ordered_fn_decls.0;
+
+    let params = &first_fn_decl.fn_decl.function.params;
+
+    if params.len() == 0 {
+        return first_fn_decl.fn_decl.ident.span;
+    }
+
+    params[0].span
+}
+
+fn get_ranges(ordered_fn_decls: (&SmAnFnDecl, &SmAnFnDecl), offset: usize) -> Vec<Range> {
+    let first_fn_decl = ordered_fn_decls.0;
+    let last_fn_decl = ordered_fn_decls.1;
+
+    vec![
+        get_range(first_fn_decl, offset),
+        get_range(last_fn_decl, offset),
+    ]
+}
+
+fn get_range(sm_an_fn_decl: &SmAnFnDecl, offset: usize) -> Range {
+    let params = &sm_an_fn_decl.fn_decl.function.params;
+
+    let range: Range = if params.len() == 0 {
+        let span = sm_an_fn_decl.fn_decl.ident.span;
+
+        (span.lo.to_usize(), span.hi.to_usize())
+    } else {
+        let first_param_span = params[0].span;
+        let last_param_span = params[params.len() - 1].span;
+
+        (
+            first_param_span.lo.to_usize(),
+            last_param_span.hi.to_usize(),
+        )
+    };
+
+    (range.0 - offset, range.1 - offset)
 }

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/errors/mismatched_post_deploy_params.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/errors/mismatched_post_deploy_params.rs
@@ -1,0 +1,124 @@
+use annotate_snippets::{
+    display_list::{DisplayList, FormatOptions},
+    snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
+};
+use swc_common::source_map::Pos;
+
+use crate::{canister_method::AnnotatedFnDecl, traits::GetSourceFileInfo, ts_ast::SourceMapped};
+
+/// Returned when Azle detects a difference between the params in $init and $postUpgrade
+///
+/// # Example
+///
+/// ```ts
+/// import { $init, $postUpgrade, int32 } from 'azle';
+///
+/// $init;
+/// export function init(p1: boolean, p2: string, p3: int32): void {
+///     console.log('Initialization complete.');
+/// }
+///
+/// $postUpgrade;
+/// export function postUpgrade(p1: int32, p2: boolean): void {
+///     console.log('PostUpgrade complete.');
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MismatchedPostDeployParams {
+    pub origin: String,
+    pub line_number: usize,
+    pub source: String,
+    pub ranges: Vec<(usize, usize)>,
+}
+
+impl MismatchedPostDeployParams {
+    pub fn from_annotated_fn_decls(
+        init_fn_decl: &SourceMapped<AnnotatedFnDecl>,
+        post_upgrade_fn_decl: &SourceMapped<AnnotatedFnDecl>,
+    ) -> Self {
+        // TODO: Might this be a problem if the fn_decls come from different
+        // typescript files?
+        let source_map = init_fn_decl.source_map;
+
+        let init_span = init_fn_decl.fn_decl.function.span;
+        let post_upgrade_span = post_upgrade_fn_decl.fn_decl.function.span;
+
+        // TODO: What if post_upgrade is before init?
+        // Consider checking for the bigger/smaller of the two
+        let total_range = (init_span.lo, post_upgrade_span.hi);
+
+        let source = source_map.get_source_from_range(total_range);
+
+        let first_occurrence = init_span;
+        let line_number = source_map.get_line_number(first_occurrence);
+        let origin = source_map.get_origin(first_occurrence);
+        let offset = total_range.0.to_usize() - source_map.get_range(first_occurrence).0;
+
+        let ranges = vec![
+            source_map.get_multi_line_range(&init_span, offset),
+            source_map.get_multi_line_range(&post_upgrade_span, offset),
+        ];
+
+        Self {
+            origin,
+            line_number,
+            source,
+            ranges,
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let error_snippet = Snippet {
+            title: Some(Annotation {
+                label: Some("params for $init and $postUpgrade must be exactly the same"),
+                id: None,
+                annotation_type: AnnotationType::Error,
+            }),
+            slices: vec![Slice {
+                source: &self.source,
+                line_start: self.line_number,
+                origin: Some(&self.origin),
+                fold: true,
+                annotations: vec![
+                    SourceAnnotation {
+                        label: "these params",
+                        annotation_type: AnnotationType::Error,
+                        range: self.ranges[0],
+                    },
+                    SourceAnnotation {
+                        label: "and these params do not match",
+                        annotation_type: AnnotationType::Error,
+                        range: self.ranges[1],
+                    },
+                ],
+            }],
+            footer: vec![Annotation {
+                label: Some(
+                    "update the params for either $init or $postUpgrade to match the other",
+                ),
+                id: None,
+                annotation_type: AnnotationType::Help,
+            }],
+            opt: FormatOptions {
+                color: true,
+                ..Default::default()
+            },
+        };
+
+        format!("{}", DisplayList::from(error_snippet))
+    }
+}
+
+impl std::error::Error for MismatchedPostDeployParams {}
+
+impl std::fmt::Display for MismatchedPostDeployParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.to_string())
+    }
+}
+
+impl From<MismatchedPostDeployParams> for crate::Error {
+    fn from(error: MismatchedPostDeployParams) -> Self {
+        Self::MismatchedPostDeployParams(error)
+    }
+}

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/errors/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/errors/mod.rs
@@ -5,12 +5,14 @@ use crate::{canister_method::AnnotatedFnDecl, ts_ast::SourceMapped};
 pub use async_not_allowed::AsyncNotAllowed;
 pub use duplicate_system_method::DuplicateSystemMethod;
 pub use extraneous_canister_method_annotation::ExtraneousCanisterMethodAnnotation;
+pub use mismatched_post_deploy_params::MismatchedPostDeployParams;
 pub use missing_return_type::MissingReturnTypeAnnotation;
 pub use void_return_type_required::VoidReturnTypeRequired;
 
 mod async_not_allowed;
 mod duplicate_system_method;
 mod extraneous_canister_method_annotation;
+mod mismatched_post_deploy_params;
 mod missing_return_type;
 mod void_return_type_required;
 

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/mod.rs
@@ -1,6 +1,7 @@
 use cdk_framework::{act::CanisterMethods, traits::CollectResults};
 
 use crate::{plugin::Plugin, ts_ast::TsAst, Error};
+use validations::ensure_init_and_post_upgrade_params_match;
 
 pub use annotated_fn_decl::{AnnotatedFnDecl, GetAnnotatedFnDecls};
 pub use annotation::Annotation;
@@ -16,6 +17,7 @@ mod post_upgrade;
 mod pre_upgrade;
 mod query_and_update;
 mod rust;
+mod validations;
 
 pub mod errors;
 pub mod module;
@@ -55,6 +57,8 @@ impl TsAst {
                     query_methods,
                     update_methods,
                 ) = canister_methods;
+
+                ensure_init_and_post_upgrade_params_match(&annotated_fn_decls)?;
 
                 Ok(CanisterMethods {
                     heartbeat_method,

--- a/src/compiler/typescript_to_rust/azle_generate/src/canister_method/validations.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/canister_method/validations.rs
@@ -1,0 +1,51 @@
+use crate::{
+    canister_method::{errors::MismatchedPostDeployParams, AnnotatedFnDecl},
+    ts_ast::SourceMapped,
+};
+use swc_ecma_ast::Param;
+
+pub fn ensure_init_and_post_upgrade_params_match(
+    annotated_fn_decls: &Vec<SourceMapped<AnnotatedFnDecl>>,
+) -> Result<(), MismatchedPostDeployParams> {
+    let init_params = get_init_params(&annotated_fn_decls);
+    let post_upgrade_params = get_post_upgrade_params(&annotated_fn_decls);
+
+    if are_param_vecs_equivalent(&init_params, &post_upgrade_params) {
+        return Ok(());
+    } else {
+        Err(create_err(&annotated_fn_decls))
+    }
+}
+
+fn get_init_params(_annotated_fn_decls: &Vec<SourceMapped<AnnotatedFnDecl>>) -> Vec<Param> {
+    vec![]
+}
+
+fn get_post_upgrade_params(_annotated_fn_decls: &Vec<SourceMapped<AnnotatedFnDecl>>) -> Vec<Param> {
+    vec![]
+}
+
+fn create_err(
+    annotated_fn_decls: &Vec<SourceMapped<AnnotatedFnDecl>>,
+) -> MismatchedPostDeployParams {
+    MismatchedPostDeployParams::from_annotated_fn_decls(
+        &annotated_fn_decls[0],
+        &annotated_fn_decls[1],
+    )
+}
+
+fn are_param_vecs_equivalent(_a: &Vec<Param>, _b: &Vec<Param>) -> bool {
+    return false;
+
+    // if a.len() != b.len() {
+    //     return false;
+    // }
+
+    // a.iter()
+    //     .zip(b.iter())
+    //     .all(|(a_param, b_param)| are_params_equivalent(a_param, b_param))
+}
+
+// fn are_params_equivalent(a: &Param, b: &Param) -> bool {
+//     false
+// }

--- a/src/compiler/typescript_to_rust/azle_generate/src/errors/mod.rs
+++ b/src/compiler/typescript_to_rust/azle_generate/src/errors/mod.rs
@@ -43,7 +43,7 @@ use crate::{
         annotated_fn_decl::errors::{MissingReturnType, ParamDefaultValue, UntypedParam},
         errors::{
             AsyncNotAllowed, DuplicateSystemMethod, ExtraneousCanisterMethodAnnotation,
-            MissingReturnTypeAnnotation, VoidReturnTypeRequired,
+            MismatchedPostDeployParams, MissingReturnTypeAnnotation, VoidReturnTypeRequired,
         },
     },
     ts_ast::{
@@ -114,6 +114,7 @@ pub enum Error {
     MultipleTypeDefinitions(MultipleTypeDefinitions),
     MultipleGuardFunctionDefinitions(MultipleGuardFunctionDefinitions),
     MultipleCanisterMethodDefinitions(MultipleCanisterMethodDefinitions),
+    MismatchedPostDeployParams(MismatchedPostDeployParams),
 }
 
 impl std::error::Error for Error {}
@@ -174,6 +175,7 @@ impl Error {
             Self::MultipleTypeDefinitions(e) => e,
             Self::MultipleGuardFunctionDefinitions(e) => e,
             Self::MultipleCanisterMethodDefinitions(e) => e,
+            Self::MismatchedPostDeployParams(e) => e,
         }
     }
 }


### PR DESCRIPTION
This adds a compilation-time check to ensure that the params for init and post-upgrade are of the same length. If they differ in length then an error is returned to the user. If they are of the same length then no error occurs.

This does not check they types of the params. Checking the types will require deep knowledge of each type reference, including which file it's from etc. and is not tackled as part of this PR. See https://github.com/demergent-labs/azle/issues/1095#issuecomment-1663364443 for more information.

Closes #1095 