### PR TITLE
Revert "update unstable tests"

### DIFF
--- a/.github/actions/get_exclude_dirs/action.yml
+++ b/.github/actions/get_exclude_dirs/action.yml
@@ -31,6 +31,7 @@ runs:
               examples/stable/test/property/ic_api/performance_counter
               examples/stable/test/property/ic_api/instruction_counter
               examples/experimental/test/end_to_end/http_server/http_outcall_fetch
+              examples/experimental/test/end_to_end/http_server/ic_evm_rpc
               examples/experimental/test/end_to_end/http_server/multi_deploy
               examples/experimental/test/property/candid_rpc/stable_b_tree_map
               ') }}"
@@ -39,7 +40,6 @@ runs:
               examples/experimental/demo/basic_bitcoin
               examples/experimental/demo/bitcoin_psbt
               examples/experimental/demo/ckbtc
-              examples/experimental/test/end_to_end/http_server/ic_evm_rpc
               examples/stable/test/end_to_end/candid_rpc/bitcoin
               examples/stable/test/end_to_end/candid_rpc/stable_structures
               examples/experimental/test/end_to_end/candid_rpc/bitcoin

--- a/.github/actions/get_exclude_dirs/action.yml
+++ b/.github/actions/get_exclude_dirs/action.yml
@@ -30,17 +30,16 @@ runs:
               examples/stable/test/property/candid_rpc/stable_b_tree_map
               examples/stable/test/property/ic_api/performance_counter
               examples/stable/test/property/ic_api/instruction_counter
-              examples/experimental/demo/basic_bitcoin
-              examples/experimental/demo/bitcoin_psbt
-              examples/experimental/demo/ckbtc
-              examples/experimental/test/end_to_end/http_server/ethers_base
               examples/experimental/test/end_to_end/http_server/http_outcall_fetch
-              examples/experimental/test/end_to_end/http_server/ic_evm_rpc
               examples/experimental/test/end_to_end/http_server/multi_deploy
               examples/experimental/test/property/candid_rpc/stable_b_tree_map
               ') }}"
 
               SLOW_EXCLUSIONS="${{ format('
+              examples/experimental/demo/basic_bitcoin
+              examples/experimental/demo/bitcoin_psbt
+              examples/experimental/demo/ckbtc
+              examples/experimental/test/end_to_end/http_server/ic_evm_rpc
               examples/stable/test/end_to_end/candid_rpc/bitcoin
               examples/stable/test/end_to_end/candid_rpc/stable_structures
               examples/experimental/test/end_to_end/candid_rpc/bitcoin

--- a/.github/actions/get_exclude_dirs/action.yml
+++ b/.github/actions/get_exclude_dirs/action.yml
@@ -30,16 +30,17 @@ runs:
               examples/stable/test/property/candid_rpc/stable_b_tree_map
               examples/stable/test/property/ic_api/performance_counter
               examples/stable/test/property/ic_api/instruction_counter
+              examples/experimental/demo/basic_bitcoin
+              examples/experimental/demo/bitcoin_psbt
+              examples/experimental/demo/ckbtc
+              examples/experimental/test/end_to_end/http_server/ethers_base
               examples/experimental/test/end_to_end/http_server/http_outcall_fetch
+              examples/experimental/test/end_to_end/http_server/ic_evm_rpc
               examples/experimental/test/end_to_end/http_server/multi_deploy
               examples/experimental/test/property/candid_rpc/stable_b_tree_map
               ') }}"
 
               SLOW_EXCLUSIONS="${{ format('
-              examples/experimental/demo/basic_bitcoin
-              examples/experimental/demo/bitcoin_psbt
-              examples/experimental/demo/ckbtc
-              examples/experimental/test/end_to_end/http_server/ic_evm_rpc
               examples/stable/test/end_to_end/candid_rpc/bitcoin
               examples/stable/test/end_to_end/candid_rpc/stable_structures
               examples/experimental/test/end_to_end/candid_rpc/bitcoin


### PR DESCRIPTION
This reverts commit 4eb14ab83612fc746d9f3495036a0695f711e5ea.

## Contributor

- [x] Breaking changes enumerated in [the release issue](https://github.com/demergent-labs/azle/issues/2053)
- [x] New documentation enumerated in [the release issue](https://github.com/demergent-labs/azle/issues/2053)
- [x] Code has been declaratized
- [x] Error handling beautiful (no unwraps or expects etc)
- [x] Code tested thoroughly
- [x] All new functions have JSDoc/Rustdoc comments
- [x] Related issues have been linked and all tasks have been completed or made into separate issues

## Reviewer

- [x] Breaking changes enumerated in [the release issue](https://github.com/demergent-labs/azle/issues/2053)
- [x] New documentation enumerated in [the release issue](https://github.com/demergent-labs/azle/issues/2053)
- [x] Code has been declaratized
- [x] Error handling beautiful (no unwraps or expects etc)
- [x] Code tested thoroughly
- [x] All new functions have JSDoc/Rustdoc comments
- [x] Related issues have been linked and all tasks have been completed or made into separate issues
