### PR TITLE
Remove awaits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
             - if: contains(github.head_ref, 'release--')
               name: Install dfx
               run: |
-                  DFXVM_INIT_YES=true DFX_VERSION=0.17.0 sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+                  DFXVM_INIT_YES=true DFX_VERSION=0.18.0 sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
                   echo "$HOME/.local/share/dfx/bin" >> $GITHUB_PATH
             # TODO we should use some Action-specific bot account
             - if: contains(github.head_ref, 'release--')
@@ -237,7 +237,7 @@ jobs:
             - if: ${{ needs.release-candidate-deploy.outputs.should_run_tests }}
               name: Install dfx
               run: |
-                  DFXVM_INIT_YES=true DFX_VERSION=0.17.0 sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+                  DFXVM_INIT_YES=true DFX_VERSION=0.18.0 sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
                   echo "$HOME/.local/share/dfx/bin" >> $GITHUB_PATH
             - if: ${{ needs.release-candidate-deploy.outputs.should_run_tests }}
               uses: actions/cache@v3

--- a/benchmark/setup.ts
+++ b/benchmark/setup.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 export async function run_setup(argument?: string) {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister create azle`, {
         stdio: 'inherit'
     });

--- a/examples/apollo_server/test/pretest.ts
+++ b/examples/apollo_server/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code apollo_server || true`, {
         stdio: 'inherit'
     });

--- a/examples/async_await/test/pretest.ts
+++ b/examples/async_await/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code async_await || true`, {
         stdio: 'inherit'
     });

--- a/examples/audio_recorder/test/pretest.ts
+++ b/examples/audio_recorder/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code audio_recorder || true`, {
         stdio: 'inherit'
     });

--- a/examples/blob_array/test/pretest.ts
+++ b/examples/blob_array/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code blob_array || true`, {
         stdio: 'inherit'
     });

--- a/examples/bytes/test/pretest.ts
+++ b/examples/bytes/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code bytes_canister || true`, {
         stdio: 'inherit'
     });

--- a/examples/call_raw/test/pretest.ts
+++ b/examples/call_raw/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code call_raw || true`, {
         stdio: 'inherit'
     });

--- a/examples/candid_encoding/test/pretest.ts
+++ b/examples/candid_encoding/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code candid_encoding || true`, {
         stdio: 'inherit'
     });

--- a/examples/candid_keywords/test/pretest.ts
+++ b/examples/candid_keywords/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code candid_keywords || true`, {
         stdio: 'inherit'
     });

--- a/examples/canister/test/pretest.ts
+++ b/examples/canister/test/pretest.ts
@@ -2,8 +2,6 @@ import { execSync } from 'child_process';
 import { getCanisterId } from 'azle/test';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code canister || true`, {
         stdio: 'inherit'
     });

--- a/examples/ckbtc/test/pretest.ts
+++ b/examples/ckbtc/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     uninstall(
         'ckbtc',
         'internet_identity',

--- a/examples/complex_init/test/pretest.ts
+++ b/examples/complex_init/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code complex_init || true`, {
         stdio: 'inherit'
     });

--- a/examples/complex_types/test/pretest.ts
+++ b/examples/complex_types/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code complex_types || true`, {
         stdio: 'inherit'
     });

--- a/examples/composite_queries/test/pretest.ts
+++ b/examples/composite_queries/test/pretest.ts
@@ -2,8 +2,6 @@ import { getCanisterId } from 'azle/test';
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code canister1 || true`, {
         stdio: 'inherit'
     });

--- a/examples/counter/test/pretest.ts
+++ b/examples/counter/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code counter || true`, {
         stdio: 'inherit'
     });

--- a/examples/cross_canister_calls/test/pretest.ts
+++ b/examples/cross_canister_calls/test/pretest.ts
@@ -2,8 +2,6 @@ import { getCanisterId } from 'azle/test';
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code canister1 || true`, {
         stdio: 'inherit'
     });

--- a/examples/cycles/test/pretest.ts
+++ b/examples/cycles/test/pretest.ts
@@ -2,8 +2,6 @@ import { getCanisterId } from 'azle/test';
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code cycles || true`, {
         stdio: 'inherit'
     });

--- a/examples/date/test/pretest.ts
+++ b/examples/date/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code date || true`, {
         stdio: 'inherit'
     });

--- a/examples/ethereum_json_rpc/test/pretest.ts
+++ b/examples/ethereum_json_rpc/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code ethereum_json_rpc || true`, {
         stdio: 'inherit'
     });

--- a/examples/ethers/test/pretest.ts
+++ b/examples/ethers/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code ethers || true`, {
         stdio: 'inherit'
     });

--- a/examples/express/test/pretest.ts
+++ b/examples/express/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code express || true`, {
         stdio: 'inherit'
     });

--- a/examples/file_protocol/test/pretest.ts
+++ b/examples/file_protocol/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code backend || true`, {
         stdio: 'inherit'
     });

--- a/examples/fs/test/pretest.ts
+++ b/examples/fs/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code fs || true`, {
         stdio: 'inherit'
     });

--- a/examples/func_types/test/pretest.ts
+++ b/examples/func_types/test/pretest.ts
@@ -2,8 +2,6 @@ import { getCanisterId } from 'azle/test';
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code func_types || true`, {
         stdio: 'inherit'
     });

--- a/examples/generics/test/pretest.ts
+++ b/examples/generics/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code generics || true`, {
         stdio: 'inherit'
     });

--- a/examples/guard_functions/test/pretest.ts
+++ b/examples/guard_functions/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code guard_functions || true`, {
         stdio: 'inherit'
     });

--- a/examples/heartbeat/test/pretest.ts
+++ b/examples/heartbeat/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code heartbeat_async || true`, {
         stdio: 'inherit'
     });

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -51,7 +51,7 @@ node --version
 Install the dfx command line tools for managing ICP applications:
 
 ```bash
-DFX_VERSION=0.16.1 sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+DFX_VERSION=0.18.0 sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
 ```
 
 Check that the installation went smoothly by looking for clean output from the following command:

--- a/examples/ic_api/test/pretest.ts
+++ b/examples/ic_api/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code ic_api || true`, {
         stdio: 'inherit'
     });

--- a/examples/icrc/test/pretest.ts
+++ b/examples/icrc/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest(icrcPath: string) {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code proxy || true`, {
         stdio: 'inherit'
     });

--- a/examples/imports/test/pretest.ts
+++ b/examples/imports/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code imports || true`, {
         stdio: 'inherit'
     });

--- a/examples/init/test/pretest.ts
+++ b/examples/init/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code init || true`, {
         stdio: 'inherit'
     });

--- a/examples/inspect_message/test/pretest.ts
+++ b/examples/inspect_message/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code inspect_message || true`, {
         stdio: 'inherit'
     });

--- a/examples/key_value_store/test/pretest.ts
+++ b/examples/key_value_store/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code key_value_store || true`, {
         stdio: 'inherit'
     });

--- a/examples/ledger_canister/test/pretest.ts
+++ b/examples/ledger_canister/test/pretest.ts
@@ -2,8 +2,6 @@ import { execSync } from 'child_process';
 import { getCanisterId } from 'azle/test';
 
 async function pretest(icp_ledger_path: string) {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code icp_ledger || true`, {
         stdio: 'inherit'
     });

--- a/examples/list_of_lists/test/pretest.ts
+++ b/examples/list_of_lists/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code list_of_lists || true`, {
         stdio: 'inherit'
     });

--- a/examples/management_canister/test/pretest.ts
+++ b/examples/management_canister/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code management_canister || true`, {
         stdio: 'inherit'
     });

--- a/examples/manual_reply/test/pretest.ts
+++ b/examples/manual_reply/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code manual_reply || true`, {
         stdio: 'inherit'
     });

--- a/examples/motoko_examples/calc/test/pretest.ts
+++ b/examples/motoko_examples/calc/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code calc || true`, {
         stdio: 'inherit'
     });

--- a/examples/motoko_examples/counter/test/pretest.ts
+++ b/examples/motoko_examples/counter/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code counter || true`, {
         stdio: 'inherit'
     });

--- a/examples/motoko_examples/echo/test/pretest.ts
+++ b/examples/motoko_examples/echo/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code echo || true`, {
         stdio: 'inherit'
     });

--- a/examples/motoko_examples/factorial/test/pretest.ts
+++ b/examples/motoko_examples/factorial/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code factorial || true`, {
         stdio: 'inherit'
     });

--- a/examples/motoko_examples/hello-world/test/pretest.ts
+++ b/examples/motoko_examples/hello-world/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code hello_world || true`, {
         stdio: 'inherit'
     });

--- a/examples/motoko_examples/hello/test/pretest.ts
+++ b/examples/motoko_examples/hello/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code hello || true`, {
         stdio: 'inherit'
     });

--- a/examples/motoko_examples/http_counter/test/pretest.ts
+++ b/examples/motoko_examples/http_counter/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code http_counter || true`, {
         stdio: 'inherit'
     });

--- a/examples/motoko_examples/minimal-counter-dapp/test/pretest.ts
+++ b/examples/motoko_examples/minimal-counter-dapp/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code minimal_dapp || true`, {
         stdio: 'inherit'
     });

--- a/examples/motoko_examples/persistent-storage/test/pretest.ts
+++ b/examples/motoko_examples/persistent-storage/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code persistent_storage || true`, {
         stdio: 'inherit'
     });

--- a/examples/motoko_examples/phone-book/test/pretest.ts
+++ b/examples/motoko_examples/phone-book/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code phone_book || true`, {
         stdio: 'inherit'
     });

--- a/examples/motoko_examples/quicksort/test/pretest.ts
+++ b/examples/motoko_examples/quicksort/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code quicksort || true`, {
         stdio: 'inherit'
     });

--- a/examples/motoko_examples/simple-to-do/test/pretest.ts
+++ b/examples/motoko_examples/simple-to-do/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code simple_to_do || true`, {
         stdio: 'inherit'
     });

--- a/examples/motoko_examples/superheroes/test/pretest.ts
+++ b/examples/motoko_examples/superheroes/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code superheroes || true`, {
         stdio: 'inherit'
     });

--- a/examples/motoko_examples/threshold_ecdsa/test/pretest.ts
+++ b/examples/motoko_examples/threshold_ecdsa/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code threshold_ecdsa || true`, {
         stdio: 'inherit'
     });

--- a/examples/motoko_examples/whoami/test/pretest.ts
+++ b/examples/motoko_examples/whoami/test/pretest.ts
@@ -6,8 +6,6 @@ const someoneIdentity = createIdentity(2);
 export const someonePrincipal = someoneIdentity.getPrincipal().toString();
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code whoami || true`, {
         stdio: 'inherit'
     });

--- a/examples/notify_raw/test/pretest.ts
+++ b/examples/notify_raw/test/pretest.ts
@@ -2,8 +2,6 @@ import { getCanisterId } from 'azle/test';
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code canister1 || true`, {
         stdio: 'inherit'
     });

--- a/examples/null_example/test/pretest.ts
+++ b/examples/null_example/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code null_example || true`, {
         stdio: 'inherit'
     });

--- a/examples/optional_types/test/pretest.ts
+++ b/examples/optional_types/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code optional_types || true`, {
         stdio: 'inherit'
     });

--- a/examples/outgoing_http_requests/test/pretest.ts
+++ b/examples/outgoing_http_requests/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code outgoing_http_requests || true`, {
         stdio: 'inherit'
     });

--- a/examples/plugins/test/pretest.ts
+++ b/examples/plugins/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code plugins || true`, {
         stdio: 'inherit'
     });

--- a/examples/pre_and_post_upgrade/test/pretest.ts
+++ b/examples/pre_and_post_upgrade/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code pre_and_post_upgrade || true`, {
         stdio: 'inherit'
     });

--- a/examples/primitive_types/test/pretest.ts
+++ b/examples/primitive_types/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code primitive_types || true`, {
         stdio: 'inherit'
     });

--- a/examples/principal/test/pretest.ts
+++ b/examples/principal/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code principal || true`, {
         stdio: 'inherit'
     });

--- a/examples/query/test/pretest.ts
+++ b/examples/query/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code query || true`, {
         stdio: 'inherit'
     });

--- a/examples/randomness/test/pretest.ts
+++ b/examples/randomness/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code randomness || true`, {
         stdio: 'inherit'
     });

--- a/examples/recursion/test/pretest.ts
+++ b/examples/recursion/test/pretest.ts
@@ -2,8 +2,6 @@ import { execSync } from 'child_process';
 import { getCanisterId } from 'azle/test';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code recursive_canister || true`, {
         stdio: 'inherit'
     });

--- a/examples/rejections/test/pretest.ts
+++ b/examples/rejections/test/pretest.ts
@@ -2,8 +2,6 @@ import { getCanisterId } from 'azle/test';
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code rejections || true`, {
         stdio: 'inherit'
     });

--- a/examples/robust_imports/test/pretest.ts
+++ b/examples/robust_imports/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code robust_imports || true`, {
         stdio: 'inherit'
     });

--- a/examples/run_time_errors/test/pretest.ts
+++ b/examples/run_time_errors/test/pretest.ts
@@ -3,8 +3,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code run_time_errors || true`, {
         stdio: 'inherit'
     });

--- a/examples/simple_erc20/test/pretest.ts
+++ b/examples/simple_erc20/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code simple_erc20 || true`, {
         stdio: 'inherit'
     });

--- a/examples/simple_user_accounts/test/pretest.ts
+++ b/examples/simple_user_accounts/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code simple_user_accounts || true`, {
         stdio: 'inherit'
     });

--- a/examples/sqlite/test/pretest.ts
+++ b/examples/sqlite/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code sqlite || true`, {
         stdio: 'inherit'
     });

--- a/examples/stable_memory/test/pretest.ts
+++ b/examples/stable_memory/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code stable_memory || true`, {
         stdio: 'inherit'
     });

--- a/examples/stable_structures/test/pretest.ts
+++ b/examples/stable_structures/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code canister1 || true`, {
         stdio: 'inherit'
     });

--- a/examples/timers/test/pretest.ts
+++ b/examples/timers/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code timers || true`, {
         stdio: 'inherit'
     });

--- a/examples/tuple_types/test/pretest.ts
+++ b/examples/tuple_types/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code tuple_types || true`, {
         stdio: 'inherit'
     });

--- a/examples/update/test/pretest.ts
+++ b/examples/update/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code update || true`, {
         stdio: 'inherit'
     });

--- a/examples/vanilla_js/test/pretest.ts
+++ b/examples/vanilla_js/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code vanilla_js || true`, {
         stdio: 'inherit'
     });

--- a/examples/web_assembly/test/pretest.ts
+++ b/examples/web_assembly/test/pretest.ts
@@ -1,8 +1,6 @@
 import { execSync } from 'child_process';
 
 async function pretest() {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
     execSync(`dfx canister uninstall-code web_assembly || true`, {
         stdio: 'inherit'
     });

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
     "name": "azle",
     "version": "0.20.2",
-    "rust_version": "1.73.0",
-    "dfx_version": "0.16.1",
+    "dfx_version": "0.18.0",
     "description": "TypeScript and JavaScript CDK for the Internet Computer",
     "scripts": {
         "typecheck": "tsc --noEmit",


### PR DESCRIPTION
This PR sort of depends on the dfx 0.18.0 PR, so we can either remove the updates to dfx 0.18.0 or be blocked: We're blocked on updating until issues with bitcoin are resolved: https://forum.dfinity.org/t/btc-integration-canister-endpoints-not-returning-expected-results/28395