### PR TITLE
fix(compiler): Fix pin lalrpop version rust compatibility

### DIFF
--- a/src/compiler/rust/canister/Cargo.toml
+++ b/src/compiler/rust/canister/Cargo.toml
@@ -16,6 +16,8 @@ quickjs-wasm-rs = { git = "https://github.com/ulan/javy.git", branch = "ulan/loc
 slotmap = "=1.0.6"
 ic-cdk = "0.10.0"
 ic-cdk-macros = "0.7.0"
+lalrpop = "=0.20.0"
+lalrpop-util = "=0.20.0"
 # TODO for now we must turn on the transient feature (no stable storage file system) or we can't generate the Candid file
 ic-wasi-polyfill = { git = "https://github.com/demergent-labs/ic-wasi-polyfill", rev = "f3812b879c096faf930331e76441fadf2ebe6586", features = [
     "transient",


### PR DESCRIPTION
Pin lalrpop versions because of the latest version 0.20.1 requires Rust 1.70.0 but azle supports Rust 1.68.2

<img width="948" alt="image" src="https://github.com/demergent-labs/azle/assets/59317431/ebbc09d0-74d3-4b63-a8ec-ec8db55f48d3">

This triggers error while a build (even simple hello world application):

```
error: package `lalrpop-util v0.20.1` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.68.2
Either upgrade to rustc 1.70 or newer, or use
cargo update -p lalrpop-util@0.20.1 --precise ver
w
```

![image](https://github.com/demergent-labs/azle/assets/59317431/4773e1fa-a905-4e2f-949d-37d24f1760a0)


https://discord.com/channels/748416164832608337/956466775380336680/1165985305761955870
https://discord.com/channels/748416164832608337/956466775380336680/1165988592611508356