### PR TITLE
update release workflow to only add files from the current working directory to limit conflicts

### DIFF
--- a/.github/actions/commit_and_push/action.yml
+++ b/.github/actions/commit_and_push/action.yml
@@ -11,6 +11,10 @@ inputs:
     commit-message:
         description: 'Commit message'
         required: true
+    add-files:
+        description: 'Optional file pattern to limit git add. E.g. "src/" to only add changes from the src directory. Defaults to "--all" to add all changes.'
+        required: false
+        default: '--all'
     gpg-signing-key:
         description: 'The GPG signing key to use for signing commits'
         required: true
@@ -40,7 +44,9 @@ runs:
               git status
 
               # Add and commit changes if there are any
-              git add --all
+              echo "Adding files: ${{ inputs.add-files }}"
+              git add "${{ inputs.add-files }}"
+
               if ! git diff --cached --quiet; then
                 git commit -m "${{ inputs.commit-message }}"
                 git push origin "${{ inputs.branch-name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,7 @@ jobs:
               with:
                   branch-name: ${{ steps.create-branch-name.outputs.branch-name }}
                   commit-message: 'Update test files for ${{ matrix.test.displayPath }}'
+                  add-files: ${{ matrix.test.path }}
                   gpg-signing-key: ${{ secrets.GPG_SIGNING_KEY }}
                   create-branch: 'true'
                   signing-key-id: ${{ inputs.signing-key-id }}


### PR DESCRIPTION
## Contributor

- [x] Code has been declaratized
- [x] All new functions have JSDoc/Rustdoc comments
- [x] Error handling beautiful (no unwraps or expects etc)
- [x] Code tested thoroughly
- [x] PR title:
    - [x] `feat:` prefix used if functionality should be included in the `Features` section of the release notes
    - [x] Not sentence cased
    - [x] Described well for release notes
    - [x] Indicates breaking changes with suffix "(breaking changes)"
- [x] Related issues have been linked and all tasks have been completed or made into separate issues
- [x] New documentation enumerated in [the release issue](https://github.com/demergent-labs/azle/issues/2053)
- [x] All breaking changes
    - [x] Described below in the "Breaking Changes" section
    - [x] Migration path described
- [x] Review is requested when ready

## Reviewer

- [x] Code has been declaratized
- [x] All new functions have JSDoc/Rustdoc comments
- [x] Error handling beautiful (no unwraps or expects etc)
- [x] Code tested thoroughly
     - [x] See
          - [x] https://github.com/demergent-labs/azle/actions/runs/13418458615/job/37485820828
          - [x] https://github.com/demergent-labs/azle/pull/2728
- [x] PR title:
    - [x] `feat:` prefix used if functionality should be included in the `Features` section of the release notes
    - [x] Not sentence cased
    - [x] Described well for release notes
    - [x] Indicates breaking changes with suffix "(breaking changes)"
- [x] Related issues have been linked and all tasks have been completed or made into separate issues
- [x] New documentation enumerated in [the release issue](https://github.com/demergent-labs/azle/issues/2053)
- [x] All breaking changes
    - [x] Described below in the "Breaking Changes" section
    - [x] Migration path described

## Breaking Changes

- None
