### PR TITLE
Prettier property tests

### DIFF
--- a/property_tests/index.ts
+++ b/property_tests/index.ts
@@ -16,6 +16,10 @@ export function runPropTests(testArb: fc.Arbitrary<TestSample>) {
 
             writeFileSync('src/index.ts', canister.sourceCode);
 
+            execSync(`npx prettier --write src`, {
+                stdio: 'inherit'
+            });
+
             execSync(`dfx canister uninstall-code canister || true`, {
                 stdio: 'inherit'
             });


### PR DESCRIPTION
The generated files are a little difficult to read. By adding prettier before we run the tests it produces cleaner src files and makes finding problems easier.