### PR TITLE
set the default depth level for recursive types to 3 instead of 5

### DIFF
--- a/src/experimental/test/property/arbitraries/candid/recursive/index.ts
+++ b/src/experimental/test/property/arbitraries/candid/recursive/index.ts
@@ -2,7 +2,6 @@ import '#experimental/build/assert_experimental';
 
 import fc from 'fast-check';
 
-import { DEFAULT_DEFINITION_MAX_DEPTH } from '../../config';
 import { Context } from '../../types';
 import { complexCandidDefinitionMemo } from '../candid_definition_arb/complex_candid_definition_memo';
 import { RecursiveCandidDefinition } from '../candid_definition_arb/types';
@@ -23,7 +22,7 @@ export function RecursiveArb(
             {
                 ...context,
                 constraints: {
-                    depthLevel: DEFAULT_DEFINITION_MAX_DEPTH,
+                    depthLevel: 3,
                     forceInline: true
                 }
             },


### PR DESCRIPTION
## Contributor

- [ ] Related issues have been linked and all tasks have been completed or made into separate issues
- [ ] All features are described below in the "Features" section
- [ ] All breaking changes
    - [ ] Described below in the "Breaking Changes" section
    - [ ] Migration path described
- [ ] PR title:
    - [ ] `feat:` prefix used if functionality should be included in the `Features` section of the release notes
    - [ ] Indicates breaking changes with suffix "(breaking changes)"
    - [ ] Described well for release notes
    - [ ] Not sentence cased
- [ ] Code quality
    - [ ] Declarative
    - [ ] Appropriate JSDocs, Rustdocs, or comments
    - [ ] Beautiful error handling (no unwraps, expects, etc)
    - [ ] Thoroughly tested
- [ ] New documentation enumerated in [the release issue](https://github.com/demergent-labs/azle/issues/2053)
- [ ] AI review requested and addressed

## Reviewer

- [x] Related issues have been linked and all tasks have been completed or made into separate issues
- [x] All features are described below in the "Features" section
- [x] All breaking changes
    - [x] Described below in the "Breaking Changes" section
    - [x] Migration path described
- [x] PR title:
    - [x] `feat:` prefix used if functionality should be included in the `Features` section of the release notes
    - [x] Indicates breaking changes with suffix "(breaking changes)"
    - [x] Described well for release notes
    - [x] Not sentence cased
- [x] Code quality
    - [x] Declarative
    - [x] Appropriate JSDocs, Rustdocs, or comments
    - [x] Beautiful error handling (no unwraps, expects, etc)
    - [x] Thoroughly tested
- [x] New documentation enumerated in [the release issue](https://github.com/demergent-labs/azle/issues/2053)

## Features

- None

## Breaking Changes

- None
