### PR TITLE
temporarily filter out 206 responses from response arbitrary

### DIFF
--- a/test/property/arbitraries/http/response_arb.ts
+++ b/test/property/arbitraries/http/response_arb.ts
@@ -34,11 +34,13 @@ const StatusCodeArb = fc
         },
         { arbitrary: fc.integer({ min: 200, max: 599 }), weight: 1 } // The ic replica doesn't support returning status codes in the 1xx range.
     )
-    .filter((status) => status !== 407 && status !== 421);
+    .filter((status) => status !== 407 && status !== 421 && status !== 206);
 // TODO Node's fetch doesn't handle 407 the same as other status, so we're filtering it out until we can figure out why
 // TODO https://github.com/demergent-labs/azle/pull/1652
 // TODO same applies to 421 status see https://github.com/demergent-labs/fourZeroSeven for more details
 // TODO https://github.com/nodejs/help/issues/4345
+// TODO Status 206 needs Content-Range header to work so we're filtering it out until we support that header in our arbitraries
+// TODO https://github.com/demergent-labs/azle/issues/2768
 
 export function HttpResponseValueArb<T>(): fc.Arbitrary<HttpResponse<T>> {
     return fc

--- a/test/property/test/index.ts
+++ b/test/property/test/index.ts
@@ -119,7 +119,7 @@ export function testEquality<T = any>(actual: T, expected: T): AzleResult {
     if (deepEqual(actualJson, expectedJson)) {
         return { Ok: { isSuccessful: true } };
     } else {
-        const message = `Expected: ${expectedJson}, Received: ${actualJson}`;
+        const message = `Expected: ${expectedJsonString},\n\n Received: ${actualJsonString}`;
         return { Ok: { isSuccessful: false, message } };
     }
 }


### PR DESCRIPTION
## Contributor

- [x] Code has been declaratized
- [x] All new functions have JSDoc/Rustdoc comments
- [x] Error handling beautiful (no unwraps or expects etc)
- [x] Code tested thoroughly
- [x] PR title:
    - [x] `feat:` prefix used if functionality should be included in the `Features` section of the release notes
    - [x] Not sentence cased
    - [x] Described well for release notes
    - [x] Indicates breaking changes with suffix "(breaking changes)"
- [x] Related issues have been linked and all tasks have been completed or made into separate issues
- [x] New documentation enumerated in [the release issue](https://github.com/demergent-labs/azle/issues/2053)
- [x] All breaking changes
    - [x] Described below in the "Breaking Changes" section
    - [x] Migration path described
- [x] Review is requested when ready

## Reviewer

- [x] Code has been declaratized
- [x] All new functions have JSDoc/Rustdoc comments
- [x] Error handling beautiful (no unwraps or expects etc)
- [x] Code tested thoroughly
- [x] PR title:
    - [x] `feat:` prefix used if functionality should be included in the `Features` section of the release notes
    - [x] Not sentence cased
    - [x] Described well for release notes
    - [x] Indicates breaking changes with suffix "(breaking changes)"
- [x] Related issues have been linked and all tasks have been completed or made into separate issues
- [x] New documentation enumerated in [the release issue](https://github.com/demergent-labs/azle/issues/2053)
- [x] All breaking changes
    - [x] Described below in the "Breaking Changes" section
    - [x] Migration path described

## Breaking Changes

- None
