### PR TITLE
Improve terminal error output

### DIFF
--- a/src/compiler/compile_rust_code.ts
+++ b/src/compiler/compile_rust_code.ts
@@ -1,4 +1,6 @@
-import { execSync, IOType } from 'child_process';
+import { IOType } from 'child_process';
+
+import { execSyncPretty } from './utils/exec_sync_pretty';
 
 export function compileRustCode(
     dockerContainerName: string,
@@ -18,47 +20,47 @@ function compileRustCodeWithPodman(
     canisterName: string,
     stdio: IOType
 ) {
-    execSync(
+    execSyncPretty(
         `podman exec ${dockerContainerName} rm -rf /.azle/${canisterName}`,
-        { stdio }
+        stdio
     );
 
-    execSync(`podman exec ${dockerContainerName} mkdir -p /.azle`, {
-        stdio
-    });
+    execSyncPretty(`podman exec ${dockerContainerName} mkdir -p /.azle`, stdio);
 
-    execSync(`podman exec ${dockerContainerName} mkdir -p /global_target_dir`, {
+    execSyncPretty(
+        `podman exec ${dockerContainerName} mkdir -p /global_target_dir`,
         stdio
-    });
+    );
 
-    execSync(`podman cp .azle/${canisterName} ${dockerContainerName}:/.azle`, {
+    execSyncPretty(
+        `podman cp .azle/${canisterName} ${dockerContainerName}:/.azle`,
         stdio
-    });
+    );
 
-    execSync(
+    execSyncPretty(
         `podman exec -w /.azle/${canisterName} ${dockerContainerName} env CARGO_TARGET_DIR=/global_target_dir cargo build --target wasm32-wasi --manifest-path canister/Cargo.toml --release`,
-        { stdio }
+        stdio
     );
 
-    execSync(
+    execSyncPretty(
         `podman exec -w /.azle/${canisterName} ${dockerContainerName} wasi2ic /global_target_dir/wasm32-wasi/release/canister.wasm /global_target_dir/wasm32-wasi/release/canister.wasm`,
-        { stdio }
+        stdio
     );
 
-    execSync(
+    execSyncPretty(
         `podman cp ${dockerContainerName}:/global_target_dir/wasm32-wasi/release/canister.wasm .azle/${canisterName}/${canisterName}.wasm`,
-        { stdio }
+        stdio
     );
 }
 
 function compileRustCodeNatively(canisterName: string, stdio: IOType) {
-    execSync(
+    execSyncPretty(
         `CARGO_TARGET_DIR=target cargo build --target wasm32-wasi --manifest-path .azle/${canisterName}/canister/Cargo.toml --release`,
-        { stdio }
+        stdio
     );
 
-    execSync(
+    execSyncPretty(
         `wasi2ic target/wasm32-wasi/release/canister.wasm .azle/${canisterName}/${canisterName}.wasm`,
-        { stdio }
+        stdio
     );
 }

--- a/src/compiler/file_watcher/setup_file_watcher.ts
+++ b/src/compiler/file_watcher/setup_file_watcher.ts
@@ -1,5 +1,7 @@
-import { execSync, spawn } from 'child_process';
+import { spawn } from 'child_process';
 import { join } from 'path';
+
+import { execSyncPretty } from '../utils/exec_sync_pretty';
 
 export function setupFileWatcher(
     reloadedJsPath: string,
@@ -14,7 +16,7 @@ export function setupFileWatcher(
         // TODO should we figure out why the || true
         // TODO does not result in a 0 exit code
         // TODO and look into removing the try catch?
-        execSync(`pkill -f ./file_watcher_loader.js || true`);
+        execSyncPretty(`pkill -f ./file_watcher_loader.js || true`);
     } catch (error) {
         // For some reason pkill throws even with || true
     }

--- a/src/compiler/get_names.ts
+++ b/src/compiler/get_names.ts
@@ -1,4 +1,3 @@
-import { execSync } from 'child_process';
 import { createHash } from 'crypto';
 import { readFileSync } from 'fs';
 import { hashOfDirectory } from 'hash-of-directory';
@@ -11,6 +10,7 @@ import {
     getStdIoType,
     unwrap
 } from './utils';
+import { execSyncPretty } from './utils/exec_sync_pretty';
 import { GLOBAL_AZLE_CONFIG_DIR } from './utils/global_paths';
 import { JSCanisterConfig } from './utils/types';
 
@@ -38,7 +38,7 @@ export async function getNamesBeforeCli() {
         wasmedgeQuickJsName
     );
 
-    const replicaWebServerPort = execSync(`dfx info webserver-port`)
+    const replicaWebServerPort = execSyncPretty(`dfx info webserver-port`)
         .toString()
         .trim();
 

--- a/src/compiler/handle_cli.ts
+++ b/src/compiler/handle_cli.ts
@@ -1,10 +1,11 @@
-import { execSync, IOType } from 'child_process';
+import { IOType } from 'child_process';
 import { rmSync } from 'fs';
 
 import { version as azleVersion } from '../../package.json';
 import { uploadFiles } from './file_uploader';
 import { getFilesToUpload } from './file_uploader/get_files_to_upload';
 import { generateNewAzleProject } from './new_command';
+import { execSyncPretty } from './utils/exec_sync_pretty';
 import { GLOBAL_AZLE_CONFIG_DIR } from './utils/global_paths';
 
 export function handleCli(
@@ -53,9 +54,7 @@ function handleCommandNew() {
 }
 
 function handleCommandDockerfileHash(dockerfileHash: string) {
-    execSync(`echo -n "${dockerfileHash}"`, {
-        stdio: 'inherit'
-    });
+    execSyncPretty(`echo -n "${dockerfileHash}"`, 'inherit');
 }
 
 function handleCommandClean(
@@ -77,29 +76,23 @@ function handleCommandClean(
 
     console.info(`.azle directory deleted`);
 
-    execSync(
+    execSyncPretty(
         `podman stop $(podman ps --filter "name=${dockerContainerPrefix}" --format "{{.ID}}") || true`,
-        {
-            stdio: stdioType
-        }
+        stdioType
     );
 
     console.info(`azle containers stopped`);
 
-    execSync(
+    execSyncPretty(
         `podman rm $(podman ps -a --filter "name=${dockerContainerPrefix}" --format "{{.ID}}") || true`,
-        {
-            stdio: stdioType
-        }
+        stdioType
     );
 
     console.info(`azle containers removed`);
 
-    execSync(
+    execSyncPretty(
         `podman image rm $(podman images --filter "reference=${dockerImagePrefix}" --format "{{.ID}}") || true`,
-        {
-            stdio: stdioType
-        }
+        stdioType
     );
 
     console.info(`azle images removed`);

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -86,7 +86,8 @@ async function azle() {
             prepareRustStagingArea(
                 canisterConfig,
                 canisterPath,
-                canisterJavaScript
+                canisterJavaScript,
+                stdioType
             );
 
             const { candid, canisterMethods } = getCandidAndCanisterMethods(

--- a/src/compiler/prepare_rust_staging_area.ts
+++ b/src/compiler/prepare_rust_staging_area.ts
@@ -1,15 +1,17 @@
-import { execSync } from 'child_process';
+import { IOType } from 'child_process';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { copySync } from 'fs-extra';
 import { join } from 'path';
 
 import { generateWorkspaceCargoToml } from './generate_cargo_toml_files';
+import { execSyncPretty } from './utils/exec_sync_pretty';
 import { JSCanisterConfig, Toml } from './utils/types';
 
 export function prepareRustStagingArea(
     canisterConfig: JSCanisterConfig,
     canisterPath: string,
-    canisterJavaScript: string
+    canisterJavaScript: string,
+    stdioType: IOType
 ) {
     const workspaceCargoToml: Toml = generateWorkspaceCargoToml(
         canisterConfig.opt_level ?? '0'
@@ -44,7 +46,7 @@ export function prepareRustStagingArea(
         canisterConfig.build_assets !== undefined &&
         canisterConfig.build_assets !== null
     ) {
-        execSync(canisterConfig.build_assets);
+        execSyncPretty(canisterConfig.build_assets, stdioType);
     }
 
     for (const [src, dest] of canisterConfig.assets ?? []) {

--- a/src/compiler/utils/exec_sync_pretty.ts
+++ b/src/compiler/utils/exec_sync_pretty.ts
@@ -1,0 +1,9 @@
+import { execSync, IOType } from 'child_process';
+
+export function execSyncPretty(command: string, stdio?: IOType): Buffer {
+    try {
+        return execSync(command, { stdio });
+    } catch (error) {
+        throw new Error(`Azle build error`);
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/demergent-labs/azle/issues/1752

I've introduced an `execSyncPretty` function to be used in place of `execSync`. This will catch the default error output and create a much nicer terminal output for the developer. It has a default stack trace and should be quite practical. Not the most beautiful still, we might want to improve it in the future, but it should be much better than what currently happens.

What currently happens is confusing and verbose, it logs stdout, stderr, with a lot of Uint8Arrays or buffers or such, and it is generally scary-looking and not helpful.

That has hopefully been fixed or greatly improved with this PR.