### PR TITLE
Use default params for the arb property tests

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -2,7 +2,6 @@ import * as dns from 'node:dns';
 dns.setDefaultResultOrder('ipv4first');
 
 import { describe, expect, test } from '@jest/globals';
-import * as fc from 'fast-check';
 
 import { execSyncPretty } from '../src/build/stable/utils/exec_sync_pretty';
 export { expect } from '@jest/globals';
@@ -12,6 +11,7 @@ import { runFuzzTests } from './fuzz';
 export type Test = () => void;
 
 export { getCanisterActor } from './get_canister_actor';
+export { defaultPropTestParams } from './property/default_prop_test_params';
 
 export function runTests(
     tests: Test,
@@ -95,34 +95,6 @@ export function it(name: string, fn: () => void | Promise<void>): void {
 }
 it.only = test.only;
 it.skip = test.skip;
-
-export function defaultPropTestParams<T = unknown>(): fc.Parameters<T> {
-    const baseParams = {
-        numRuns: Number(process.env.AZLE_PROPTEST_NUM_RUNS ?? 1),
-        reporter: (runDetails: fc.RunDetails<T>): void => {
-            const seed = runDetails.seed;
-            const path = runDetails.counterexamplePath;
-            const reproductionCommand = `AZLE_PROPTEST_SEED=${seed}${path !== null ? ` AZLE_PROPTEST_PATH="${path}"` : ''} AZLE_VERBOSE=true AZLE_TEMPLATE=true npm test`;
-            const reproductionMessage = `To reproduce this exact test case, run:\n${reproductionCommand}`;
-            console.info(reproductionMessage);
-            if (runDetails.failed) {
-                throw new Error(
-                    `${reproductionMessage}\n\n${fc.defaultReportMessage(runDetails)}`
-                );
-            }
-        },
-        endOnFailure: process.env.AZLE_PROPTEST_SHRINK === 'true' ? false : true
-    };
-
-    const seed =
-        process.env.AZLE_PROPTEST_SEED !== undefined
-            ? Number(process.env.AZLE_PROPTEST_SEED)
-            : undefined;
-
-    const path = process.env.AZLE_PROPTEST_PATH;
-
-    return seed !== undefined ? { ...baseParams, seed, path } : baseParams;
-}
 
 function processEnvVars(): {
     shouldRunTests: boolean;

--- a/test/property/default_prop_test_params.ts
+++ b/test/property/default_prop_test_params.ts
@@ -1,0 +1,29 @@
+import * as fc from 'fast-check';
+
+export function defaultPropTestParams<T = unknown>(): fc.Parameters<T> {
+    const baseParams = {
+        numRuns: Number(process.env.AZLE_PROPTEST_NUM_RUNS ?? 1),
+        reporter: (runDetails: fc.RunDetails<T>): void => {
+            const seed = runDetails.seed;
+            const path = runDetails.counterexamplePath;
+            const reproductionCommand = `AZLE_PROPTEST_SEED=${seed}${path !== null ? ` AZLE_PROPTEST_PATH="${path}"` : ''} AZLE_VERBOSE=true AZLE_TEMPLATE=true npm test`;
+            const reproductionMessage = `To reproduce this exact test case, run:\n${reproductionCommand}`;
+            console.info(reproductionMessage);
+            if (runDetails.failed) {
+                throw new Error(
+                    `${reproductionMessage}\n\n${fc.defaultReportMessage(runDetails)}`
+                );
+            }
+        },
+        endOnFailure: process.env.AZLE_PROPTEST_SHRINK === 'true' ? false : true
+    };
+
+    const seed =
+        process.env.AZLE_PROPTEST_SEED !== undefined
+            ? Number(process.env.AZLE_PROPTEST_SEED)
+            : undefined;
+
+    const path = process.env.AZLE_PROPTEST_PATH;
+
+    return seed !== undefined ? { ...baseParams, seed, path } : baseParams;
+}

--- a/test/property/index.ts
+++ b/test/property/index.ts
@@ -4,9 +4,9 @@ import { execSync } from 'child_process';
 import fc from 'fast-check';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 
-import { defaultPropTestParams } from '../';
 import { Canister } from './arbitraries/canister_arb';
 import { clear as clearUniquePrimitiveArb } from './arbitraries/unique_primitive_arb';
+import { defaultPropTestParams } from './default_prop_test_params';
 import { runTests } from './test';
 
 export type Named<T> = {

--- a/test/property/index.ts
+++ b/test/property/index.ts
@@ -4,6 +4,7 @@ import { execSync } from 'child_process';
 import fc from 'fast-check';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 
+import { defaultPropTestParams } from '../';
 import { Canister } from './arbitraries/canister_arb';
 import { clear as clearUniquePrimitiveArb } from './arbitraries/unique_primitive_arb';
 import { runTests } from './test';
@@ -19,26 +20,16 @@ export async function runPropTests(
     canisterArb: fc.Arbitrary<Canister>,
     runTestsSeparately = false
 ): Promise<void> {
-    const defaultParams = {
+    const executionParams = {
+        ...defaultPropTestParams(),
         numRuns: runTestsSeparately
             ? 1
-            : Number(process.env.AZLE_PROPTEST_NUM_RUNS ?? 1),
-        endOnFailure: true // TODO This essentially disables shrinking. We don't know how to do shrinking well yet
+            : Number(process.env.AZLE_PROPTEST_NUM_RUNS ?? 1)
     };
     // TODO https://github.com/demergent-labs/azle/issues/1568
     const numRuns = runTestsSeparately
         ? Number(process.env.AZLE_PROPTEST_NUM_RUNS ?? 1)
         : 1;
-
-    const seed =
-        process.env.AZLE_PROPTEST_SEED !== undefined
-            ? Number(process.env.AZLE_PROPTEST_SEED)
-            : undefined;
-
-    const path = process.env.AZLE_PROPTEST_PATH;
-
-    const executionParams =
-        seed !== undefined ? { ...defaultParams, seed, path } : defaultParams;
 
     try {
         for (let i = 0; i < numRuns; i++) {


### PR DESCRIPTION
## Contributor

- [x] Code has been declaratized
- [x] All new functions have JSDoc/Rustdoc comments
- [x] Error handling beautiful (no unwraps or expects etc)
- [x] Code tested thoroughly
- [x] PR title:
    - [x] Indicates breaking changes with suffix "(breaking changes)"
    - [x] Sentence cased
- [x] Related issues have been linked and all tasks have been completed or made into separate issues
- [x] New documentation enumerated in [the release issue](https://github.com/demergent-labs/azle/issues/2053)
- [x] All breaking changes
    - [x] Described below in the "Breaking Changes" section
    - [x] Migration path described

## Reviewer

- [x] Code has been declaratized
- [x] All new functions have JSDoc/Rustdoc comments
- [x] Error handling beautiful (no unwraps or expects etc)
- [x] Code tested thoroughly
- [x] PR title:
    - [x] Indicates breaking changes with suffix "(breaking changes)"
    - [x] Sentence cased
- [x] Related issues have been linked and all tasks have been completed or made into separate issues
- [x] New documentation enumerated in [the release issue](https://github.com/demergent-labs/azle/issues/2053)
- [x] All breaking changes
    - [x] Described below in the "Breaking Changes" section
    - [x] Migration path described

## Breaking Changes

- None
