### PR TITLE
Fix Float32Arb precision issue

### DIFF
--- a/property_tests/arbitraries/candid/primitive/floats/float32_arb.ts
+++ b/property_tests/arbitraries/candid/primitive/floats/float32_arb.ts
@@ -1,4 +1,4 @@
-import fc from 'fast-check';
+import fc, { sample } from 'fast-check';
 import { floatToSrcLiteral } from '../../to_src_literal/float';
 import { SimpleCandidDefinitionArb } from '../../simple_type_arbs/definition_arb';
 import { SimpleCandidValuesArb } from '../../simple_type_arbs/values_arb';
@@ -23,7 +23,9 @@ export function Float32DefinitionArb(): fc.Arbitrary<FloatCandidDefinition> {
 // TODO the agent should encode and decode -0 correctly
 export function Float32ValueArb(): fc.Arbitrary<CandidValues<number>> {
     return SimpleCandidValuesArb(
-        fc.float().map((sample) => (sample === 0 ? sample * 0 : sample)),
+        fc
+            .float32Array({ maxLength: 1, minLength: 1 })
+            .map((sample) => (sample[0] === 0 ? sample[0] * 0 : sample[0])),
         floatToSrcLiteral
     );
 }


### PR DESCRIPTION
Floats generated by fc.float may lose precision. Floats that fit in a Float32Array however match the precision of Rust/Candid.

> [!NOTE]
> This is already what we do for float64s.

We recently made changes to account for -0. If this doesn't fix those issues, then we can incorporate those changes with this instead:

```ts
export function Float32ValueArb(): fc.Arbitrary<CandidValues<number>> {
    return SimpleCandidValuesArb(
        fc
            .float32Array({ maxLength: 1, minLength: 1 })
            .map(([sample]) => (sample === 0 ? sample * 0 : sample)),
        floatToSrcLiteral
    );
}
```

If we want to exclude `Infinity` and `NaN` we could also do:

```ts
export function Float32ValueArb(): fc.Arbitrary<CandidValues<number>> {
    return SimpleCandidValuesArb(
        fc
            .float32Array({
                maxLength: 1,
                minLength: 1,
                noDefaultInfinity: true,
                noNaN: true
            })
            .map(([sample]) => (sample === 0 ? sample * 0 : sample)),
        floatToSrcLiteral
    );
}
```