### PR TITLE
Fix caller

### DIFF
--- a/src/compiler/typescript_to_rust/azle_generate_rearchitecture/src/ic/stable_b_tree_map_init.rs
+++ b/src/compiler/typescript_to_rust/azle_generate_rearchitecture/src/ic/stable_b_tree_map_init.rs
@@ -15,7 +15,7 @@ pub fn generate() -> TokenStream {
                 let mut stable_b_tree_maps = stable_b_tree_maps.borrow_mut();
                 stable_b_tree_maps.insert(
                     memory_id,
-                    StableBTreeMap::init_v2(MEMORY_MANAGER_REF_CELL.with(|m| m.borrow().get(MemoryId::new(memory_id))),)
+                    StableBTreeMap::init(MEMORY_MANAGER_REF_CELL.with(|m| m.borrow().get(MemoryId::new(memory_id))),)
                 );
             });
 

--- a/src/lib_new/ic.ts
+++ b/src/lib_new/ic.ts
@@ -564,7 +564,7 @@ export const ic: Ic = globalThis._azleIc
           },
           caller: () => {
               const callerBytes = globalThis._azleIc.caller();
-              return Principal.fromUint8Array(callerBytes);
+              return Principal.fromUint8Array(new Uint8Array(callerBytes));
           },
           candidDecode: (candidEncoded) => {
               return globalThis._azleIc.candidDecode(candidEncoded.buffer);


### PR DESCRIPTION
`ic.caller` currently tries to make a Principal from an ArrayBuffer when it expects a Uint8Array. This adds that extra conversion.

Also, it changes `init_v2` back to `init` for stable structures since that currently breaks things.